### PR TITLE
Add Vagrantfile to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,32 @@ make
 
 # build and then start the query REST frontend
 ../bin/start_clipper.sh
+
+```
+
+__Using Vagrant:__
+
+You can use Vagrant to automatically create a development environment in a virtual machine.
+This is one method for using Windows for Clipper development. Before you start, you must have [Vagrant](https://www.vagrantup.com/) and [VirtualBox](https://www.virtualbox.org/wiki/VirtualBox)
+installed.  Once you have them installed, perform the following command to initialize Vagrant.
+
+```sh
+vagrant up
+```
+
+And the environment will be created for you. You can now edit Clipper files
+on your local machine and when you want to test your changes, you can just
+perform the following commands:
+
+```sh
+# Log in to the virtual machine
+vagrant ssh
+
+# Enter root Clipper directory
+cd /vagrant
+
+# Run tests
+./bin/run_unittests.sh
 ```
 
 Clipper has been tested on OSX 10.11, 10.12, and on Debian stretch/sid and Ubuntu 12.04 and 16.04. It does not support Windows.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/testing64"
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  config.vm.provision "shell", inline: <<-SHELL
+    apt-get update
+    apt-get upgrade
+    apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git
+
+    cd /vagrant
+    ./configure
+    cd debug/
+    make
+
+    ../bin/run_unittests.sh
+
+  SHELL
+end


### PR DESCRIPTION
This MR adds a Vagrantfile to the project, with the aim at helping automating the creation of a development environment for new users. 

Vagrant basically will create a virtual machine running Debian stretch, install all the necessary packages and run the unit tests to see if the environment is okay.

Currently, I am using virtualbox as the virtual machine provider, but this can be updated if necessary