### PR TITLE
Removes exit from configure when downloading cmake into local deps directory

### DIFF
--- a/configure
+++ b/configure
@@ -218,7 +218,6 @@ if [ -z $CMAKE ]; then
   tar -xzvf cmake.tar.gz
   # cd into the extracted directory and install
   cd cmake-*
-  exit 0
   ./configure --prefix=$DEPS_PREFIX
   make -j2
   make install


### PR DESCRIPTION
Somehow an extraneous `exit 0` snuck into our configure script (git blame says this is my fault) when downloading CMake to install locally, as pointed out in #49. This fixes the issue.

Test on Ubuntu 14.04 on a clean EC2 instance.