### PR TITLE
Modify clipper manager to provide option for local execution

### DIFF
--- a/examples/cifar_demo/README.md
+++ b/examples/cifar_demo/README.md
@@ -5,8 +5,9 @@ and querying Clipper for predictions.
 
 ## Setup
 
-Before you can run the demo, you must have access to a machine running
-Docker that you can SSH into. If running on EC2, you can use AMI `ami-3ba0f05b`,
+In order to run the demo, you must either have Docker installed locally
+or have access to a machine running Docker that you can SSH into.
+If running on EC2, you can use AMI `ami-3ba0f05b`,
 an Ubuntu image that has Docker and Docker-Compose installed.
 
 The demo uses Python and Jupyter notebooks to interact with Clipper and

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -90,7 +90,6 @@ class Clipper:
         if not self.host_is_local():
             env.user = user
             env.key_filename = key_path
-
         # Make sure docker is running on cluster
         self.start_docker_if_necessary()
 

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -157,6 +157,9 @@ class Clipper:
     # shutil.copytree() alone because it stipulates that
     # dst cannot already exist
     def copytree(self, src, dst, symlinks=False, ignore=None):
+        # Appends the final directory in the tree specified by "src" to
+        # the tree specified by "dst". This is consistent with fabric's
+        # put() behavior
         final_dst_char = dst[len(dst) - 1]
         if final_dst_char != "/":
             dst = dst + "/"

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -52,7 +52,7 @@ DOCKER_COMPOSE_DICT = {
             'depends_on': [
                 'redis',
                 'mgmt_frontend'],
-            'image': 'clipper/query_frontend:latest',
+            'image': 'czumar/clresilience:latest',
             'ports': [
                 '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                 '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)]},
@@ -128,7 +128,8 @@ class Clipper:
 
     def execute_local(self, *args, **kwargs):
         # fabric.local() does not accept the "warn_only"
-        # key word argument, so we must remove it before calling
+        # key word argument, so we must remove it before
+        # calling
         if "warn_only" in kwargs.keys():
                 del kwargs["warn_only"]
             # Forces execution to continue in the face of an error,

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -428,7 +428,7 @@ class Clipper:
             result = self.execute_root(add_container_cmd)
             return result.return_code == 0
 
-    def inspect_instance(self, clear=False):
+    def inspect_instance(self):
         """Fetches metrics from the running Clipper instance.
 
         Returns
@@ -439,10 +439,7 @@ class Clipper:
             (not JSON formatted).
         """
         url = "http://%s:1337/metrics" % self.host
-        if clear:
-            r = requests.post(url)
-        else:
-            r = requests.get(url)
+        r = requests.get(url)
         try:
             s = r.json()
         except TypeError:

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -344,6 +344,8 @@ class Clipper:
             The Docker container image to use to run this model container.
         labels : list of str
             A set of strings annotating the model
+        input_type : str
+            One of "integers", "floats", "doubles", "bytes", or "strings".
         num_containers : int, optional
             The number of replicas of the model to create. More replicas can be
             created later as well. Defaults to 1.

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -331,12 +331,12 @@ class Clipper:
             The name to assign this model.
         version : int
             The version to assign this model.
-        model : str or BaseEstimator
+        model_data : str or BaseEstimator
             The trained model to add to Clipper. This can either be a
             Scikit-Learn trained model object (an instance of BaseEstimator),
             or a path to a serialized model. Note that many model serialization
             formats split the model across multiple files (e.g. definition file
-            and weights file or files). If this is the case, model must be a path
+            and weights file or files). If this is the case, model_data must be a path
             to the root of a directory tree containing ALL the needed files.
             Depending on the model serialization library you use, this may or may not
             be the path you provided to the serialize method call.

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -336,7 +336,7 @@ class Clipper:
             Scikit-Learn trained model object (an instance of BaseEstimator),
             or a path to a serialized model. Note that many model serialization
             formats split the model across multiple files (e.g. definition file
-            and weights file or files). If this is the case, model_data must be a path
+            and weights file or files). If this is the case, `model_data` must be a path
             to the root of a directory tree containing ALL the needed files.
             Depending on the model serialization library you use, this may or may not
             be the path you provided to the serialize method call.

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -7,7 +7,6 @@ import json
 import yaml
 import pprint
 import subprocess32 as subprocess
-import shutil
 from sklearn import base
 from sklearn.externals import joblib
 
@@ -91,7 +90,6 @@ class Clipper:
         if not self.host_is_local():
             env.user = user
             env.key_filename = key_path
-
         # Make sure docker is running on cluster
         self.start_docker_if_necessary()
 
@@ -141,36 +139,24 @@ class Clipper:
             result = local(*args, **kwargs)
         return result
 
-    def execute_put(self, local_path, remote_path, *args, **kwargs):
-        if self.host_is_local():
-            # We should only copy data if the paths are different
-            if local_path != remote_path:
-                if os.path.isdir(local_path):
-                    self.copytree(local_path, remote_path)
-                else:
-                    shutil.copy2(local_path, remote_path)
-        else:
-            put(local_path=local_path, remote_path=remote_path, *args, **kwargs)
-
     def execute_append(self, filename, text, **kwargs):
         if self.host_is_local():
             file = open(filename, "a+")
+            # As with fabric.append(), we should only
+            # append the text if it is not already
+            # present within the file
             if text not in file.read():
                 file.write(text)
             file.close()
-
         else:
             append(filename, text, **kwargs)
 
-    # Modified from http://stackoverflow.com/a/12514470
+    # Taken from http://stackoverflow.com/a/12514470
     # Recursively copies a directory from src to dst,
     # where dst may or may not exist. We cannot use
     # shutil.copytree() alone because it stipulates that
     # dst cannot already exist
     def copytree(self, src, dst, symlinks=False, ignore=None):
-        # Appends the final directory in the tree specified by "src" to
-        # the tree specified by "dst". This is consistent with fabric's
-        # put() behavior
         final_dst_char = dst[len(dst) - 1]
         if final_dst_char != "/":
             dst = dst + "/"
@@ -187,7 +173,6 @@ class Clipper:
             else:
                 if not os.path.exists(d) or os.stat(s).st_mtime - os.stat(d).st_mtime > 1:
                     shutil.copy2(s, d)
-
 
     def start(self):
         """Start a Clipper instance.
@@ -323,7 +308,7 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         return r.text
 
-    def deploy_model(self, name, version, model_data, container_name, labels, input_type, num_containers=1):
+    def deploy_model(self, name, version, model, container_name, labels, num_containers=1):
         """Add a model to Clipper.
 
         Parameters
@@ -332,12 +317,12 @@ class Clipper:
             The name to assign this model.
         version : int
             The version to assign this model.
-        model_data : str or BaseEstimator
+        model : str or BaseEstimator
             The trained model to add to Clipper. This can either be a
             Scikit-Learn trained model object (an instance of BaseEstimator),
             or a path to a serialized model. Note that many model serialization
             formats split the model across multiple files (e.g. definition file
-            and weights file or files). If this is the case, `model_data` must be a path
+            and weights file or files). If this is the case, model must be a path
             to the root of a directory tree containing ALL the needed files.
             Depending on the model serialization library you use, this may or may not
             be the path you provided to the serialize method call.
@@ -345,8 +330,6 @@ class Clipper:
             The Docker container image to use to run this model container.
         labels : list of str
             A set of strings annotating the model
-        input_type : str
-            One of "integers", "floats", "doubles", "bytes", or "strings".
         num_containers : int, optional
             The number of replicas of the model to create. More replicas can be
             created later as well. Defaults to 1.
@@ -400,7 +383,7 @@ class Clipper:
                                     vol, os.path.basename(model_data_path))))
                     else:
                         with hide("output", "running"):
-                                self.execute_put(model_data_path, vol)
+                            self.execute_put(model_data_path, vol)
 
             print("Copied model data to host")
             if not self._publish_new_model(name, version, labels, input_type,
@@ -465,7 +448,7 @@ class Clipper:
             result = self.execute_root(add_container_cmd)
             return result.return_code == 0
 
-    def inspect_instance(self, clear=False):
+    def inspect_instance(self):
         """Fetches metrics from the running Clipper instance.
 
         Returns
@@ -524,7 +507,6 @@ class Clipper:
         })
         headers = {'Content-type': 'application/json'}
         r = requests.post(url, headers=headers, data=req_json)
-
         if r.status_code == requests.codes.ok:
             return True
         else:
@@ -574,7 +556,7 @@ class Clipper:
                     fn=saved_fname,
                     cn=container_name))
                 tar_loc = "/tmp/{fn}.tar".format(fn=saved_fname)
-                self.execute_put(tar_loc, tar_loc)
+                put(tar_loc, tar_loc)
                 self.execute_root("docker load -i {loc}".format(loc=tar_loc))
                 # self.execute_root("docker tag {image_id} {cn}".format(
                 #       image_id=image_id, cn=cn))

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -52,7 +52,7 @@ DOCKER_COMPOSE_DICT = {
             'depends_on': [
                 'redis',
                 'mgmt_frontend'],
-            'image': 'czumar/clresilience:latest',
+            'image': 'clipper/query_frontend:latest',
             'ports': [
                 '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                 '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)]},
@@ -116,13 +116,13 @@ class Clipper:
 
     def execute_root(self, *args, **kwargs):
         if self.host_is_local():
-            self.execute_local(*args, **kwargs)
+            return self.execute_local(*args, **kwargs)
         else:
             return sudo(*args, **kwargs)
 
     def execute_standard(self, *args, **kwargs):
         if self.host_is_local():
-            self.execute_local(*args, **kwargs)
+            return self.execute_local(*args, **kwargs)
         else:
             return run(*args, **kwargs)
 
@@ -131,12 +131,14 @@ class Clipper:
         # key word argument, so we must remove it before
         # calling
         if "warn_only" in kwargs.keys():
-                del kwargs["warn_only"]
+            del kwargs["warn_only"]
             # Forces execution to continue in the face of an error,
             # just like warn_only=True
             with warn_only():
                 result = local(*args, **kwargs)
-                return result
+        else:
+            result = local(*args, **kwargs)
+        return result
 
     def execute_append(self, filename, text, **kwargs):
         if self.host_is_local():

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -143,10 +143,12 @@ class Clipper:
     def execute_append(self, filename, text, **kwargs):
         if self.host_is_local():
             file = open(filename, "a+")
+            # As with fabric.append(), we should only
+            # append the text if it is not already
+            # present within the file
             if text not in file.read():
                 file.write(text)
             file.close()
-
         else:
             append(filename, text, **kwargs)
 

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -52,7 +52,7 @@ DOCKER_COMPOSE_DICT = {
             'depends_on': [
                 'redis',
                 'mgmt_frontend'],
-            'image': 'czumar/clresilience:latest',
+            'image': 'clipper/query_frontend:latest',
             'ports': [
                 '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                 '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)]},
@@ -128,8 +128,7 @@ class Clipper:
 
     def execute_local(self, *args, **kwargs):
         # fabric.local() does not accept the "warn_only"
-        # key word argument, so we must remove it before
-        # calling
+        # key word argument, so we must remove it before calling
         if "warn_only" in kwargs.keys():
                 del kwargs["warn_only"]
             # Forces execution to continue in the face of an error,

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -322,7 +322,7 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         return r.text
 
-    def deploy_model(self, name, version, model, container_name, labels, num_containers=1):
+    def deploy_model(self, name, version, model_data, container_name, labels, input_type, num_containers=1):
         """Add a model to Clipper.
 
         Parameters

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -157,7 +157,6 @@ class Clipper:
         """
         with hide("output", "warnings", "running"):
             self.execute_standard("rm -f docker-compose.yml")
-            print(yaml.dump(DOCKER_COMPOSE_DICT, default_flow_style=False))
             self.execute_append(
                 "docker-compose.yml",
                 yaml.dump(


### PR DESCRIPTION
Enables clipper manager to be used to manage clipper locally. Specifying a host of `127.0.0.1` or `localhost` at initialization indicates local launch