### PR TITLE
Make vagrant provision run without root permission

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,10 +7,10 @@ Vagrant.configure("2") do |config|
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
-  config.vm.provision "shell", inline: <<-SHELL
-    apt-get update
-    apt-get upgrade
-    apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get upgrade -y
+    sudo apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git
 
     cd /vagrant
     ./configure


### PR DESCRIPTION
While developing with Vagrant, I just realized that the provision step is being executed with root permissions. 

https://www.vagrantup.com/docs/provisioning/shell.html#privileged

Therefore, all files created during that step would belong to the root user. With that configuration, if an user using vagrant wants to run the tests, it will have to run as the root user, which is not necessary.

![vagrant_bug](https://cloud.githubusercontent.com/assets/2703696/24613255/2b06449e-185e-11e7-814d-60fd1123ba96.png)

The above Figure shows the problem. This MR fixes that issue, by not allowing the provision step to be run with root permission.
