### PR TITLE
[CLIPPER-57] Read existing configuration from Redis on startup

### DIFF
--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -63,5 +63,7 @@ set -e
 redis-server --port $REDIS_PORT &> /dev/null &
 
 ./src/libclipper/libclippertests --redis_port $REDIS_PORT
+redis-cli -p $REDIS_PORT "flushall"
 ./src/frontends/frontendtests --redis_port $REDIS_PORT
+redis-cli -p $REDIS_PORT "flushall"
 ./src/management/managementtests --redis_port $REDIS_PORT

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -149,16 +149,14 @@ class RequestHandler {
     // Read from Redis configuration tables and update models/applications
     // (1) Iterate through applications and set up predict/update endpoints.
     for (std::string app_name :
-            clipper::redis::get_all_application_names(redis_connection_)) {
+         clipper::redis::get_all_application_names(redis_connection_)) {
       // Is there a way/need to not repeat these function calls? (from above)
       auto app_info =
           clipper::redis::get_application_by_key(redis_connection_, app_name);
 
       std::vector<std::string> candidate_model_names =
-          clipper::redis::str_to_model_names(
-              app_info["candidate_model_names"]);
-      InputType input_type =
-          clipper::parse_input_type(app_info["input_type"]);
+          clipper::redis::str_to_model_names(app_info["candidate_model_names"]);
+      InputType input_type = clipper::parse_input_type(app_info["input_type"]);
       std::string policy = app_info["policy"];
       int latency_slo_micros = std::stoi(app_info["latency_slo_micros"]);
 
@@ -167,10 +165,9 @@ class RequestHandler {
     }
     // (2) Update current_model_versions_ with (model, version) pairs.
     for (std::string model_name :
-            clipper::redis::get_all_model_names(redis_connection_)) {
-      auto model_version =
-          clipper::redis::get_current_model_version(redis_connection_,
-                                                    model_name);
+         clipper::redis::get_all_model_names(redis_connection_)) {
+      auto model_version = clipper::redis::get_current_model_version(
+          redis_connection_, model_name);
       // Error handle model_version being < 0?
       std::unique_lock<std::mutex> l(current_model_versions_mutex_);
       current_model_versions_[model_name] = model_version;

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -145,6 +145,36 @@ class RequestHandler {
             }
           }
         });
+
+    // Read from Redis configuration tables and update models/applications
+    // (1) Iterate through applications and set up predict/update endpoints.
+    for (std::string app_name :
+            clipper::redis::get_all_application_names(redis_connection_)) {
+      // Is there a way/need to not repeat these function calls? (from above)
+      auto app_info =
+          clipper::redis::get_application_by_key(redis_connection_, app_name);
+
+      std::vector<std::string> candidate_model_names =
+          clipper::redis::str_to_model_names(
+              app_info["candidate_model_names"]);
+      InputType input_type =
+          clipper::parse_input_type(app_info["input_type"]);
+      std::string policy = app_info["policy"];
+      int latency_slo_micros = std::stoi(app_info["latency_slo_micros"]);
+
+      add_application(app_name, candidate_model_names, input_type, policy,
+                      latency_slo_micros);
+    }
+    // (2) Update current_model_versions_ with (model, version) pairs.
+    for (std::string model_name :
+            clipper::redis::get_all_model_names(redis_connection_)) {
+      auto model_version =
+          clipper::redis::get_current_model_version(redis_connection_,
+                                                    model_name);
+      // Error handle model_version being < 0?
+      std::unique_lock<std::mutex> l(current_model_versions_mutex_);
+      current_model_versions_[model_name] = model_version;
+    }
   }
 
   ~RequestHandler() {

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -307,11 +307,13 @@ TEST_F(QueryFrontendTest, TestReadModelsAtStartup) {
 TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {
   std::vector<std::string> labels{"ads", "images", "experimental", "other",
                                   "labels"};
-  VersionedModelId model1 = std::make_pair("m", -10 /* invalid version */);
+  VersionedModelId model1 = std::make_pair("m", 1);
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
                         container_name, model_path));
+  // Not setting the version number will cause get_current_model_version()
+  // to return -1, and the RequestHandler should then throw a runtime_error.
   ASSERT_THROW(RequestHandler<QueryProcessor>("127.0.0.1", 1337, 8),
                std::runtime_error);
 }

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -1,12 +1,14 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <clipper/config.hpp>
 #include <clipper/datatypes.hpp>
 #include <clipper/query_processor.hpp>
 
 #include "query_frontend.hpp"
 
 using namespace clipper;
+using namespace clipper::redis;
 using namespace query_frontend;
 
 namespace {
@@ -32,8 +34,28 @@ class QueryFrontendTest : public ::testing::Test {
  public:
   RequestHandler<MockQueryProcessor> rh_;
   // MockQueryProcessor qp_;
+  std::shared_ptr<redox::Redox> redis_;
+  std::shared_ptr<redox::Subscriber> subscriber_;
 
-  QueryFrontendTest() : rh_("0.0.0.0", 1337, 8) {}
+  QueryFrontendTest()
+      : rh_("0.0.0.0", 1337, 8),
+        redis_(std::make_shared<redox::Redox>()),
+        subscriber_(std::make_shared<redox::Subscriber>()) {
+    Config& conf = get_config();
+    redis_->connect(conf.get_redis_address(), conf.get_redis_port());
+    subscriber_->connect(conf.get_redis_address(), conf.get_redis_port());
+
+    // delete all keys
+    send_cmd_no_reply<std::string>(*redis_, {"FLUSHALL"});
+
+    send_cmd_no_reply<std::string>(
+        *redis_, {"CONFIG", "SET", "notify-keyspace-events", "AKE"});
+  }
+
+  virtual ~QueryFrontendTest() {
+    subscriber_->disconnect();
+    redis_->disconnect();
+  }
 };
 
 TEST_F(QueryFrontendTest, TestDecodeCorrectInputInts) {
@@ -227,6 +249,71 @@ TEST_F(QueryFrontendTest,
         parsed_error_response.FindMember(PREDICTION_ERROR_RESPONSE_KEY_CAUSE)
             ->value.IsString());
   }
+}
+
+TEST_F(QueryFrontendTest, TestReadApplicationsAtStartup) {
+  // Add a few applications
+  std::string name = "my_app_name";
+  std::vector<std::string> model_names{"music_random_features", "simple_svm",
+                                       "music_cnn"};
+  InputType input_type = InputType::Doubles;
+  std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  ASSERT_TRUE(add_application(*redis_, name, model_names, input_type, policy,
+                              default_output, latency_slo_micros));
+  std::string name2 = "my_app_name_2";
+  std::vector<std::string> model_names2{"img_random_features", "simple_svm",
+                                        "img_cnn"};
+  InputType input_type2 = InputType::Doubles;
+  std::string policy2 = "exp4_policy";
+  int latency_slo_micros2 = 50000;
+  std::string default_output2 = "1.0";
+  ASSERT_TRUE(add_application(*redis_, name2, model_names2, input_type2,
+                              policy2, default_output2, latency_slo_micros2));
+
+  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
+  size_t two_apps = rh2_.num_applications();
+  EXPECT_EQ(two_apps, (size_t)2);
+}
+
+TEST_F(QueryFrontendTest, TestReadModelsAtStartup) {
+  // Add multiple models (some with multiple versions)
+  std::vector<std::string> labels{"ads", "images", "experimental", "other",
+                                  "labels"};
+  VersionedModelId model1 = std::make_pair("m", 1);
+  std::string container_name = "clipper/test_container";
+  std::string model_path = "/tmp/models/m/1";
+  ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
+                        container_name, model_path));
+  VersionedModelId model2 = std::make_pair("m", 2);
+  std::string model_path2 = "/tmp/models/m/2";
+  ASSERT_TRUE(add_model(*redis_, model2, InputType::Ints, labels,
+                        container_name, model_path2));
+  VersionedModelId model3 = std::make_pair("n", 3);
+  std::string model_path3 = "/tmp/models/n/3";
+  ASSERT_TRUE(add_model(*redis_, model3, InputType::Ints, labels,
+                        container_name, model_path3));
+
+  // Set m@v2 and n@v3 as current model versions
+  set_current_model_version(*redis_, "m", 2);
+  set_current_model_version(*redis_, "n", 3);
+  std::unordered_map<std::string, int> expected_models = {{"m", 2}, {"n", 3}};
+
+  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
+  EXPECT_EQ(rh2_.get_current_model_versions(), expected_models);
+}
+
+TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {
+  std::vector<std::string> labels{"ads", "images", "experimental", "other",
+                                  "labels"};
+  VersionedModelId model1 = std::make_pair("m", -10 /* invalid version */);
+  std::string container_name = "clipper/test_container";
+  std::string model_path = "/tmp/models/m/1";
+  ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
+                        container_name, model_path));
+  ASSERT_THROW(RequestHandler<QueryProcessor>("127.0.0.1", 1337, 8),
+               std::runtime_error);
 }
 
 }  // namespace

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -159,6 +159,16 @@ std::unordered_map<std::string, std::string> get_model_by_key(
     redox::Redox& redis, const std::string& key);
 
 /**
+ * Looks up model names listed in the model table. Since a call to KEYS may
+ * return multiple version values associated with each model key, this method
+ * de-duplicates the model names before returning.
+ *
+ * \return Returns a vector of model names as strings. If no model names
+ * were found, then an empty vector will be returned.
+ */
+std::vector<std::string> get_all_model_names(redox::Redox& redis);
+
+/**
  * Adds a container into the container table. This will
  * overwrite any existing entry with the same key.
  *
@@ -262,6 +272,14 @@ std::unordered_map<std::string, std::string> get_application(
  */
 std::unordered_map<std::string, std::string> get_application_by_key(
     redox::Redox& redis, const std::string& key);
+
+/**
+ * \return Returns a vector of application names as strings.
+ * The returned application names can subsequently be used as keys in
+ * the application table. If no applications are found in the table,
+ * an empty vector will be returned.
+ */
+std::vector<std::string> get_all_application_names(redox::Redox& redis);
 
 /**
 * Subscribes to changes in the model table. The

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -127,6 +127,31 @@ TEST_F(RedisTest, GetModelVersions) {
   ASSERT_EQ(versions, std::vector<int>({1, 2, 4}));
 }
 
+TEST_F(RedisTest, GetAllModelNames) {
+  // Add multiple models (some with multiple versions)
+  std::vector<std::string> labels{"ads", "images", "experimental", "other",
+                                  "labels"};
+  VersionedModelId model1 = std::make_pair("m", 1);
+  std::string container_name = "clipper/test_container";
+  std::string model_path = "/tmp/models/m/1";
+  ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
+                        container_name, model_path));
+  VersionedModelId model2 = std::make_pair("m", 2);
+  std::string model_path2 = "/tmp/models/m/2";
+  ASSERT_TRUE(add_model(*redis_, model2, InputType::Ints, labels,
+                        container_name, model_path2));
+  VersionedModelId model3 = std::make_pair("n", 3);
+  std::string model_path3 = "/tmp/models/n/3";
+  ASSERT_TRUE(add_model(*redis_, model3, InputType::Ints, labels,
+                        container_name, model_path3));
+
+  // get_all_model_names() should return the de-duplicated model names
+  std::vector<std::string> names = get_all_model_names(*redis_);
+  ASSERT_EQ(names.size(), static_cast<size_t>(2));
+  std::sort(names.begin(), names.end());
+  ASSERT_EQ(names, std::vector<std::string>({"m", "n"}));
+}
+
 TEST_F(RedisTest, DeleteModel) {
   std::vector<std::string> labels{"ads", "images", "experimental"};
   VersionedModelId model = std::make_pair("m", 1);
@@ -210,6 +235,31 @@ TEST_F(RedisTest, DeleteApplication) {
   ASSERT_TRUE(delete_application(*redis_, name));
   auto delete_result = get_application(*redis_, name);
   EXPECT_EQ(delete_result.size(), static_cast<size_t>(0));
+}
+
+TEST_F(RedisTest, GetAllApplicationNames) {
+  // Add a few applications, get should return all of their names.
+  std::string name = "my_app_name";
+  std::vector<std::string> model_names{"music_random_features", "simple_svm",
+                                       "music_cnn"};
+  InputType input_type = InputType::Doubles;
+  std::string policy = "exp3_policy";
+  int latency_slo_micros = 10000;
+  ASSERT_TRUE(add_application(*redis_, name, model_names, input_type, policy,
+                              latency_slo_micros));
+  std::string name2 = "my_app_name_2";
+  std::vector<std::string> model_names2{"img_random_features", "simple_svm",
+                                        "img_cnn"};
+  InputType input_type2 = InputType::Doubles;
+  std::string policy2 = "exp4_policy";
+  int latency_slo_micros2 = 50000;
+  ASSERT_TRUE(add_application(*redis_, name2, model_names2, input_type2, policy2,
+                              latency_slo_micros2));
+
+  std::vector<std::string> app_names = get_all_application_names(*redis_);
+  ASSERT_EQ(app_names.size(), static_cast<size_t>(2));
+  std::sort(app_names.begin(), app_names.end());
+  ASSERT_EQ(app_names, std::vector<std::string>({name, name2}));
 }
 
 TEST_F(RedisTest, SubscriptionDetectModelAdd) {

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -253,8 +253,8 @@ TEST_F(RedisTest, GetAllApplicationNames) {
   InputType input_type2 = InputType::Doubles;
   std::string policy2 = "exp4_policy";
   int latency_slo_micros2 = 50000;
-  ASSERT_TRUE(add_application(*redis_, name2, model_names2, input_type2, policy2,
-                              latency_slo_micros2));
+  ASSERT_TRUE(add_application(*redis_, name2, model_names2, input_type2,
+                              policy2, latency_slo_micros2));
 
   std::vector<std::string> app_names = get_all_application_names(*redis_);
   ASSERT_EQ(app_names.size(), static_cast<size_t>(2));

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -248,17 +248,19 @@ TEST_F(RedisTest, GetAllApplicationNames) {
                                        "music_cnn"};
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   ASSERT_TRUE(add_application(*redis_, name, model_names, input_type, policy,
-                              latency_slo_micros));
+                              default_output, latency_slo_micros));
   std::string name2 = "my_app_name_2";
   std::vector<std::string> model_names2{"img_random_features", "simple_svm",
                                         "img_cnn"};
   InputType input_type2 = InputType::Doubles;
   std::string policy2 = "exp4_policy";
   int latency_slo_micros2 = 50000;
+  std::string default_output2 = "1.0";
   ASSERT_TRUE(add_application(*redis_, name2, model_names2, input_type2,
-                              policy2, latency_slo_micros2));
+                              policy2, default_output2, latency_slo_micros2));
 
   std::vector<std::string> app_names = get_all_application_names(*redis_);
   ASSERT_EQ(app_names.size(), static_cast<size_t>(2));


### PR DESCRIPTION
* Create two functions get_all_model_names() and
  get_all_application_names() which call the KEYS command with a
  wildcard (*) argument on the model and application table
* Update query frontend to (1) add existing applications and
  (2) fill internal state with current model name and versions
  on startup