### PR TITLE
[CLIPPER-78] Future compositions

### DIFF
--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -45,7 +45,9 @@ add_executable(libclippertests EXCLUDE_FROM_ALL
     test/config_test.cpp
     test/selection_policies_test.cpp
     test/json_util_test.cpp
-    test/logging_test.cpp)
+    test/logging_test.cpp
+    test/future_test.cpp
+    )
 target_link_libraries(libclippertests clipper gtest gmock_main)
 add_dependencies(unittests libclippertests)
 

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -1,6 +1,7 @@
 #ifndef CLIPPER_LIB_DATATYPES_H
 #define CLIPPER_LIB_DATATYPES_H
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -219,6 +220,7 @@ class Query {
   long latency_micros_;
   std::string selection_policy_;
   std::vector<VersionedModelId> candidate_models_;
+  std::chrono::time_point<std::chrono::high_resolution_clock> create_time_;
 };
 
 class Response {

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -1,0 +1,86 @@
+#ifndef CLIPPER_LIB_FUTURE_HPP
+#define CLIPPER_LIB_FUTURE_HPP
+
+#include <atomic>
+#include <cassert>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "boost/thread.hpp"
+
+namespace clipper {
+
+namespace future {
+
+/// The first element in the pair is a future that will complete when
+/// all the futures provided have completed. The value of the future
+/// will always be true (there were some issues with a future<void>).
+/// The second element is a vector
+/// of futures that have the same values and will complete at the same time
+/// as the futures passed in as argument.
+template <class T>
+std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all(
+    std::vector<boost::shared_future<T>> futures,
+    std::shared_ptr<std::atomic<int>> num_completed) {
+  if (futures.size() == 0) {
+    return std::make_pair(boost::make_ready_future(),
+                          std::vector<boost::future<T>>{});
+  }
+  int num_futures = futures.size();
+  auto completion_promise = std::make_shared<boost::promise<void>>();
+  std::vector<boost::future<T>> wrapped_futures;
+  for (auto f = futures.begin(); f != futures.end(); ++f) {
+    // PROBLEM: Passing a reference to an atomic (num_completed) but the atomic
+    // can go out of scope and be destructed
+    wrapped_futures.push_back(f->then(
+        [num_futures, completion_promise, num_completed](auto result) mutable {
+          if (*num_completed + 1 == num_futures) {
+            completion_promise->set_value();
+            //
+          } else {
+            *num_completed += 1;
+          }
+          return result.get();
+        }));
+  }
+
+  return std::make_pair<boost::future<void>, std::vector<boost::future<T>>>(
+      completion_promise->get_future(), std::move(wrapped_futures));
+}
+
+template <typename R>
+boost::future<R> wrap_when_any(
+    boost::future<R> f, std::shared_ptr<std::atomic<int>> completed,
+    std::shared_ptr<boost::promise<void>> completion_promise) {
+  return f.then([completion_promise, completed](auto result) mutable {
+
+    // Only set completed to true if the original value was false. This ensures
+    // that we only set the value once, and therefore only complete the promise
+    // once.
+    int num_finished = completed->fetch_add(1);
+    if (num_finished == 0) {
+      completion_promise->set_value();
+    }
+    return result.get();
+  });
+}
+
+template <typename R0, typename R1>
+std::tuple<boost::future<void>, boost::future<R0>, boost::future<R1>> when_any(
+    boost::future<R0> f0, boost::future<R1> f1,
+    std::shared_ptr<std::atomic<int>> completed) {
+  auto completion_promise = std::make_shared<boost::promise<void>>();
+  auto wrapped_f0 = wrap_when_any(std::move(f0), completed, completion_promise);
+  auto wrapped_f1 = wrap_when_any(std::move(f1), completed, completion_promise);
+
+  return std::make_tuple<boost::future<void>, boost::future<R0>,
+                         boost::future<R1>>(completion_promise->get_future(),
+                                            std::move(wrapped_f0),
+                                            std::move(wrapped_f1));
+}
+
+}  // namespace future
+}  // namespace clipper
+
+#endif  // define CLIPPER_LIB_FUTURE_HPP

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -27,7 +27,7 @@ namespace future {
 */
 template <class T>
 std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all(
-    std::vector<boost::shared_future<T>> futures,
+    std::vector<boost::future<T>> futures,
     std::shared_ptr<std::atomic<int>> num_completed) {
   if (futures.size() == 0) {
     return std::make_pair(boost::make_ready_future(),
@@ -54,16 +54,61 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all(
 }
 
 template <typename R>
-boost::future<R> wrap_when_any(
-    boost::future<R> f, std::shared_ptr<std::atomic<int>> completed,
+boost::future<R> wrap_when_both(
+    boost::future<R> future, std::shared_ptr<std::atomic<int>> num_completed,
     std::shared_ptr<boost::promise<void>> completion_promise) {
-  return f.then([completion_promise, completed](auto result) mutable {
+  return future.then([completion_promise, num_completed](auto result) mutable {
+
+    int num_already_completed = num_completed->fetch_add(1);
+    // means the other future has already finished
+    if (num_already_completed == 1) {
+      completion_promise->set_value();
+    }
+    return result.get();
+  });
+}
+
+/**
+ * A function for waiting until both of a pair of futures has completed.
+ *
+ *
+ * \param num_completed A counter indicating the number of futures that
+ * have completed so far. The reason this is an argument to the function
+ * instead of internal state is that the caller of `when_both` must make sure
+ * that the counter stays in scope for the lifetime of all the futures.
+ *
+ * \return A tuple of three futures. The first is the composed future that will
+ * complete when both of the two futures provided as argument completes. The
+ * second two elements in the tuple are futures that will complete at the same
+ * time and with the same value as the futures passed in as arguments.
+ */
+template <typename R0, typename R1>
+std::tuple<boost::future<void>, boost::future<R0>, boost::future<R1>> when_both(
+    boost::future<R0> f0, boost::future<R1> f1,
+    std::shared_ptr<std::atomic<int>> num_completed) {
+  auto completion_promise = std::make_shared<boost::promise<void>>();
+  auto wrapped_f0 =
+      wrap_when_both(std::move(f0), num_completed, completion_promise);
+  auto wrapped_f1 =
+      wrap_when_both(std::move(f1), num_completed, completion_promise);
+
+  return std::make_tuple<boost::future<void>, boost::future<R0>,
+                         boost::future<R1>>(completion_promise->get_future(),
+                                            std::move(wrapped_f0),
+                                            std::move(wrapped_f1));
+}
+
+template <typename R>
+boost::future<R> wrap_when_either(
+    boost::future<R> future, std::shared_ptr<std::atomic_flag> completed_flag,
+    std::shared_ptr<boost::promise<void>> completion_promise) {
+  return future.then([completion_promise, completed_flag](auto result) mutable {
 
     // Only set completed to true if the original value was false. This ensures
     // that we only set the value once, and therefore only complete the promise
     // once.
-    int num_finished = completed->fetch_add(1);
-    if (num_finished == 0) {
+    bool flag_already_set = completed_flag->test_and_set();
+    if (!flag_already_set) {
       completion_promise->set_value();
     }
     return result.get();
@@ -73,11 +118,9 @@ boost::future<R> wrap_when_any(
 /**
  * A function for waiting until either of a pair of futures has completed.
  *
- *
- *
- * \param num_completed A counter indicating the number of futures that
- * have completed so far. The reason this is an argument to the function
- * instead of internal state is that the caller of `when_all` must make sure
+ * \param completed_flag A flag indicating whether any futures have completed
+ * so far. The reason this is an argument to the function
+ * instead of internal state is that the caller of `when_either` must make sure
  * that the counter stays in scope for the lifetime of all the futures.
  *
  * \return A tuple of three futures. The first is the composed future that will
@@ -86,12 +129,14 @@ boost::future<R> wrap_when_any(
  * time and with the same value as the futures passed in as arguments.
  */
 template <typename R0, typename R1>
-std::tuple<boost::future<void>, boost::future<R0>, boost::future<R1>> when_any(
-    boost::future<R0> f0, boost::future<R1> f1,
-    std::shared_ptr<std::atomic<int>> completed) {
+std::tuple<boost::future<void>, boost::future<R0>, boost::future<R1>>
+when_either(boost::future<R0> f0, boost::future<R1> f1,
+            std::shared_ptr<std::atomic_flag> completed_flag) {
   auto completion_promise = std::make_shared<boost::promise<void>>();
-  auto wrapped_f0 = wrap_when_any(std::move(f0), completed, completion_promise);
-  auto wrapped_f1 = wrap_when_any(std::move(f1), completed, completion_promise);
+  auto wrapped_f0 =
+      wrap_when_either(std::move(f0), completed_flag, completion_promise);
+  auto wrapped_f1 =
+      wrap_when_either(std::move(f1), completed_flag, completion_promise);
 
   return std::make_tuple<boost::future<void>, boost::future<R0>,
                          boost::future<R1>>(completion_promise->get_future(),

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -66,6 +66,9 @@ boost::future<R> wrap_when_any(
   });
 }
 
+/**
+ *
+ */
 template <typename R0, typename R1>
 std::tuple<boost::future<void>, boost::future<R0>, boost::future<R1>> when_any(
     boost::future<R0> f0, boost::future<R1> f1,

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -47,8 +47,9 @@ class json_semantic_error : public std::runtime_error {
 };
 
 /* Check for matching types else throw exception */
-rapidjson::Value& check_kv_type_and_return(
-    rapidjson::Value& d, const char* key_name, Type expected_type) {
+rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
+                                           const char* key_name,
+                                           Type expected_type) {
   if (!d.IsObject()) {
     throw json_semantic_error("Can only get key-value pair from an object");
   } else if (!d.HasMember(key_name)) {
@@ -196,10 +197,10 @@ std::vector<VersionedModelId> get_candidate_models(rapidjson::Value& d,
                                 " is not of type Object");
     } else if (!elem.HasMember("model_name")) {
       throw json_semantic_error(
-        "Candidate model JSON object missing model_name.");
+          "Candidate model JSON object missing model_name.");
     } else if (!elem.HasMember("model_version")) {
       throw json_semantic_error(
-        "Candidate model JSON object missing model_version.");
+          "Candidate model JSON object missing model_version.");
     }
     std::string model_name = get_string(elem, "model_name");
     int model_version = get_int(elem, "model_version");
@@ -224,8 +225,7 @@ void parse_json(const std::string& json_content, rapidjson::Document& d) {
   }
 }
 
-std::shared_ptr<Input> parse_input(InputType input_type,
-                                    rapidjson::Value& d) {
+std::shared_ptr<Input> parse_input(InputType input_type, rapidjson::Value& d) {
   switch (input_type) {
     case InputType::Doubles: {
       std::vector<double> inputs = get_double_array(d, "input");
@@ -270,8 +270,8 @@ Output parse_output(OutputType output_type, rapidjson::Value& parsed_json) {
 }
 
 /* Utilities for serialization into JSON */
-void add_kv_pair(rapidjson::Document& d,
-    const char* key_name, rapidjson::Value& value_to_add) {
+void add_kv_pair(rapidjson::Document& d, const char* key_name,
+                 rapidjson::Value& value_to_add) {
   if (!d.IsObject()) {
     throw json_semantic_error("Can only add a key-value pair to an object");
   } else if (d.HasMember(key_name)) {
@@ -283,8 +283,8 @@ void add_kv_pair(rapidjson::Document& d,
   d.AddMember(key, value_to_add, allocator);
 }
 
-void add_double_array(rapidjson::Document& d,
-    const char* key_name, std::vector<double>& values_to_add) {
+void add_double_array(rapidjson::Document& d, const char* key_name,
+                      std::vector<double>& values_to_add) {
   rapidjson::Value double_array(rapidjson::kArrayType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   for (std::size_t i = 0; i < values_to_add.size(); i++) {
@@ -293,8 +293,8 @@ void add_double_array(rapidjson::Document& d,
   add_kv_pair(d, key_name, double_array);
 }
 
-void add_float_array(rapidjson::Document& d,
-    const char* key_name, std::vector<float>& values_to_add) {
+void add_float_array(rapidjson::Document& d, const char* key_name,
+                     std::vector<float>& values_to_add) {
   rapidjson::Value float_array(rapidjson::kArrayType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   for (std::size_t i = 0; i < values_to_add.size(); i++) {
@@ -303,8 +303,8 @@ void add_float_array(rapidjson::Document& d,
   add_kv_pair(d, key_name, float_array);
 }
 
-void add_int_array(rapidjson::Document& d,
-    const char* key_name, std::vector<int>& values_to_add) {
+void add_int_array(rapidjson::Document& d, const char* key_name,
+                   std::vector<int>& values_to_add) {
   rapidjson::Value int_array(rapidjson::kArrayType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   for (std::size_t i = 0; i < values_to_add.size(); i++) {
@@ -313,8 +313,8 @@ void add_int_array(rapidjson::Document& d,
   add_kv_pair(d, key_name, int_array);
 }
 
-void add_string_array(rapidjson::Document& d,
-    const char* key_name, std::vector<std::string>& values_to_add) {
+void add_string_array(rapidjson::Document& d, const char* key_name,
+                      std::vector<std::string>& values_to_add) {
   rapidjson::Value string_array(rapidjson::kArrayType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   for (std::size_t i = 0; i < values_to_add.size(); i++) {
@@ -340,18 +340,18 @@ void add_int(rapidjson::Document& d, const char* key_name, int val) {
 }
 
 void add_long(rapidjson::Document& d, const char* key_name, long val) {
-  rapidjson::Value val_to_add((int64_t) val);
+  rapidjson::Value val_to_add((int64_t)val);
   add_kv_pair(d, key_name, val_to_add);
 }
 
-void add_string(rapidjson::Document& d,
-    const char* key_name, const std::string& val) {
+void add_string(rapidjson::Document& d, const char* key_name,
+                const std::string& val) {
   rapidjson::Value val_to_add(val.c_str(), d.GetAllocator());
   add_kv_pair(d, key_name, val_to_add);
 }
 
-void add_object(rapidjson::Document& d,
-    const char* key_name, rapidjson::Document& to_add) {
+void add_object(rapidjson::Document& d, const char* key_name,
+                rapidjson::Document& to_add) {
   add_kv_pair(d, key_name, to_add);
 }
 
@@ -363,5 +363,5 @@ std::string to_json_string(rapidjson::Document& d) {
 }
 
 }  // namespace json
-} // namespace clipper
+}  // namespace clipper
 #endif  // CLIPPER_LIB_JSON_UTIL_H

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -11,11 +11,11 @@
 #include <clipper/config.hpp>
 #include <clipper/containers.hpp>
 #include <clipper/datatypes.hpp>
+#include <clipper/logging.hpp>
+#include <clipper/metrics.hpp>
 #include <clipper/redis.hpp>
 #include <clipper/rpc_service.hpp>
 #include <clipper/util.hpp>
-#include <clipper/metrics.hpp>
-#include <clipper/logging.hpp>
 
 namespace clipper {
 
@@ -35,15 +35,15 @@ class CacheEntry {
   CacheEntry &operator=(CacheEntry &&) = default;
 
   bool completed_ = false;
-  boost::promise<Output> value_promise_;
-  boost::shared_future<Output> value_;
+  Output value_;
+  std::vector<boost::promise<Output>> value_promises_;
 };
 
 class PredictionCache {
  public:
   PredictionCache();
-  boost::shared_future<Output> fetch(const VersionedModelId &model,
-                                     const std::shared_ptr<Input> &input);
+  boost::future<Output> fetch(const VersionedModelId &model,
+                              const std::shared_ptr<Input> &input);
 
   void put(const VersionedModelId &model, const std::shared_ptr<Input> &input,
            const Output &output);
@@ -57,7 +57,7 @@ class PredictionCache {
   std::shared_ptr<metrics::RatioCounter> hit_ratio_;
 };
 
-template<typename Scheduler>
+template <typename Scheduler>
 class TaskExecutor {
  public:
   ~TaskExecutor() { active_ = false; };
@@ -70,14 +70,16 @@ class TaskExecutor {
     Config &conf = get_config();
     while (!redis_connection_.connect(conf.get_redis_address(),
                                       conf.get_redis_port())) {
-      log_error(
-          LOGGING_TAG_TASK_EXECUTOR, "TaskExecutor failed to connect to redis", "Retrying in 1 second...");
+      log_error(LOGGING_TAG_TASK_EXECUTOR,
+                "TaskExecutor failed to connect to redis",
+                "Retrying in 1 second...");
       std::this_thread::sleep_for(std::chrono::seconds(1));
     }
     while (!redis_subscriber_.connect(conf.get_redis_address(),
                                       conf.get_redis_port())) {
-      log_error(
-          LOGGING_TAG_TASK_EXECUTOR, "TaskExecutor subscriber failed to connect to redis", "Retrying in 1 second...");
+      log_error(LOGGING_TAG_TASK_EXECUTOR,
+                "TaskExecutor subscriber failed to connect to redis",
+                "Retrying in 1 second...");
       std::this_thread::sleep_for(std::chrono::seconds(1));
     }
     redis::send_cmd_no_reply<std::string>(
@@ -99,10 +101,15 @@ class TaskExecutor {
           }
 
         });
-    throughput_meter = metrics::MetricsRegistry::get_metrics().create_meter("model_throughput");
-    predictions_counter = metrics::MetricsRegistry::get_metrics().create_counter("num_predictions");
-    throughput_meter = metrics::MetricsRegistry::get_metrics().create_meter("prediction_throughput");
-    latency_hist = metrics::MetricsRegistry::get_metrics().create_histogram("prediction_latency", "milliseconds", 2056);
+    throughput_meter = metrics::MetricsRegistry::get_metrics().create_meter(
+        "model_throughput");
+    predictions_counter =
+        metrics::MetricsRegistry::get_metrics().create_counter(
+            "num_predictions");
+    throughput_meter = metrics::MetricsRegistry::get_metrics().create_meter(
+        "prediction_throughput");
+    latency_hist = metrics::MetricsRegistry::get_metrics().create_histogram(
+        "prediction_latency", "milliseconds", 2056);
     boost::thread(&TaskExecutor::send_messages, this).detach();
     boost::thread(&TaskExecutor::recv_messages, this).detach();
   }
@@ -114,9 +121,9 @@ class TaskExecutor {
   TaskExecutor(TaskExecutor &&other) = default;
   TaskExecutor &operator=(TaskExecutor &&other) = default;
 
-  std::vector<boost::shared_future<Output>> schedule_predictions(
+  std::vector<boost::future<Output>> schedule_predictions(
       std::vector<PredictTask> tasks) {
-    std::vector<boost::shared_future<Output>> output_futures;
+    std::vector<boost::future<Output>> output_futures;
     for (auto t : tasks) {
       // assign tasks to containers independently
       auto replicas = active_containers_->get_model_replicas_snapshot(t.model_);
@@ -126,8 +133,9 @@ class TaskExecutor {
         container->send_prediction(t);
         output_futures.push_back(std::move(cache_.fetch(t.model_, t.input_)));
       } else {
-        log_info_formatted(
-            LOGGING_TAG_TASK_EXECUTOR, "No active containers found for model {}:{}", t.model_.first, t.model_.second);
+        log_info_formatted(LOGGING_TAG_TASK_EXECUTOR,
+                           "No active containers found for model {}:{}",
+                           t.model_.first, t.model_.second);
       }
     }
     return output_futures;
@@ -151,8 +159,8 @@ class TaskExecutor {
   redox::Subscriber redis_subscriber_;
   bool active_ = false;
   std::mutex inflight_messages_mutex_;
-  std::unordered_map<
-      int, std::vector<std::tuple<const long, VersionedModelId, std::shared_ptr<Input>>>>
+  std::unordered_map<int, std::vector<std::tuple<const long, VersionedModelId,
+                                                 std::shared_ptr<Input>>>>
       inflight_messages_;
   std::shared_ptr<metrics::Counter> predictions_counter;
   std::shared_ptr<metrics::Meter> throughput_meter;
@@ -193,7 +201,8 @@ class TaskExecutor {
             std::unique_lock<std::mutex> l(inflight_messages_mutex_);
             // std::vector<const std::vector<uint8_t>> serialized_inputs;
 
-            std::vector<std::tuple<const long, VersionedModelId, std::shared_ptr<Input>>>
+            std::vector<std::tuple<const long, VersionedModelId,
+                                   std::shared_ptr<Input>>>
                 cur_batch;
             rpc::PredictionRequest prediction_request(c->input_type_);
             for (auto b : batch) {
@@ -228,14 +237,16 @@ class TaskExecutor {
         int batch_size = keys.size();
         predictions_counter->increment(batch_size);
         throughput_meter->mark(batch_size);
-        long current_time = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::system_clock::now().time_since_epoch()).count();
+        long current_time =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::system_clock::now().time_since_epoch())
+                .count();
         for (int batch_num = 0; batch_num < batch_size; ++batch_num) {
           long send_time = std::get<0>(keys[batch_num]);
           latency_hist->insert(static_cast<int64_t>(current_time - send_time));
-          cache_.put(
-              std::get<1>(keys[batch_num]), std::get<2>(keys[batch_num]),
-              Output{deserialized_outputs[batch_num], std::get<1>(keys[batch_num])});
+          cache_.put(std::get<1>(keys[batch_num]), std::get<2>(keys[batch_num]),
+                     Output{deserialized_outputs[batch_num],
+                            std::get<1>(keys[batch_num])});
         }
       }
     }

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -1,11 +1,11 @@
 #include <chrono>
 #include <cstring>
 #include <iostream>
-#include <vector>
 #include <sstream>
+#include <vector>
 
-#include <clipper/datatypes.hpp>
 #include <boost/functional/hash.hpp>
+#include <clipper/datatypes.hpp>
 
 namespace clipper {
 
@@ -106,9 +106,7 @@ size_t ByteVector::serialize(uint8_t *buf) const {
   return serialize_to_buffer(data_, buf);
 }
 
-size_t ByteVector::hash() const {
-  return primitive_input_hash(data_);
-}
+size_t ByteVector::hash() const { return primitive_input_hash(data_); }
 
 size_t ByteVector::size() const { return data_.size(); }
 
@@ -124,9 +122,7 @@ size_t IntVector::serialize(uint8_t *buf) const {
   return serialize_to_buffer(data_, buf);
 }
 
-size_t IntVector::hash() const {
-  return primitive_input_hash(data_);
-}
+size_t IntVector::hash() const { return primitive_input_hash(data_); }
 
 size_t IntVector::size() const { return data_.size(); }
 
@@ -143,8 +139,10 @@ size_t FloatVector::serialize(uint8_t *buf) const {
 InputType FloatVector::type() const { return InputType::Floats; }
 
 size_t FloatVector::hash() const {
-  // TODO [CLIPPER-63]: Find an alternative to hashing floats directly, as this is
-  // generally a bad idea due to loss of precision from floating point representations
+  // TODO [CLIPPER-63]: Find an alternative to hashing floats directly, as this
+  // is
+  // generally a bad idea due to loss of precision from floating point
+  // representations
   return primitive_input_hash(data_);
 }
 
@@ -163,8 +161,10 @@ size_t DoubleVector::serialize(uint8_t *buf) const {
 }
 
 size_t DoubleVector::hash() const {
-  // TODO [CLIPPER-63]: Find an alternative to hashing doubles directly, as this is
-  // generally a bad idea due to loss of precision from floating point representations
+  // TODO [CLIPPER-63]: Find an alternative to hashing doubles directly, as this
+  // is
+  // generally a bad idea due to loss of precision from floating point
+  // representations
   return primitive_input_hash(data_);
 }
 
@@ -204,17 +204,20 @@ rpc::PredictionRequest::PredictionRequest(InputType input_type)
 rpc::PredictionRequest::PredictionRequest(
     std::vector<std::shared_ptr<Input>> inputs, InputType input_type)
     : inputs_(inputs), input_type_(input_type) {
-  for (int i = 0; i < (int) inputs.size(); i++) {
+  for (int i = 0; i < (int)inputs.size(); i++) {
     validate_input_type(inputs[i]);
     input_data_size_ += inputs[i]->byte_size();
   }
 }
 
-void rpc::PredictionRequest::validate_input_type(std::shared_ptr<Input> &input) const {
+void rpc::PredictionRequest::validate_input_type(
+    std::shared_ptr<Input> &input) const {
   if (input->type() != input_type_) {
     std::ostringstream ss;
-    ss << "Attempted to add an input of type " << get_readable_input_type(input->type())
-       << " to a prediction request with input type " << get_readable_input_type(input_type_);
+    ss << "Attempted to add an input of type "
+       << get_readable_input_type(input->type())
+       << " to a prediction request with input type "
+       << get_readable_input_type(input_type_);
     throw std::invalid_argument(ss.str());
   }
 }
@@ -274,7 +277,8 @@ Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
       input_(input),
       latency_micros_(latency_micros),
       selection_policy_(selection_policy),
-      candidate_models_(candidate_models) {}
+      candidate_models_(candidate_models),
+      create_time_(std::chrono::high_resolution_clock::now()) {}
 
 Response::Response(Query query, QueryId query_id, long duration_micros,
                    Output output, std::vector<VersionedModelId> models_used)

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -140,8 +140,7 @@ InputType FloatVector::type() const { return InputType::Floats; }
 
 size_t FloatVector::hash() const {
   // TODO [CLIPPER-63]: Find an alternative to hashing floats directly, as this
-  // is
-  // generally a bad idea due to loss of precision from floating point
+  // is generally a bad idea due to loss of precision from floating point
   // representations
   return primitive_input_hash(data_);
 }
@@ -161,9 +160,8 @@ size_t DoubleVector::serialize(uint8_t *buf) const {
 }
 
 size_t DoubleVector::hash() const {
-  // TODO [CLIPPER-63]: Find an alternative to hashing doubles directly, as this
-  // is
-  // generally a bad idea due to loss of precision from floating point
+  // TODO [CLIPPER-63]: Find an alternative to hashing doubles directly, as
+  // this is generally a bad idea due to loss of precision from floating point
   // representations
   return primitive_input_hash(data_);
 }

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -8,6 +8,7 @@
 #include <unordered_map>
 
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
+#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
 #define PROVIDES_EXECUTORS
 #include <boost/thread.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
@@ -261,6 +262,7 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   vector<boost::future<FeedbackAck>> feedback_task_completion_futures =
       task_executor_.schedule_feedback(std::move(feedback_tasks));
 
+  // TODO: replace with clipper::future implementation of when_all
   // when this future completes, we are ready to update the selection state
   auto predictions_completed =
       boost::when_all(predict_task_completion_futures.begin(),

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -1,5 +1,6 @@
 
 #include <cassert>
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <string>
@@ -7,22 +8,20 @@
 #include <unordered_map>
 
 #define BOOST_THREAD_PROVIDES_FUTURE_CONTINUATION
-#define BOOST_THREAD_PROVIDES_FUTURE_WHEN_ALL_WHEN_ANY
 #define PROVIDES_EXECUTORS
 #include <boost/thread.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
 
 #include <clipper/containers.hpp>
 #include <clipper/datatypes.hpp>
+#include <clipper/future.hpp>
+#include <clipper/logging.hpp>
 #include <clipper/query_processor.hpp>
 #include <clipper/task_executor.hpp>
 #include <clipper/timers.hpp>
-#include <clipper/logging.hpp>
 
 #define UNREACHABLE() assert(false)
 
-using boost::future;
-using boost::shared_future;
 using std::vector;
 using std::tuple;
 
@@ -100,7 +99,7 @@ std::shared_ptr<StateDB> QueryProcessor::get_state_table() const {
   return state_db_;
 }
 
-future<Response> QueryProcessor::predict(Query query) {
+boost::future<Response> QueryProcessor::predict(Query query) {
   long query_id = query_counter_.fetch_add(1);
   std::vector<PredictTask> tasks;
   std::string serialized_state;
@@ -111,7 +110,8 @@ future<Response> QueryProcessor::predict(Query query) {
         query, query_id, get_state_table());
     tasks = tasks_and_state.first;
     serialized_state = tasks_and_state.second;
-    log_info(LOGGING_TAG_QUERY_PROCESSOR, "Used NewestModelSelectionPolicy to select tasks");
+    log_info(LOGGING_TAG_QUERY_PROCESSOR,
+             "Used NewestModelSelectionPolicy to select tasks");
   } else if (query.selection_policy_ == "simple_policy") {
     auto tasks_and_state =
         select_predict_tasks<SimplePolicy>(query, query_id, get_state_table());
@@ -125,79 +125,85 @@ future<Response> QueryProcessor::predict(Query query) {
     serialized_state = tasks_and_state.second;
     log_info(LOGGING_TAG_QUERY_PROCESSOR, "Used BanditPolicy to select tasks");
   } else {
-    log_error_formatted(
-        LOGGING_TAG_QUERY_PROCESSOR, "{} is an invalid selection policy", query.selection_policy_);
+    log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
+                        "{} is an invalid selection policy",
+                        query.selection_policy_);
     // TODO better error handling
     return boost::make_ready_future(
         Response{query, query_id, 20000, Output{1.0, std::make_pair("m1", 1)},
                  std::vector<VersionedModelId>()});
   }
-  log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR, "Found {} tasks", tasks.size());
+  log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR, "Found {} tasks",
+                     tasks.size());
 
-  vector<shared_future<Output>> task_completion_futures =
+  vector<boost::shared_future<Output>> shared_task_completion_futures =
       task_executor_.schedule_predictions(tasks);
-  auto task_completion_copies = task_completion_futures;
-  log_info_formatted(
-      LOGGING_TAG_QUERY_PROCESSOR, "Found {} task completion futures", task_completion_futures.size());
-  future<void> timer_future = timer_system_.set_timer(query.latency_micros_);
+  boost::future<void> timer_future =
+      timer_system_.set_timer(query.latency_micros_);
 
-  auto all_tasks_completed = boost::when_all(task_completion_copies.begin(),
-                                             task_completion_copies.end());
-  auto make_response_future =
-      boost::when_any(std::move(all_tasks_completed), std::move(timer_future));
+  vector<boost::future<Output>> task_completion_futures;
+
+  boost::future<void> all_tasks_completed;
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  std::tie(all_tasks_completed, task_completion_futures) = future::when_all(
+      std::move(shared_task_completion_futures), num_completed);
+
+  auto completion_flag = std::make_shared<std::atomic<int>>(0);
+  boost::future<void> response_ready_future;
+  boost::future<void> all_tasks_completed_wrapped;
+  boost::future<void> timer_future_wrapped;
+
+  std::tie(response_ready_future, all_tasks_completed_wrapped,
+           timer_future_wrapped) =
+      future::when_any(std::move(all_tasks_completed), std::move(timer_future),
+                       completion_flag);
 
   boost::promise<Response> promise;
   auto f = promise.get_future();
 
-  make_response_future.then([
-    query, query_id, moved_promise = std::move(promise),
-    moved_serialized_state = std::move(serialized_state),
-    task_futures = std::move(task_completion_futures)
-  ](auto result_future) mutable {
-    log_info(LOGGING_TAG_QUERY_PROCESSOR, "ENTERED CONTINUATION LAMBDA");
+  response_ready_future.then([
+    query, query_id, p = std::move(promise), s = std::move(serialized_state),
+    task_futures = std::move(task_completion_futures), num_completed,
+    completion_flag
+  ](auto) mutable {
 
-    auto result = result_future.get();
-    log_info(LOGGING_TAG_QUERY_PROCESSOR, std::boolalpha);
-    log_info_formatted(
-        LOGGING_TAG_QUERY_PROCESSOR, "All tasks finished: ", std::get<0>(result).is_ready());
-    log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR, "Timer Fired: ", std::get<1>(result).is_ready());
     vector<Output> outputs;
     vector<VersionedModelId> used_models;
-    //    vector<shared_future<Output>> completed_tasks =
-    //    std::get<0>(result).get();
-
-    //      vector<boost::shared_future<Output>> completed_tasks =
-    //      task_futures.get();
     for (auto r = task_futures.begin(); r != task_futures.end(); ++r) {
       if ((*r).is_ready()) {
         outputs.push_back((*r).get());
       }
     }
-    log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR, "Found {} completed tasks", outputs.size());
 
     Output final_output;
     if (query.selection_policy_ == "newest_model") {
-      final_output = combine_predictions<NewestModelSelectionPolicy>(
-          query, outputs, moved_serialized_state);
+      final_output =
+          combine_predictions<NewestModelSelectionPolicy>(query, outputs, s);
     } else if (query.selection_policy_ == "simple_policy") {
-      final_output = combine_predictions<SimplePolicy>(query, outputs,
-                                                       moved_serialized_state);
+      final_output = combine_predictions<SimplePolicy>(query, outputs, s);
     } else if (query.selection_policy_ == "bandit_policy") {
-      final_output = combine_predictions<BanditPolicy>(query, outputs,
-                                                       moved_serialized_state);
+      final_output = combine_predictions<BanditPolicy>(query, outputs, s);
     } else {
       UNREACHABLE();
     }
-    Response response{query, query_id, 20000, final_output,
+    std::chrono::time_point<std::chrono::high_resolution_clock> end =
+        std::chrono::high_resolution_clock::now();
+    long duration_micros =
+        std::chrono::duration_cast<std::chrono::microseconds>(
+            end - query.create_time_)
+            .count();
+
+    Response response{query, query_id, duration_micros, final_output,
                       query.candidate_models_};
-    moved_promise.set_value(response);
+    p.set_value(response);
 
   });
   return f;
 }
 
 boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
-  log_info(LOGGING_TAG_QUERY_PROCESSOR, "Received feedback for user {}", feedback.user_id_);
+  log_info(LOGGING_TAG_QUERY_PROCESSOR, "Received feedback for user {}",
+           feedback.user_id_);
 
   long query_id = query_counter_.fetch_add(1);
   std::vector<PredictTask> predict_tasks;
@@ -212,8 +218,8 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
     predict_tasks = tasks_and_state.first.first;
     feedback_tasks = tasks_and_state.first.second;
     serialized_state = tasks_and_state.second;
-    log_info(
-        LOGGING_TAG_QUERY_PROCESSOR, "Used NewestModelSelectionPolicy to select tasks during feedback");
+    log_info(LOGGING_TAG_QUERY_PROCESSOR,
+             "Used NewestModelSelectionPolicy to select tasks during feedback");
   } else if (feedback.selection_policy_ == "simple_policy") {
     auto tasks_and_state = select_feedback_tasks<SimplePolicy>(
         feedback, query_id, get_state_table());
@@ -221,7 +227,8 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
     predict_tasks = tasks_and_state.first.first;
     feedback_tasks = tasks_and_state.first.second;
     serialized_state = tasks_and_state.second;
-    log_info(LOGGING_TAG_QUERY_PROCESSOR, "Used SimplePolicy to select tasks during feedback");
+    log_info(LOGGING_TAG_QUERY_PROCESSOR,
+             "Used SimplePolicy to select tasks during feedback");
   } else if (feedback.selection_policy_ == "bandit_policy") {
     auto tasks_and_state = select_feedback_tasks<BanditPolicy>(
         feedback, query_id, get_state_table());
@@ -229,16 +236,18 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
     predict_tasks = tasks_and_state.first.first;
     feedback_tasks = tasks_and_state.first.second;
     serialized_state = tasks_and_state.second;
-    log_info(LOGGING_TAG_QUERY_PROCESSOR, "Used BanditPolicy to select tasks during feedback");
+    log_info(LOGGING_TAG_QUERY_PROCESSOR,
+             "Used BanditPolicy to select tasks during feedback");
   } else {
-    log_error_formatted(
-        LOGGING_TAG_QUERY_PROCESSOR, "{} is an invalid feedback selection policy", feedback.selection_policy_);
+    log_error_formatted(LOGGING_TAG_QUERY_PROCESSOR,
+                        "{} is an invalid feedback selection policy",
+                        feedback.selection_policy_);
     // TODO better error handling
     return boost::make_ready_future(false);
   }
   log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR,
-      "Scheduling {} prediction tasks and {} feedback tasks",
-      predict_tasks.size(), feedback_tasks.size());
+                     "Scheduling {} prediction tasks and {} feedback tasks",
+                     predict_tasks.size(), feedback_tasks.size());
 
   // 1) Wait for all prediction_tasks to complete
   // 2) Update selection policy
@@ -246,7 +255,7 @@ boost::future<FeedbackAck> QueryProcessor::update(FeedbackQuery feedback) {
   // 4) Wait for all feedback_tasks to complete (feedback_processed future)
 
   // copy the vector
-  vector<shared_future<Output>> predict_task_completion_futures =
+  vector<boost::shared_future<Output>> predict_task_completion_futures =
       task_executor_.schedule_predictions({predict_tasks});
 
   vector<boost::future<FeedbackAck>> feedback_task_completion_futures =

--- a/src/libclipper/test/future_test.cpp
+++ b/src/libclipper/test/future_test.cpp
@@ -1,0 +1,33 @@
+
+#include <gtest/gtest.h>
+#include <chrono>
+#include <random>
+#include <thread>
+#include <unordered_map>
+
+#include <boost/thread.hpp>
+#include <clipper/future.hpp>
+
+using namespace clipper;
+using namespace std::chrono_literals;
+
+namespace {
+
+// class TimerSystemTests : public ::testing::Test {
+//  public:
+//   TimerSystem<ManualClock> ts_{ManualClock()};
+// };
+//
+// TEST_F(TimerSystemTests, SingleTimerExpire) {
+//   ASSERT_EQ(ts_.num_outstanding_timers(), (size_t)0);
+//   auto timer_future = ts_.set_timer(20000);
+//   ASSERT_FALSE(timer_future.is_ready());
+//   ASSERT_EQ(ts_.num_outstanding_timers(), (size_t)1);
+//   ts_.clock_.increment(10000);
+//   ASSERT_FALSE(timer_future.is_ready());
+//   ts_.clock_.increment(11000);
+//   // Let the timer system detect this
+//   std::this_thread::sleep_for(500us);
+//   ASSERT_TRUE(timer_future.is_ready()) << "Uh oh";
+// }
+}

--- a/src/libclipper/test/future_test.cpp
+++ b/src/libclipper/test/future_test.cpp
@@ -69,6 +69,33 @@ TEST(WhenAllTests, CompleteCorrectly) {
   ASSERT_TRUE(completion_future.is_ready());
 }
 
+TEST(WhenAllTests, SomeFuturesAlreadyComplete) {
+  boost::promise<void> p1;
+  boost::shared_future<void> f1 = p1.get_future();
+  p1.set_value();
+  boost::promise<void> p2;
+  boost::promise<void> p3;
+
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  std::vector<boost::shared_future<void>> v;
+  v.push_back(std::move(f1));
+  v.push_back(p2.get_future());
+  v.push_back(p3.get_future());
+
+  boost::future<void> completion_future;
+  std::vector<boost::future<void>> v_copy;
+  std::tie(completion_future, v_copy) =
+      future::when_all(std::move(v), num_completed);
+
+  ASSERT_FALSE(completion_future.is_ready());
+  p2.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_FALSE(completion_future.is_ready());
+  p3.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_TRUE(completion_future.is_ready());
+}
+
 TEST(WhenAnyTests, CompleteFirstEntry) {
   boost::promise<void> p1;
   boost::promise<void> p2;
@@ -99,6 +126,20 @@ TEST(WhenAnyTests, CompleteSecondEntry) {
 
   ASSERT_FALSE(completion_future.is_ready());
   p2.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_TRUE(completion_future.is_ready());
+}
+
+TEST(WhenAnyTests, EntryAlreadyComplete) {
+  boost::promise<void> p2;
+  boost::future<void> f1 = boost::make_ready_future();
+  boost::future<void> f2 = p2.get_future();
+
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  boost::future<void> completion_future;
+  std::tie(completion_future, f1, f2) =
+      future::when_any(std::move(f1), std::move(f2), num_completed);
+
   std::this_thread::sleep_for(500us);
   ASSERT_TRUE(completion_future.is_ready());
 }

--- a/src/libclipper/test/future_test.cpp
+++ b/src/libclipper/test/future_test.cpp
@@ -13,21 +13,93 @@ using namespace std::chrono_literals;
 
 namespace {
 
-// class TimerSystemTests : public ::testing::Test {
-//  public:
-//   TimerSystem<ManualClock> ts_{ManualClock()};
-// };
-//
-// TEST_F(TimerSystemTests, SingleTimerExpire) {
-//   ASSERT_EQ(ts_.num_outstanding_timers(), (size_t)0);
-//   auto timer_future = ts_.set_timer(20000);
-//   ASSERT_FALSE(timer_future.is_ready());
-//   ASSERT_EQ(ts_.num_outstanding_timers(), (size_t)1);
-//   ts_.clock_.increment(10000);
-//   ASSERT_FALSE(timer_future.is_ready());
-//   ts_.clock_.increment(11000);
-//   // Let the timer system detect this
-//   std::this_thread::sleep_for(500us);
-//   ASSERT_TRUE(timer_future.is_ready()) << "Uh oh";
-// }
+TEST(WhenAllTests, DontCompleteEarly) {
+  boost::promise<void> p1;
+  boost::promise<void> p2;
+  boost::promise<void> p3;
+
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  std::vector<boost::shared_future<void>> v;
+  v.push_back(p1.get_future());
+  v.push_back(p2.get_future());
+  v.push_back(p3.get_future());
+
+  boost::future<void> completion_future;
+  std::vector<boost::future<void>> v_copy;
+  std::tie(completion_future, v_copy) =
+      future::when_all(std::move(v), num_completed);
+
+  ASSERT_FALSE(completion_future.is_ready());
+  p1.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_FALSE(completion_future.is_ready());
+  p2.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_FALSE(completion_future.is_ready());
+  // p3.set_value();
+  // std::this_thread::sleep_for(500us);
+  // ASSERT_TRUE(completion_future.is_ready());
+}
+
+TEST(WhenAllTests, CompleteCorrectly) {
+  boost::promise<void> p1;
+  boost::promise<void> p2;
+  boost::promise<void> p3;
+
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  std::vector<boost::shared_future<void>> v;
+  v.push_back(p1.get_future());
+  v.push_back(p2.get_future());
+  v.push_back(p3.get_future());
+
+  boost::future<void> completion_future;
+  std::vector<boost::future<void>> v_copy;
+  std::tie(completion_future, v_copy) =
+      future::when_all(std::move(v), num_completed);
+
+  ASSERT_FALSE(completion_future.is_ready());
+  p1.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_FALSE(completion_future.is_ready());
+  p2.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_FALSE(completion_future.is_ready());
+  p3.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_TRUE(completion_future.is_ready());
+}
+
+TEST(WhenAnyTests, CompleteFirstEntry) {
+  boost::promise<void> p1;
+  boost::promise<void> p2;
+  boost::future<void> f1 = p1.get_future();
+  boost::future<void> f2 = p2.get_future();
+
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  boost::future<void> completion_future;
+  std::tie(completion_future, f1, f2) =
+      future::when_any(std::move(f1), std::move(f2), num_completed);
+
+  ASSERT_FALSE(completion_future.is_ready());
+  p1.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_TRUE(completion_future.is_ready());
+}
+
+TEST(WhenAnyTests, CompleteSecondEntry) {
+  boost::promise<void> p1;
+  boost::promise<void> p2;
+  boost::future<void> f1 = p1.get_future();
+  boost::future<void> f2 = p2.get_future();
+
+  auto num_completed = std::make_shared<std::atomic<int>>(0);
+  boost::future<void> completion_future;
+  std::tie(completion_future, f1, f2) =
+      future::when_any(std::move(f1), std::move(f2), num_completed);
+
+  ASSERT_FALSE(completion_future.is_ready());
+  p2.set_value();
+  std::this_thread::sleep_for(500us);
+  ASSERT_TRUE(completion_future.is_ready());
+}
 }


### PR DESCRIPTION
Replaces Boost future composition functions (`when_all`, `when_any`) with a more efficient version. The big issue with the Boost implementation was that it created a new thread for each call to one of the composition functions.

The API on these replacements is a little rough. It works fine for the specific situation in [`query_processor`](https://github.com/ucbrise/clipper/blob/2d521eb0922c3b431b4e1003c5022095cd88713d/src/libclipper/src/query_processor.cpp#L144-L147) where they are needed, but it's not very general purpose. Is it worth investing the time to craft a better API when it's unclear if there will ever be demand for it?