### PR TITLE
[CLIPPER-130] Allows for registering external models without deploying containers

### DIFF
--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -376,7 +376,6 @@ class Clipper:
                     EXTERNALLY_MANAGED_MODEL,
                     EXTERNALLY_MANAGED_MODEL)
 
-
     def deploy_model(self,
                      name,
                      version,

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -68,6 +68,7 @@ DOCKER_COMPOSE_DICT = {
 
 LOCAL_HOST_NAMES = ["local", "localhost", "127.0.0.1"]
 
+EXTERNALLY_MANAGED_MODEL = "EXTERNAL"
 
 class Clipper:
     """
@@ -353,6 +354,29 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         return r.text
 
+    def register_external_model(self, name, version, labels, input_type):
+        """Registers a model with Clipper without deploying it in any containers.
+
+        Parameters
+        ----------
+        name : str
+            The name to assign this model.
+        version : int
+            The version to assign this model.
+        labels : list of str
+            A set of strings annotating the model
+        input_type : str
+            One of "integers", "floats", "doubles", "bytes", or "strings".
+        """
+        return self._publish_new_model(
+                    name,
+                    version,
+                    labels,
+                    input_type,
+                    EXTERNALLY_MANAGED_MODEL,
+                    EXTERNALLY_MANAGED_MODEL)
+
+
     def deploy_model(self,
                      name,
                      version,
@@ -361,7 +385,7 @@ class Clipper:
                      labels,
                      input_type,
                      num_containers=1):
-        """Add a model to Clipper.
+        """Registers a model with Clipper and deploys instances of it in containers.
 
         Parameters
         ----------

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -70,6 +70,7 @@ LOCAL_HOST_NAMES = ["local", "localhost", "127.0.0.1"]
 
 EXTERNALLY_MANAGED_MODEL = "EXTERNAL"
 
+
 class Clipper:
     """
     Connection to a Clipper instance for administrative purposes.
@@ -368,13 +369,9 @@ class Clipper:
         input_type : str
             One of "integers", "floats", "doubles", "bytes", or "strings".
         """
-        return self._publish_new_model(
-                    name,
-                    version,
-                    labels,
-                    input_type,
-                    EXTERNALLY_MANAGED_MODEL,
-                    EXTERNALLY_MANAGED_MODEL)
+        return self._publish_new_model(name, version, labels, input_type,
+                                       EXTERNALLY_MANAGED_MODEL,
+                                       EXTERNALLY_MANAGED_MODEL)
 
     def deploy_model(self,
                      name,


### PR DESCRIPTION
Adds a function to the Clipper management library that allows model metadata (name, version, labels, and input_type) to be registered with Clipper without actually supplying the model and deploying it in a container.

https://clipper.atlassian.net/projects/CLIPPER/issues/CLIPPER-130?filter=allopenissues

