### PR TITLE
[CLIPPER-84] Fix the docker builds

### DIFF
--- a/ManagementFrontendDockerfile
+++ b/ManagementFrontendDockerfile
@@ -3,6 +3,8 @@ FROM frolvlad/alpine-gxx
 COPY ./ /clipper
 
 RUN apk add --no-cache git bash make boost-dev cmake libev-dev hiredis-dev zeromq-dev \
+    && cd /clipper/src/libs/spdlog \
+    && git apply ../patches/make_spdlog_compile_linux.patch \
     && cd /clipper \
     && ./configure --cleanup-quiet \
     && ./configure --release \

--- a/QueryFrontendDockerfile
+++ b/QueryFrontendDockerfile
@@ -3,6 +3,8 @@ FROM frolvlad/alpine-gxx
 COPY ./ /clipper
 
 RUN apk add --no-cache git bash make boost-dev cmake libev-dev hiredis-dev zeromq-dev \
+    && cd /clipper/src/libs/spdlog \
+    && git apply ../patches/make_spdlog_compile_linux.patch \
     && cd /clipper \
     && ./configure --cleanup-quiet \
     && ./configure --release \

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -1,11 +1,14 @@
 #ifndef CLIPPER_LIB_JSON_UTIL_H
 #define CLIPPER_LIB_JSON_UTIL_H
+
+#include <stdexcept>
+
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
+
 #include <clipper/datatypes.hpp>
-#include <stdexcept>
 
 using clipper::Input;
 using clipper::InputType;

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -28,7 +28,8 @@ enum Type {
 static std::vector<std::string> kTypeNames = {
     "Null", "False", "True", "Object", "Array", "String", "Number"};
 
-namespace clipper::json {
+namespace clipper {
+namespace json {
 
 class json_parse_error : public std::runtime_error {
  public:
@@ -358,5 +359,6 @@ std::string to_json_string(rapidjson::Document& d) {
   return buffer.GetString();
 }
 
-}  // namespace clipper::json
+}  // namespace json
+} // namespace clipper
 #endif  // CLIPPER_LIB_JSON_UTIL_H

--- a/src/libs/patches/make_spdlog_compile_linux.patch
+++ b/src/libs/patches/make_spdlog_compile_linux.patch
@@ -1,0 +1,25 @@
+From c0fcb37692da01049b4acfd92a779738c14d32ff Mon Sep 17 00:00:00 2001
+From: Dan Crankshaw <dscrankshaw@gmail.com>
+Date: Thu, 2 Feb 2017 15:05:56 -0800
+Subject: [PATCH] make compile on alpine
+
+---
+ include/spdlog/details/os.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/include/spdlog/details/os.h b/include/spdlog/details/os.h
+index b63ce66..dae02f2 100644
+--- a/include/spdlog/details/os.h
++++ b/include/spdlog/details/os.h
+@@ -378,7 +378,7 @@ inline std::string errno_str(int err_num)
+         return "Unkown error";
+ 
+ #elif defined(__FreeBSD__) || defined(__APPLE__) || defined(ANDROID) || defined(__SUNPRO_CC) || \
+-      ((_POSIX_C_SOURCE >= 200112L) && ! defined(_GNU_SOURCE)) // posix version
++      ((_POSIX_C_SOURCE >= 200112L) && ! defined(_GNU_SOURCE)) || !defined(__GLIBC__)   // posix version
+ 
+     if (strerror_r(err_num, buf, buf_size) == 0)
+         return std::string(buf);
+-- 
+1.9.1
+


### PR DESCRIPTION
The addition of the spdlog and rapidjson libraries broke the build for Docker (alpine linux with musl) and on Ubuntu with gcc.

This PR fixes those problems.