### PR TITLE
[CLIPPER-136] Add input header and input content sizes to RPC protocol

### DIFF
--- a/containers/container_implementation.md
+++ b/containers/container_implementation.md
@@ -61,7 +61,9 @@ RPC requests sent from Clipper to model containers are divided into two categori
 ### Serializing Prediction Requests
 1. All requests begin with a 32-bit integer header, sent as a single ZeroMQ message. The value of this integer will be 0, indicating that the request is a prediction request.
 
-2. The next ZeroMQ message contains an input header. This is a list of 32-bit integers.
+2. The second ZeroMQ message contains the size of the input header, in bytes, as a 64-bit long. This is the size of the content of the third ZeroMQ message.
+
+3. The third ZeroMQ message contains an input header. This is a list of 32-bit integers.
  * The input header begins with a 32-bit integer specifying the type of inputs contained in the request. This integer can assume values 0-4, as defined in point 2 of **Initializing a Connection**.
  
  * The next 32-bit integer in the input header is the number of inputs included in the serialized content.
@@ -70,8 +72,10 @@ RPC requests sent from Clipper to model containers are divided into two categori
    * For example, if the request contains three double vectors of size 500, the offsets will be `[500, 1000]`, indicating that the deserialized vector of 1500 doubles should be split into three vectors containing doubles 0-499, 500-999, and 1000-1499 respectively.
    
     * In the case of strings, the offset list is not relevant and should not be used.
+    
+4. The fourth ZeroMQ message contains the size of the input content, in bytes, as a 64-bit long. This is the size of the content of the fifth ZeroMQ message.
    
-3. The final ZeroMQ message contains the concatenation of all inputs, represented as a string of bytes. This string of bytes should be converted to an array of the type specified by the input header.
+5. The final ZeroMQ message contains the concatenation of all inputs, represented as a string of bytes. This string of bytes should be converted to an array of the type specified by the input header.
  * In the case of primitive inputs (types 0-3), deserialized inputs can then be obtained by splitting the typed array at the offsets specified in the input header.
    * Python example:
    

--- a/containers/python/rpc.py
+++ b/containers/python/rpc.py
@@ -118,7 +118,9 @@ class Server(threading.Thread):
             request_type = struct.unpack("<I", request_header)[0]
 
             if request_type == REQUEST_TYPE_PREDICT:
+                input_header_size = self.socket.recv()
                 input_header = self.socket.recv()
+                raw_content_size = self.socket.recv()
                 raw_content = self.socket.recv()
 
                 t2 = datetime.now()

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -226,7 +226,7 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
   ByteBuffer serialized_request_metadata = get_byte_buffer(request_metadata);
   ByteBuffer serialized_inputs =
       ByteBuffer(input_buf_start, input_buf_start + input_data_size_);
-  
+
   std::vector<long> input_metadata_size_bytes;
   // Add the size of the input metadata in bytes. This will be
   // sent prior to the input metadata to allow for proactive

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -232,7 +232,8 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
   // sent prior to the input metadata to allow for proactive
   // buffer allocation in the receiving container
   input_metadata_size_bytes.push_back(serialized_input_metadata.size());
-  ByteBuffer serialized_input_metadata_size = get_byte_buffer(input_metadata_size_bytes);
+  ByteBuffer serialized_input_metadata_size =
+      get_byte_buffer(input_metadata_size_bytes);
 
   std::vector<long> inputs_size_bytes;
   // Add the size of the serialized inputs in bytes. This will be

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -203,7 +203,6 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
   request_metadata.emplace_back(
       static_cast<uint32_t>(RequestType::PredictRequest));
 
-
   std::vector<uint32_t> input_metadata;
   input_metadata.emplace_back(static_cast<uint32_t>(input_type_));
   input_metadata.emplace_back(static_cast<uint32_t>(inputs_.size()));
@@ -227,8 +226,7 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
   ByteBuffer serialized_request_metadata = get_byte_buffer(request_metadata);
   ByteBuffer serialized_inputs =
       ByteBuffer(input_buf_start, input_buf_start + input_data_size_);
-
-
+  
   std::vector<long> input_metadata_size_bytes;
   // Add the size of the input metadata in bytes. This will be
   // sent prior to the input metadata to allow for proactive

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -203,6 +203,7 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
   request_metadata.emplace_back(
       static_cast<uint32_t>(RequestType::PredictRequest));
 
+
   std::vector<uint32_t> input_metadata;
   input_metadata.emplace_back(static_cast<uint32_t>(input_type_));
   input_metadata.emplace_back(static_cast<uint32_t>(inputs_.size()));
@@ -226,9 +227,27 @@ std::vector<ByteBuffer> rpc::PredictionRequest::serialize() {
   ByteBuffer serialized_request_metadata = get_byte_buffer(request_metadata);
   ByteBuffer serialized_inputs =
       ByteBuffer(input_buf_start, input_buf_start + input_data_size_);
+
+
+  std::vector<long> input_metadata_size_bytes;
+  // Add the size of the input metadata in bytes. This will be
+  // sent prior to the input metadata to allow for proactive
+  // buffer allocation in the receiving container
+  input_metadata_size_bytes.push_back(serialized_input_metadata.size());
+  ByteBuffer serialized_input_metadata_size = get_byte_buffer(input_metadata_size_bytes);
+
+  std::vector<long> inputs_size_bytes;
+  // Add the size of the serialized inputs in bytes. This will be
+  // sent prior to the input metadata to allow for proactive
+  // buffer allocation in the receiving container
+  inputs_size_bytes.push_back(serialized_inputs.size());
+  ByteBuffer serialized_inputs_size = get_byte_buffer(inputs_size_bytes);
+
   free(input_buf_start);
   serialized_request.push_back(serialized_request_metadata);
+  serialized_request.push_back(serialized_input_metadata_size);
   serialized_request.push_back(serialized_input_metadata);
+  serialized_request.push_back(serialized_inputs_size);
   serialized_request.push_back(serialized_inputs);
 
   return serialized_request;


### PR DESCRIPTION
In order for containers to preallocate reusable buffers for processing RPC messages, it is helpful to have information about the size of the often-lengthy input header and input content messages before they arrive. The recently optimized java container (#78, [CLIPPER-76](https://clipper.atlassian.net/projects/CLIPPER/issues/CLIPPER-76)) depends on these additions. 