### PR TITLE
[CLIPPER-92] Change RPC to event-based message handling

### DIFF
--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -87,8 +87,8 @@ class ActiveContainers {
   // the queues. The queues are independently threadsafe.
   boost::shared_mutex m_;
 
-  // A map of models to their replica task queues. The replicas
-  // for each model are represented as a map keyed on replica id
+  // A mapping of models to their replica task queues. The replicas
+  // for each model are represented as a map keyed on replica id.
   std::unordered_map<VersionedModelId,
                      std::map<int, std::shared_ptr<ModelContainer>>,
                      decltype(&versioned_model_hash)>

--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -55,7 +55,7 @@ class ActiveContainers {
   ActiveContainers(ActiveContainers &&) = default;
   ActiveContainers &operator=(ActiveContainers &&) = default;
 
-  void add_container(VersionedModelId model, int id, InputType input_type);
+  void add_container(VersionedModelId model, int connection_id, int replica_id, InputType input_type);
 
   /// TODO: this method should be deprecated / removed when per-model
   /// queueing is implemented, as it currently functions as an efficiency

--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -87,6 +87,8 @@ class ActiveContainers {
   // the queues. The queues are independently threadsafe.
   boost::shared_mutex m_;
 
+  // A map of models to their replica task queues. The replicas
+  // for each model are represented as a map keyed on replica id
   std::unordered_map<VersionedModelId,
                      std::map<int, std::shared_ptr<ModelContainer>>,
                      decltype(&versioned_model_hash)>

--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -57,6 +57,10 @@ class ActiveContainers {
 
   void add_container(VersionedModelId model, int id, InputType input_type);
 
+  /// TODO: this method should be deprecated / removed when per-model
+  /// queueing is implemented, as it currently functions as an efficiency
+  /// method in the context of assigning tasks to containers directly
+  ///
   /// This method returns a vector of all the active containers (replicas)
   /// of the specified model. This is threadsafe because each individual
   /// ModelContainer object is threadsafe, and this method returns

--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -67,6 +67,13 @@ class ActiveContainers {
   std::vector<std::shared_ptr<ModelContainer>> get_model_replicas_snapshot(
       const VersionedModelId &model);
 
+  /// This method returns the active container specified by the
+  /// provided model id and replica id. This is threadsafe because each
+  /// individual ModelContainer object is threadsafe, and this method returns
+  /// a shared_ptr to a ModelContainer object.
+  std::shared_ptr<ModelContainer> get_model_replica(
+      const VersionedModelId &model, const int replica_id);
+
   /// Get list of all models that have at least one active replica.
   std::vector<VersionedModelId> get_known_models();
 
@@ -76,9 +83,8 @@ class ActiveContainers {
   // the queues. The queues are independently threadsafe.
   boost::shared_mutex m_;
 
-  // Each queue corresponds to a single model container.
   std::unordered_map<VersionedModelId,
-                     std::vector<std::shared_ptr<ModelContainer>>,
+                     std::map<int, std::shared_ptr<ModelContainer>>,
                      decltype(&versioned_model_hash)>
       containers_;
 };

--- a/src/libclipper/include/clipper/rpc_service.hpp
+++ b/src/libclipper/include/clipper/rpc_service.hpp
@@ -33,14 +33,6 @@ using RPCRequest =
     std::tuple<const int, const int, const std::vector<std::vector<uint8_t>>,
                const long>;
 
-template<class T>
-class VectorHasher {
- public:
-  size_t operator()(const vector<T> &v) const {
-    return boost::hash_range(v.begin(), v.end());
-  }
-};
-
 class RPCService {
  public:
   explicit RPCService();

--- a/src/libclipper/include/clipper/rpc_service.hpp
+++ b/src/libclipper/include/clipper/rpc_service.hpp
@@ -55,7 +55,6 @@ class RPCService {
    */
   void start(const string ip,
              const int port,
-             const std::function<void(VersionedModelId, int)> &&new_container_callback,
              std::function<void(VersionedModelId, int)> &&container_ready_callback,
              std::function<void(RPCResponse)> &&new_response_callback);
   /**
@@ -103,7 +102,6 @@ class RPCService {
       replica_ids_;
   std::shared_ptr<metrics::Histogram> msg_queueing_hist;
 
-  std::function<void(VersionedModelId, int)> new_container_callback_;
   std::function<void(VersionedModelId, int)> container_ready_callback_;
   std::function<void(RPCResponse)> new_response_callback_;
 };

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -101,6 +101,8 @@ class TaskExecutor {
                 vm, std::stoi(container_info["zmq_connection_id"]),
                 parse_input_type(container_info["input_type"]));
             int replica_id = std::stoi(container_info["model_replica_id"]);
+            // TODO: These callbacks should be submitted to a thread pool
+            // for execution on separate threads
             on_new_container_added(vm, replica_id);
             std::thread([&]() {
               on_container_ready(vm, replica_id);

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -185,7 +185,7 @@ class TaskExecutor {
   /// thread that will each continuously try to send/receive.
 
   void on_new_container_added(VersionedModelId model_id, int replica_id) {
-    // Create a new model queue if this is the first connected container
+    // TODO: Create a new model queue if this is the first connected container
     // hosting the specified model (i.e. replica_id == 0)
     UNUSED(model_id);
     UNUSED(replica_id);
@@ -193,11 +193,9 @@ class TaskExecutor {
   }
 
   void on_container_ready(VersionedModelId model_id, int replica_id) {
-    // We need to request batch of size `batch_size`, send to container via its socket ID
     std::shared_ptr<ModelContainer> container = active_containers_->get_model_replica(model_id, replica_id);
     if(!container) {
-      // Throw?
-      return;
+      throw std::runtime_error("TaskExecutor failed to find previously registered active container!");
     }
     
     while(true) {
@@ -226,7 +224,6 @@ class TaskExecutor {
   }
 
   void on_new_response(rpc::RPCResponse response) {
-    // Handle the response
     std::unique_lock<std::mutex> l(inflight_messages_mutex_);
     auto keys = inflight_messages_[response.first];
 

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -245,7 +245,6 @@ class TaskExecutor {
                         {std::get<1>(keys[batch_num])}});
     }
   }
-
 };
 
 class PowerTwoChoicesScheduler {

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -65,7 +65,10 @@ class TaskExecutor {
       : active_containers_(std::make_shared<ActiveContainers>()),
         rpc_(std::make_unique<rpc::RPCService>()) {
     log_info(LOGGING_TAG_TASK_EXECUTOR, "TaskExecutor started");
-    rpc_->start("*", RPC_SERVICE_PORT);
+    rpc_->start("*", RPC_SERVICE_PORT,
+                [this](VersionedModelId model, int replica_id) { on_new_container_added(model, replica_id); },
+                [this](VersionedModelId model, int replica_id) { on_container_ready(model, replica_id); },
+                [this](rpc::RPCResponse response) { on_new_response(std::move(response)); });
     active_ = true;
     Config &conf = get_config();
     while (!redis_connection_.connect(conf.get_redis_address(),
@@ -110,8 +113,8 @@ class TaskExecutor {
         "prediction_throughput");
     latency_hist = metrics::MetricsRegistry::get_metrics().create_histogram(
         "prediction_latency", "milliseconds", 2056);
-    boost::thread(&TaskExecutor::send_messages, this).detach();
-    boost::thread(&TaskExecutor::recv_messages, this).detach();
+    //boost::thread(&TaskExecutor::send_messages, this).detach();
+    //boost::thread(&TaskExecutor::recv_messages, this).detach();
   }
 
   // Disallow copy
@@ -159,6 +162,7 @@ class TaskExecutor {
   redox::Redox redis_connection_;
   redox::Subscriber redis_subscriber_;
   bool active_ = false;
+  const int max_batch_size_ = 5;
   std::mutex inflight_messages_mutex_;
   std::unordered_map<int, std::vector<std::tuple<const long, VersionedModelId,
                                                  std::shared_ptr<Input>>>>
@@ -178,79 +182,65 @@ class TaskExecutor {
   /// receiving
   /// thread that will each continuously try to send/receive.
 
-  // Note: This method gets run in a separate thread, so all operations
-  // on member variables must be thread safe.
-  void send_messages() {
-    int max_batch_size = 5;
-    while (active_) {
-      //      std::vector<std::pair<
-      //          int,
-      //          std::vector<std::pair<VersionedModelId,
-      //          std::shared_ptr<Input>>>>>
-      //          new_messages;
-      auto current_active_models = active_containers_->get_known_models();
-      for (auto model : current_active_models) {
-        auto containers =
-            active_containers_->get_model_replicas_snapshot(model);
-        for (auto c : containers) {
-          auto batch = c->dequeue_predictions(max_batch_size);
-          if (batch.size() > 0) {
-            // move the lock up here, so that nothing can pull from the
-            // inflight_messages_
-            // map between the time a message is sent and when it gets inserted
-            // into the map
-            std::unique_lock<std::mutex> l(inflight_messages_mutex_);
-            // std::vector<const std::vector<uint8_t>> serialized_inputs;
-
-            std::vector<std::tuple<const long, VersionedModelId,
-                                   std::shared_ptr<Input>>>
-                cur_batch;
-            rpc::PredictionRequest prediction_request(c->input_type_);
-            for (auto b : batch) {
-              prediction_request.add_input(b.input_);
-              cur_batch.emplace_back(b.send_time_micros_, b.model_, b.input_);
-            }
-            int message_id = rpc_->send_message(prediction_request.serialize(),
-                                                c->container_id_);
-            inflight_messages_.emplace(message_id, std::move(cur_batch));
-          }
-        }
-      }
-    }
+  void on_new_container_added(VersionedModelId model_id, int replica_id) {
+    // Create a new model queue if this is the first connected container
+    // hosting the specified model (i.e. replica_id == 0)
+    UNUSED(model_id);
+    UNUSED(replica_id);
   }
 
-  // Note: This method gets run in a separate thread, so all operations
-  // on member variables must be thread safe.
-  void recv_messages() {
-    int max_responses = 10;
-    while (active_) {
-      auto responses = rpc_->try_get_responses(max_responses);
-      if (responses.empty()) {
-        continue;
-      }
+  void on_container_ready(VersionedModelId model_id, int replica_id) {
+    // We need to request batch of size `batch_size`, send to container via its socket ID
+    std::shared_ptr<ModelContainer> container = active_containers_->get_model_replica(model_id, replica_id);
+    if(!container) {
+      // Throw?
+      return;
+    }
+    auto batch = container->dequeue_predictions(max_batch_size_);
+    if(batch.size() > 0) {
+      // move the lock up here, so that nothing can pull from the
+      // inflight_messages_
+      // map between the time a message is sent and when it gets inserted
+      // into the map
       std::unique_lock<std::mutex> l(inflight_messages_mutex_);
-      for (auto r : responses) {
-        auto keys = inflight_messages_[r.first];
-
-        inflight_messages_.erase(r.first);
-        std::vector<float> deserialized_outputs = deserialize_outputs(r.second);
-        assert(deserialized_outputs.size() == keys.size());
-        int batch_size = keys.size();
-        throughput_meter->mark(batch_size);
-        long current_time =
-            std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::system_clock::now().time_since_epoch())
-                .count();
-        for (int batch_num = 0; batch_num < batch_size; ++batch_num) {
-          long send_time = std::get<0>(keys[batch_num]);
-          latency_hist->insert(static_cast<int64_t>(current_time - send_time));
-          cache_.put(std::get<1>(keys[batch_num]), std::get<2>(keys[batch_num]),
-                     Output{deserialized_outputs[batch_num],
-                            {std::get<1>(keys[batch_num])}});
-        }
+      std::vector<std::tuple<const long, VersionedModelId,
+                             std::shared_ptr<Input>>>
+          cur_batch;
+      rpc::PredictionRequest prediction_request(container->input_type_);
+      for (auto b : batch) {
+        prediction_request.add_input(b.input_);
+        cur_batch.emplace_back(b.send_time_micros_, b.model_, b.input_);
       }
+      int message_id = rpc_->send_message(prediction_request.serialize(),
+                                          container->container_id_);
+      inflight_messages_.emplace(message_id, std::move(cur_batch));
     }
   }
+
+  void on_new_response(rpc::RPCResponse response) {
+    // Handle the response
+    std::unique_lock<std::mutex> l(inflight_messages_mutex_);
+    auto keys = inflight_messages_[response.first];
+
+    inflight_messages_.erase(response.first);
+    std::vector<float> deserialized_outputs = deserialize_outputs(response.second);
+    assert(deserialized_outputs.size() == keys.size());
+    int batch_size = keys.size();
+    predictions_counter->increment(batch_size);
+    throughput_meter->mark(batch_size);
+    long current_time =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch())
+            .count();
+    for (int batch_num = 0; batch_num < batch_size; ++batch_num) {
+      long send_time = std::get<0>(keys[batch_num]);
+      latency_hist->insert(static_cast<int64_t>(current_time - send_time));
+      cache_.put(std::get<1>(keys[batch_num]), std::get<2>(keys[batch_num]),
+                 Output{deserialized_outputs[batch_num],
+                        {std::get<1>(keys[batch_num])}});
+    }
+  }
+
 };
 
 class PowerTwoChoicesScheduler {

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -97,10 +97,10 @@ class TaskExecutor {
             VersionedModelId vm =
                 std::make_pair(container_info["model_name"],
                                std::stoi(container_info["model_version"]));
+            int replica_id = std::stoi(container_info["model_replica_id"]);
             active_containers_->add_container(
                 vm, std::stoi(container_info["zmq_connection_id"]),
-                parse_input_type(container_info["input_type"]));
-            int replica_id = std::stoi(container_info["model_replica_id"]);
+                replica_id, parse_input_type(container_info["input_type"]));
             // TODO: This callback should be submitted to a thread pool
             // for execution on a separate thread
             on_container_ready(vm, replica_id);

--- a/src/libclipper/include/clipper/util.hpp
+++ b/src/libclipper/include/clipper/util.hpp
@@ -86,5 +86,10 @@ class Queue {
   std::queue<T> xs_;
 };
 
+template <class T>
+size_t hash_vector(const std::vector<T> &vec) {
+  return boost::hash_range(vec.begin(), vec.end());
+}
+
 }  // namespace clipper
 #endif

--- a/src/libclipper/src/containers.cpp
+++ b/src/libclipper/src/containers.cpp
@@ -36,16 +36,16 @@ ActiveContainers::ActiveContainers()
                              decltype(&versioned_model_hash)>(
               100, &versioned_model_hash)) {}
 
-void ActiveContainers::add_container(VersionedModelId model, int id,
-                                     InputType input_type) {
+void ActiveContainers::add_container(VersionedModelId model, int connection_id,
+                                     int replica_id, InputType input_type) {
   log_info_formatted(
       LOGGING_TAG_CLIPPER,
       "Adding new container - model: {}, version: {}, ID: {}, input_type: {}",
-      model.first, model.second, id, get_readable_input_type(input_type));
+      model.first, model.second, connection_id, get_readable_input_type(input_type));
   boost::unique_lock<boost::shared_mutex> l{m_};
-  auto new_container = std::make_shared<ModelContainer>(model, id, input_type);
+  auto new_container = std::make_shared<ModelContainer>(model, connection_id, input_type);
   auto entry = containers_[new_container->model_];
-  entry.emplace(id, new_container);
+  entry.emplace(replica_id, new_container);
   containers_[new_container->model_] = entry;
   assert(containers_[new_container->model_].size() > 0);
 }

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -6,20 +6,12 @@
 
 #include <boost/functional/hash.hpp>
 #include <clipper/datatypes.hpp>
+#include <clipper/util.hpp>
 
 namespace clipper {
 
 size_t versioned_model_hash(const VersionedModelId &key) {
   return std::hash<std::string>()(key.first) ^ std::hash<int>()(key.second);
-}
-
-template <typename T>
-size_t primitive_input_hash(const std::vector<T> &data) {
-  size_t cur_hash = 0;
-  for (const auto d : data) {
-    boost::hash_combine(cur_hash, d);
-  }
-  return cur_hash;
 }
 
 template <typename T>
@@ -81,7 +73,7 @@ size_t ByteVector::serialize(uint8_t *buf) const {
   return serialize_to_buffer(data_, buf);
 }
 
-size_t ByteVector::hash() const { return primitive_input_hash(data_); }
+size_t ByteVector::hash() const { return hash_vector(data_); }
 
 size_t ByteVector::size() const { return data_.size(); }
 
@@ -97,7 +89,7 @@ size_t IntVector::serialize(uint8_t *buf) const {
   return serialize_to_buffer(data_, buf);
 }
 
-size_t IntVector::hash() const { return primitive_input_hash(data_); }
+size_t IntVector::hash() const { return hash_vector(data_); }
 
 size_t IntVector::size() const { return data_.size(); }
 
@@ -117,7 +109,7 @@ size_t FloatVector::hash() const {
   // TODO [CLIPPER-63]: Find an alternative to hashing floats directly, as this
   // is generally a bad idea due to loss of precision from floating point
   // representations
-  return primitive_input_hash(data_);
+  return hash_vector(data_);
 }
 
 size_t FloatVector::size() const { return data_.size(); }
@@ -138,7 +130,7 @@ size_t DoubleVector::hash() const {
   // TODO [CLIPPER-63]: Find an alternative to hashing doubles directly, as
   // this is generally a bad idea due to loss of precision from floating point
   // representations
-  return primitive_input_hash(data_);
+  return hash_vector(data_);
 }
 
 size_t DoubleVector::size() const { return data_.size(); }

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -22,13 +22,6 @@ size_t primitive_input_hash(const std::vector<T> &data) {
   return cur_hash;
 }
 
-template <typename Container> // we can make this generic for any container [1]
-struct container_hash {
-  std::size_t operator()(Container const& c) const {
-    return boost::hash_range(c.begin(), c.end());
-  }
-};
-
 template <typename T>
 ByteBuffer get_byte_buffer(std::vector<T> vector) {
   uint8_t *data = reinterpret_cast<uint8_t *>(vector.data());

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -22,6 +22,13 @@ size_t primitive_input_hash(const std::vector<T> &data) {
   return cur_hash;
 }
 
+template <typename Container> // we can make this generic for any container [1]
+struct container_hash {
+  std::size_t operator()(Container const& c) const {
+    return boost::hash_range(c.begin(), c.end());
+  }
+};
+
 template <typename T>
 ByteBuffer get_byte_buffer(std::vector<T> vector) {
   uint8_t *data = reinterpret_cast<uint8_t *>(vector.data());

--- a/src/libclipper/src/rpc_service.cpp
+++ b/src/libclipper/src/rpc_service.cpp
@@ -251,10 +251,11 @@ void RPCService::receive_message(socket_t &socket,
     }
     std::pair<VersionedModelId, int> container_info = container_info_entry->second;
 
+    // TODO: These callbacks should be submitted to a threadpool for
+    // execution on separate threads
     std::thread([&]() {
       new_response_callback_(response);
     }).detach();
-
     std::thread([&]() {
       container_ready_callback_(container_info.first, container_info.second);
     }).detach();

--- a/src/libclipper/src/rpc_service.cpp
+++ b/src/libclipper/src/rpc_service.cpp
@@ -247,7 +247,7 @@ void RPCService::receive_message(socket_t &socket,
 
     auto container_info_entry = containers.find(connection_id);
     if(container_info_entry == containers.end()) {
-      // This is unusual, throw?
+      throw std::runtime_error("Failed to find container that was previously registered via RPC");
     }
     std::pair<VersionedModelId, int> container_info = container_info_entry->second;
 

--- a/src/libclipper/src/rpc_service.cpp
+++ b/src/libclipper/src/rpc_service.cpp
@@ -39,7 +39,7 @@ RPCService::RPCService()
       replica_ids_(std::unordered_map<VersionedModelId, int,
                                       decltype(&versioned_model_hash)>(
           INITIAL_REPLICA_ID_SIZE, &versioned_model_hash)) {
-  msg_queueing_hist = metrics::MetricsRegistry::get_metrics().create_histogram(
+  msg_queueing_hist_ = metrics::MetricsRegistry::get_metrics().create_histogram(
       "rpc_request_queueing_delay", "microseconds", 2056);
 }
 
@@ -59,13 +59,13 @@ void RPCService::start(const string ip,
   active_ = true;
   // TODO: Propagate errors from new child thread for handling
   // TODO: Explore bind vs static method call for thread creation
-  rpc_thread = std::thread([this, address]() { manage_service(address); });
+  rpc_thread_ = std::thread([this, address]() { manage_service(address); });
 }
 
 void RPCService::stop() {
   if (active_) {
     active_ = false;
-    rpc_thread.join();
+    rpc_thread_.join();
   }
 }
 
@@ -107,7 +107,13 @@ void RPCService::manage_service(const string address) {
   log_info_formatted(LOGGING_TAG_RPC, "RPC thread started at address: ",
                      address);
   boost::bimap<int, vector<uint8_t>> connections;
-  std::unordered_map<std::vector<uint8_t>, std::pair<VersionedModelId, int>, VectorHasher<uint8_t>> containers;
+  // Initializes a map to associate the ZMQ connection IDs
+  // of connected containers with their metadata, including
+  // model id and replica id
+
+  std::unordered_map
+      <std::vector<uint8_t>, std::pair<VersionedModelId, int>, std::function<size_t(const std::vector<uint8_t> &vec)>>
+       connections_containers_map(INITIAL_REPLICA_ID_SIZE, hash_vector<uint8_t>);
   context_t context = context_t(1);
   socket_t socket = socket_t(context, ZMQ_ROUTER);
   socket.bind(address);
@@ -130,7 +136,7 @@ void RPCService::manage_service(const string address) {
       // Note: We only receive one message per event loop iteration
       log_info(LOGGING_TAG_RPC, "Found message to receive");
 
-      receive_message(socket, connections, containers, zmq_connection_id, redis_connection);
+      receive_message(socket, connections, connections_containers_map, zmq_connection_id, redis_connection);
     }
     // Note: We send all queued messages per event loop iteration
     send_messages(socket, connections);
@@ -155,7 +161,7 @@ void RPCService::send_messages(
             std::chrono::system_clock::now().time_since_epoch())
             .count();
     RPCRequest request = request_queue_->pop();
-    msg_queueing_hist->insert(current_time_micros - std::get<3>(request));
+    msg_queueing_hist_->insert(current_time_micros - std::get<3>(request));
     boost::bimap<int, vector<uint8_t>>::left_const_iterator connection =
         connections.left.find(std::get<0>(request));
     if (connection == connections.left.end()) {
@@ -190,7 +196,8 @@ void RPCService::receive_message(socket_t &socket,
                                  boost::bimap<int, vector<uint8_t>> &connections,
                                  std::unordered_map<std::vector<uint8_t>,
                                                     std::pair<VersionedModelId, int>,
-                                                    VectorHasher<uint8_t>>& containers,
+                                                    std::function<size_t(const std::vector<uint8_t> &vec)>>
+                                                    &connections_containers_map,
                                  int &zmq_connection_id,
                                  std::shared_ptr<redox::Redox> redis_connection) {
   message_t msg_identity;
@@ -198,7 +205,7 @@ void RPCService::receive_message(socket_t &socket,
   socket.recv(&msg_identity, 0);
   socket.recv(&msg_delimiter, 0);
 
-  vector<uint8_t> connection_id(
+  const vector<uint8_t> connection_id(
       (uint8_t *)msg_identity.data(),
       (uint8_t *)msg_identity.data() + msg_identity.size());
   boost::bimap<int, vector<uint8_t>>::right_const_iterator connection =
@@ -233,7 +240,7 @@ void RPCService::receive_message(socket_t &socket,
     replica_ids_[model] = cur_replica_id + 1;
     redis::add_container(*redis_connection, model, cur_replica_id,
                          zmq_connection_id, input_type);
-    containers.emplace(connection_id, std::pair<VersionedModelId, int>(model, cur_replica_id));
+    connections_containers_map.emplace(connection_id, std::pair<VersionedModelId, int>(model, cur_replica_id));
     zmq_connection_id += 1;
   } else {
     message_t msg_id;
@@ -245,20 +252,16 @@ void RPCService::receive_message(socket_t &socket,
                             (uint8_t *)msg_content.data() + msg_content.size());
     RPCResponse response(id, content);
 
-    auto container_info_entry = containers.find(connection_id);
-    if(container_info_entry == containers.end()) {
+    auto container_info_entry = connections_containers_map.find(connection_id);
+    if(container_info_entry == connections_containers_map.end()) {
       throw std::runtime_error("Failed to find container that was previously registered via RPC");
     }
     std::pair<VersionedModelId, int> container_info = container_info_entry->second;
 
     // TODO: These callbacks should be submitted to a threadpool for
     // execution on separate threads
-    std::thread([&]() {
-      new_response_callback_(response);
-    }).detach();
-    std::thread([&]() {
-      container_ready_callback_(container_info.first, container_info.second);
-    }).detach();
+    new_response_callback_(response);
+    container_ready_callback_(container_info.first, container_info.second);
 
     response_queue_->push(response);
   }


### PR DESCRIPTION
Notes:

* The implementation differs slightly from the specification included in the [JIRA issue](https://clipper.atlassian.net/browse/CLIPPER-92). Notably, the `on_new_connection` callback is not passed from the task executor to the RPC service. Rather, this method is invoked via the task executor's Redis state subscriber when the addition of a new container is detected. 