### PR TITLE
[CLIPPER-126] Remove application command

### DIFF
--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -369,6 +369,20 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         print(r.text)
 
+    def delete_application(self, name):
+        """Deletes an existing Clipper application.
+
+        Parameters
+        ----------
+        name : str
+            The name of the application.
+        """
+        url = "http://%s:1338/admin/delete_app" % self.host
+        req_json = json.dumps({"name": name})
+        headers = {'Content-type': 'application/json'}
+        r = requests.delete(url, headers=headers, data=req_json)
+        print(r.text)
+
     def get_all_apps(self, verbose=False):
         """Gets information about all applications registered with Clipper.
 

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -253,10 +253,10 @@ class RequestHandler {
   }
 
   void delete_application(std::string name) {
-    std::string predict_endpoint = _get_endpoint_address(name, "predict");
-    std::string update_endpoint = _get_endpoint_address(name, "update");
-    server_.delete_endpoint(predict_endpoint, "POST");
-    server_.delete_endpoint(update_endpoint, "POST");
+    std::string predict_endpoint_addr = _get_endpoint_address(name, "predict");
+    std::string update_endpoint_addr = _get_endpoint_address(name, "update");
+    server_.delete_endpoint(predict_endpoint_addr, "POST");
+    server_.delete_endpoint(update_endpoint_addr, "POST");
   }
 
   std::string _get_endpoint_regex_str(std::string resource,

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -166,6 +166,9 @@ class RequestHandler {
             int latency_slo_micros = std::stoi(app_info["latency_slo_micros"]);
             add_application(name, candidate_model_names, input_type, policy,
                             default_output, latency_slo_micros);
+          } else if (event_type == "del") {
+            std::string name = key;
+            delete_application(name);
           }
         });
 
@@ -249,6 +252,22 @@ class RequestHandler {
     redis_subscriber_.disconnect();
   }
 
+  void delete_application(std::string name) {
+    std::string predict_endpoint = _get_endpoint_address(name, "predict");
+    std::string update_endpoint = _get_endpoint_address(name, "update");
+    server_.delete_endpoint(predict_endpoint, "POST");
+    server_.delete_endpoint(update_endpoint, "POST");
+  }
+
+  std::string _get_endpoint_regex_str(std::string resource,
+                                      std::string action) {
+    return "^" + _get_endpoint_address(resource, action) + "$";
+  }
+
+  std::string _get_endpoint_address(std::string resource, std::string action) {
+    return "/" + resource + "/" + action;
+  }
+
   void add_application(std::string name, std::vector<std::string> models,
                        InputType input_type, std::string policy,
                        std::string default_output, long latency_slo_micros) {
@@ -329,8 +348,9 @@ class RequestHandler {
         respond_http(json_error_response, "400 Bad Request", response);
       }
     };
-    std::string predict_endpoint = "^/" + name + "/predict$";
-    server_.add_endpoint(predict_endpoint, "POST", predict_fn);
+    std::string predict_endpoint_regex_str =
+        _get_endpoint_regex_str(name, "predict");
+    server_.add_endpoint(predict_endpoint_regex_str, "POST", predict_fn);
 
     auto update_fn = [this, name, input_type, policy, models](
         std::shared_ptr<HttpServer::Response> response,
@@ -366,8 +386,9 @@ class RequestHandler {
         respond_http(e.what(), "400 Bad Request", response);
       }
     };
-    std::string update_endpoint = "^/" + name + "/update$";
-    server_.add_endpoint(update_endpoint, "POST", update_fn);
+    std::string update_endpoint_regex_str =
+        _get_endpoint_regex_str(name, "update");
+    server_.add_endpoint(update_endpoint_regex_str, "POST", update_fn);
   }
 
   /**

--- a/src/libs/httpserver/server_http.hpp
+++ b/src/libs/httpserver/server_http.hpp
@@ -328,14 +328,16 @@ class ServerBase {
           if (REGEX_NS::regex_match(res_name, pair->first)) {
             size_t initial_ep_size = endpoint_pairs.size();
 
-            endpoint_pairs.erase(pair);
+            pair = endpoint_pairs.erase(pair); // Not actually necessary to assign `pair` here because we won't use it again
             if (endpoint_pairs.size() == 0) {
-              opt_resource.erase(opt_it);
-            }
-            size_t final_ep_size = endpoint_pairs.size();
+              opt_it = opt_resource.erase(opt_it); // Not actually necessary to assign `opt_it` here because we won't use it again
+            } else {
+              // This else case gets run by QueryFrontendTest.TestDeleteApplication and passes
+              size_t final_ep_size = endpoint_pairs.size();
 
-            // After deletion, size should decrease by 1
-            assert(initial_ep_size - 1 == final_ep_size);
+              // After deletion, size should decrease by 1
+              assert(initial_ep_size - 1 == final_ep_size);
+            }
 
             // How num_endpoints calculates the number of endpoints
             size_t count3 = 0;
@@ -354,9 +356,10 @@ class ServerBase {
             // Sanity check
             assert(count3 == count4);
 
+
             // After deletion of an endpoint, number of endpionts should decrease by 1
-            // This is the assert that is failing
-            assert(count - 1 == count3);
+            assert(count == count3); // I want this to fail, but it doesn't
+            assert(count - 1 == count3); // I want this to pass, but it doesn't
             return;
           }
         }

--- a/src/libs/httpserver/server_http.hpp
+++ b/src/libs/httpserver/server_http.hpp
@@ -301,6 +301,24 @@ class ServerBase {
     if (app_res.size() == 0) {
       resource.erase(res_name);
     }
+
+    // How num_endpoints calculates the number of endpoints
+    size_t count = 0;
+    for (auto e : opt_resource) {
+      count += e.second.size();
+    }
+
+    // Alternative but equivalent method for sanity check
+    size_t count2 = 0;
+    for (auto opt_it = opt_resource.begin(); opt_it != opt_resource.end();
+     opt_it++) {
+      auto endpoint_pairs = opt_it->second;
+      count2 += endpoint_pairs.size();
+    }
+
+    // Sanity check
+    assert(count == count2);
+
     for (auto opt_it = opt_resource.begin(); opt_it != opt_resource.end();
          opt_it++) {
       if (res_method == opt_it->first) {
@@ -308,15 +326,45 @@ class ServerBase {
         for (auto pair = endpoint_pairs.begin(); pair != endpoint_pairs.end();
           pair++) {
           if (REGEX_NS::regex_match(res_name, pair->first)) {
+            size_t initial_ep_size = endpoint_pairs.size();
+
             endpoint_pairs.erase(pair);
             if (endpoint_pairs.size() == 0) {
               opt_resource.erase(opt_it);
             }
+            size_t final_ep_size = endpoint_pairs.size();
+
+            // After deletion, size should decrease by 1
+            assert(initial_ep_size - 1 == final_ep_size);
+
+            // How num_endpoints calculates the number of endpoints
+            size_t count3 = 0;
+            for (auto e : opt_resource) {
+              count3 += e.second.size();
+            }
+
+            // Alternative but equivalent method for sanity check
+            size_t count4 = 0;
+            for (auto opt_it2 = opt_resource.begin(); opt_it2 != opt_resource.end();
+             opt_it2++) {
+              auto endpoint_pairs2 = opt_it2->second;
+              count4 += endpoint_pairs2.size();
+            }
+
+            // Sanity check
+            assert(count3 == count4);
+
+            // After deletion of an endpoint, number of endpionts should decrease by 1
+            // This is the assert that is failing
+            assert(count - 1 == count3);
             return;
           }
         }
       }
     }
+
+    // Shouldn't get here if we are deleting an existing endpoint
+    assert(false);
   }
 
   size_t num_endpoints() {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -47,6 +47,7 @@ const std::string LOGGING_TAG_MANAGEMENT_FRONTEND = "MGMTFRNTD";
 
 const std::string ADMIN_PATH = "^/admin";
 const std::string ADD_APPLICATION = ADMIN_PATH + "/add_app$";
+const std::string DELETE_APPLICATION = ADMIN_PATH + "/delete_app$";
 const std::string ADD_MODEL = ADMIN_PATH + "/add_model$";
 const std::string SET_MODEL_VERSION = ADMIN_PATH + "/set_model_version$";
 
@@ -60,8 +61,13 @@ const std::string GET_MODEL = ADMIN_PATH + "/get_model$";
 const std::string GET_ALL_CONTAINERS = ADMIN_PATH + "/get_all_containers$";
 const std::string GET_CONTAINER = ADMIN_PATH + "/get_container$";
 
-const std::string ADD_APPLICATION_JSON_SCHEMA = R"(
+const std::string APPLICATION_ID_JSON_SCHEMA = R"(
   {
+    "name" := string
+  }
+)";
+
+const std::string ADD_APPLICATION_JSON_SCHEMA = R"(  {
    "name" := string,
    "candidate_model_names" := [string],
    "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
@@ -179,6 +185,25 @@ class RequestHandler {
           } catch (const std::invalid_argument& e) {
             respond_http(e.what(), "400 Bad Request", response);
           }
+        });
+    server_.add_endpoint(
+        DELETE_APPLICATION, "DELETE",
+        [this](std::shared_ptr<HttpServer::Response> response,
+               std::shared_ptr<HttpServer::Request> request) {
+            try {
+              std::string result = delete_application(request->content.string());
+              respond_http(result, "200 OK", response);
+            } catch (const json_parse_error& e) {
+              std::string err_msg =
+                      json_error_msg(e.what(), APPLICATION_ID_JSON_SCHEMA);
+              respond_http(err_msg, "400 Bad Request", response);
+            } catch (const json_semantic_error& e) {
+              std::string err_msg =
+                      json_error_msg(e.what(), APPLICATION_ID_JSON_SCHEMA);
+              respond_http(err_msg, "400 Bad Request", response);
+            } catch (const std::invalid_argument& e) {
+              respond_http(e.what(), "400 Bad Request", response);
+            }
         });
     server_.add_endpoint(
         ADD_MODEL, "POST",
@@ -436,6 +461,27 @@ class RequestHandler {
       std::stringstream ss;
       ss << "Error application " << app_name << " already exists";
       throw std::invalid_argument(ss.str());
+    }
+  }
+
+  /**
+   * Creates an endpoint that listens for requests to delete existing prediction
+   * applications to Clipper.
+   *
+   * JSON format:
+   * {
+   *  "name" := string
+   * }
+   */
+  std::string delete_application(const std::string& json) {
+    rapidjson::Document d;
+    parse_json(json, d);
+
+    std::string app_name = get_string(d, "name");
+    if (clipper::redis::delete_application(redis_connection_, app_name)) {
+      return "Success!";
+    } else {
+      return "Error deleting application from Redis.";
     }
   }
 

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -190,20 +190,20 @@ class RequestHandler {
         DELETE_APPLICATION, "DELETE",
         [this](std::shared_ptr<HttpServer::Response> response,
                std::shared_ptr<HttpServer::Request> request) {
-            try {
-              std::string result = delete_application(request->content.string());
-              respond_http(result, "200 OK", response);
-            } catch (const json_parse_error& e) {
-              std::string err_msg =
-                      json_error_msg(e.what(), APPLICATION_ID_JSON_SCHEMA);
-              respond_http(err_msg, "400 Bad Request", response);
-            } catch (const json_semantic_error& e) {
-              std::string err_msg =
-                      json_error_msg(e.what(), APPLICATION_ID_JSON_SCHEMA);
-              respond_http(err_msg, "400 Bad Request", response);
-            } catch (const std::invalid_argument& e) {
-              respond_http(e.what(), "400 Bad Request", response);
-            }
+          try {
+            std::string result = delete_application(request->content.string());
+            respond_http(result, "200 OK", response);
+          } catch (const json_parse_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), APPLICATION_ID_JSON_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const json_semantic_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), APPLICATION_ID_JSON_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const std::invalid_argument& e) {
+            respond_http(e.what(), "400 Bad Request", response);
+          }
         });
     server_.add_endpoint(
         ADD_MODEL, "POST",

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -141,16 +141,14 @@ TEST_F(ManagementFrontendTest, TestAddApplicationMalformedJson) {
 
 TEST_F(ManagementFrontendTest, TestDeleteApplicationCorrect) {
   std::string add_app_json = R"(
-    {
-      "name": "myappname",
-      "candidate_models": [
-          {"model_name": "m", "model_version": 4},
-          {"model_name": "image_model", "model_version": 3}],
-      "input_type": "integers",
-      "selection_policy": "sample_policy",
-      "latency_slo_micros": 10000
-    }
-   )";
+  {
+    "name": "myappname",
+    "candidate_model_names": ["image_model"],
+    "input_type": "integers",
+    "default_output": "4.3",
+    "latency_slo_micros": 10000
+  }
+  )";
 
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
 
@@ -170,13 +168,12 @@ TEST_F(ManagementFrontendTest, TestDeleteApplicationCorrect) {
 TEST_F(ManagementFrontendTest, TestDeleteApplicationMalformedJson) {
   std::string delete_app_json = R"(
     {
-      "name": "myappname"
+      "name": myappname"
     }
   )";
 
   ASSERT_THROW(rh_.delete_application(delete_app_json), json_parse_error);
 }
-
 
 TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
   std::string name = "my_app_name";

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -139,6 +139,45 @@ TEST_F(ManagementFrontendTest, TestAddApplicationMalformedJson) {
   ASSERT_THROW(rh_.add_application(add_app_json), json_parse_error);
 }
 
+TEST_F(ManagementFrontendTest, TestDeleteApplicationCorrect) {
+  std::string add_app_json = R"(
+    {
+      "name": "myappname",
+      "candidate_models": [
+          {"model_name": "m", "model_version": 4},
+          {"model_name": "image_model", "model_version": 3}],
+      "input_type": "integers",
+      "selection_policy": "sample_policy",
+      "latency_slo_micros": 10000
+    }
+   )";
+
+  ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
+
+  std::string delete_app_json = R"(
+    {
+      "name": "myappname"
+    }
+  )";
+
+  ASSERT_EQ(rh_.delete_application(delete_app_json), "Success!");
+  auto result = get_application(*redis_, "myappname");
+  // Because the app should not exist in redis, an empty map should be
+  // returned.
+  ASSERT_EQ(result.size(), static_cast<size_t>(0));
+}
+
+TEST_F(ManagementFrontendTest, TestDeleteApplicationMalformedJson) {
+  std::string delete_app_json = R"(
+    {
+      "name": "myappname"
+    }
+  )";
+
+  ASSERT_THROW(rh_.delete_application(delete_app_json), json_parse_error);
+}
+
+
 TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
   std::string name = "my_app_name";
   std::string input_type = "doubles";


### PR DESCRIPTION
https://clipper.atlassian.net/projects/CLIPPER/issues/CLIPPER-126?filter=allopenissues

Endpoint, handler, tests, and management library function added for deleting apps.

We could use a 204 http response instead of a 200 when we successfully delete, but then we wouldn't be able to send a "Success!" message in the response.