### PR TITLE
Remove models_used_ variable from Response

### DIFF
--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -15,7 +15,7 @@ class MockQueryProcessor {
  public:
   MockQueryProcessor() = default;
   boost::future<Response> predict(Query query) {
-    Response response(query, 3, 5, Output(-1.0, {std::make_pair("m", 1)}), {});
+    Response response(query, 3, 5, Output(-1.0, {std::make_pair("m", 1)}));
     return boost::make_ready_future(response);
   }
   boost::future<FeedbackAck> update(FeedbackQuery /*feedback*/) {

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -220,8 +220,7 @@ class Response {
  public:
   ~Response() = default;
 
-  Response(Query query, QueryId query_id, long duration_micros, Output output,
-           std::vector<VersionedModelId> models_used);
+  Response(Query query, QueryId query_id, long duration_micros, Output output);
 
   // default copy constructors
   Response(const Response &) = default;
@@ -237,7 +236,6 @@ class Response {
   QueryId query_id_;
   long duration_micros_;
   Output output_;
-  std::vector<VersionedModelId> models_used_;
 };
 
 class Feedback {

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -264,12 +264,11 @@ Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
       create_time_(std::chrono::high_resolution_clock::now()) {}
 
 Response::Response(Query query, QueryId query_id, long duration_micros,
-                   Output output, std::vector<VersionedModelId> models_used)
+                   Output output)
     : query_(std::move(query)),
       query_id_(query_id),
       duration_micros_(duration_micros),
-      output_(std::move(output)),
-      models_used_(models_used) {}
+      output_(std::move(output)) {}
 
 std::string Response::debug_string() const noexcept {
   std::string debug;

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -132,9 +132,8 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                         "{} is an invalid selection policy",
                         query.selection_policy_);
     // TODO better error handling
-    return boost::make_ready_future(
-        Response{query, query_id, 20000, Output{1.0, {std::make_pair("m1", 1)}},
-                 std::vector<VersionedModelId>()});
+    return boost::make_ready_future(Response{
+        query, query_id, 20000, Output{1.0, {std::make_pair("m1", 1)}}});
   }
   log_info_formatted(LOGGING_TAG_QUERY_PROCESSOR, "Found {} tasks",
                      tasks.size());
@@ -206,8 +205,7 @@ boost::future<Response> QueryProcessor::predict(Query query) {
             end - query.create_time_)
             .count();
 
-    Response response{query, query_id, duration_micros, final_output,
-                      query.candidate_models_};
+    Response response{query, query_id, duration_micros, final_output};
     response_promise.set_value(response);
 
   });


### PR DESCRIPTION
This MR addresses #73, which states that the variable **models_used_** is being used on both **Output** and **Response**.

I have checked for the use of this variable and it seems it is only being used for the **Output** object. Therefore, I have removed the **models_used_** variable from the **Response** class.