### PR TITLE
[CLIPPER-117] Application utilities

### DIFF
--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -266,7 +266,8 @@ class Clipper:
             The query latency objective for the application in microseconds.
             Default is 20,000 (20 ms).
         """
-        url = "http://%s:1338/admin/add_app" % self.host
+        url = "http://%s:%d/admin/add_app" % (self.host,
+                                              CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "name": name,
             "candidate_model_names": [model],
@@ -299,7 +300,12 @@ class Clipper:
         req_json = json.dumps({"verbose": verbose})
         headers = {'Content-type': 'application/json'}
         r = requests.get(url, headers=headers, data=req_json)
-        return json.loads(r.text)
+
+        if r.status_code == requests.codes.ok:
+            return r.json()
+        else:
+            print(r.text)
+            return None
 
     def get_app_info(self, name):
         """Gets detailed information about a registered application.
@@ -321,10 +327,15 @@ class Clipper:
         req_json = json.dumps({"name": name})
         headers = {'Content-type': 'application/json'}
         r = requests.get(url, headers=headers, data=req_json)
-        app_info = json.loads(r.text)
-        if len(app_info) == 0:
+
+        if r.status_code == requests.codes.ok:
+            app_info = r.json()
+            if len(app_info) == 0:
+                return None
+            return app_info
+        else:
+            print(r.text)
             return None
-        return app_info
 
     def inspect_selection_policy(self, app_name, uid):
         """Fetches a human-readable string with the current selection policy state.
@@ -346,7 +357,8 @@ class Clipper:
             message from Clipper describing the problem.
         """
 
-        url = "http://%s:1338/admin/get_state" % self.host
+        url = "http://%s:%d/admin/get_state" % (self.host,
+                                                CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "app_name": app_name,
             "uid": uid,
@@ -645,7 +657,7 @@ class Clipper:
             for this instance. On error, the string will be an error message
             (not JSON formatted).
         """
-        url = "http://%s:1337/metrics" % self.host
+        url = "http://%s:%d/metrics" % (self.host, CLIPPER_QUERY_PORT)
         r = requests.get(url)
         try:
             s = r.json()
@@ -673,7 +685,8 @@ class Clipper:
             selected model version.
 
         """
-        url = "http://%s:1338/admin/set_model_version" % self.host
+        url = "http://%s:%d/admin/set_model_version" % (
+            self.host, CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "model_name": model_name,
             "model_version": model_version
@@ -711,7 +724,8 @@ class Clipper:
 
     def _publish_new_model(self, name, version, labels, input_type,
                            container_name, model_data_path):
-        url = "http://%s:1338/admin/add_model" % self.host
+        url = "http://%s:%d/admin/add_model" % (self.host,
+                                                CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "model_name": name,
             "model_version": version,

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -278,22 +278,24 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         print(r.text)
 
-    def list_apps(self, verbose=False):
-        """List the names of all applications registered with Clipper.
+    def get_all_apps(self, verbose=False):
+        """Gets information about all applications registered with Clipper.
+
+        Parameters
+        ----------
+        verbose : bool
+            If set to False, the returned list contains the apps' names.
+            If set to True, the list contains application info dictionaries.
+            These dictionaries have the same attribute name-value pairs that were
+            provided to `register_application`.
 
         Returns
         -------
         list
             Returns a list of information about all apps registered to Clipper.
-
-            If `verbose` == False, the list contains the apps' names.
-            If `verbose` == True, the list contains application info dictionaries.
-            These dictionaries have the same attribute name-value pairs that were
-            provided to `register_application`.
-
             If no apps are registered with Clipper, an empty list is returned.
         """
-        url = "http://%s:1338/admin/get_applications" % self.host
+        url = "http://%s:1338/admin/get_all_applications$" % self.host
         req_json = json.dumps({"verbose": verbose})
         headers = {'Content-type': 'application/json'}
         r = requests.get(url, headers=headers, data=req_json)
@@ -309,7 +311,7 @@ class Clipper:
 
         Returns
         -------
-        dict or None
+        dict
             Returns a dictionary with the specified application's info. This
             will contain the attribute name-value pairs that were provided to
             `register_application`. If no application with name `name` is

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -44,7 +44,7 @@ DOCKER_COMPOSE_DICT = {
         'mgmt_frontend': {
             'command': ['--redis_ip=redis', '--redis_port=%d' % REDIS_PORT],
             'depends_on': ['redis'],
-            'image': 'd3d4635a07d6',  #'clipper/management_frontend:latest',
+            'image': 'clipper/management_frontend:latest',
             'ports':
             ['%d:%d' % (CLIPPER_MANAGEMENT_PORT, CLIPPER_MANAGEMENT_PORT)]
         },
@@ -52,14 +52,14 @@ DOCKER_COMPOSE_DICT = {
             'command': ['--redis_ip=redis', '--redis_port=%d' % REDIS_PORT],
             'depends_on': ['redis', 'mgmt_frontend'],
             'image':
-            'acfb2112ae4e',  #'clipper/query_frontend:latest',
+            'clipper/query_frontend:latest',
             'ports': [
                 '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                 '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)
             ]
         },
         'redis': {
-            'image': '83638a6d3af2',  #'redis:alpine',
+            'image': 'redis:alpine',
             'ports': ['%d:%d' % (REDIS_PORT, REDIS_PORT)]
         }
     },

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -48,7 +48,7 @@ DOCKER_COMPOSE_DICT = {
         'mgmt_frontend': {
             'command': ['--redis_ip=redis', '--redis_port=%d' % REDIS_PORT],
             'depends_on': ['redis'],
-            'image': 'd3d4635a07d6',  #'clipper/management_frontend:latest',
+            'image': 'clipper/management_frontend:latest',
             'ports':
             ['%d:%d' % (CLIPPER_MANAGEMENT_PORT, CLIPPER_MANAGEMENT_PORT)]
         },
@@ -56,14 +56,14 @@ DOCKER_COMPOSE_DICT = {
             'command': ['--redis_ip=redis', '--redis_port=%d' % REDIS_PORT],
             'depends_on': ['redis', 'mgmt_frontend'],
             'image':
-            'acfb2112ae4e',  #'clipper/query_frontend:latest',
+            'clipper/query_frontend:latest',
             'ports': [
                 '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                 '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)
             ]
         },
         'redis': {
-            'image': '83638a6d3af2',  #'redis:alpine',
+            'image': 'redis:alpine',
             'ports': ['%d:%d' % (REDIS_PORT, REDIS_PORT)]
         }
     },

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -48,7 +48,7 @@ DOCKER_COMPOSE_DICT = {
         'mgmt_frontend': {
             'command': ['--redis_ip=redis', '--redis_port=%d' % REDIS_PORT],
             'depends_on': ['redis'],
-            'image': 'clipper/management_frontend:latest',
+            'image': 'd3d4635a07d6',  #'clipper/management_frontend:latest',
             'ports':
             ['%d:%d' % (CLIPPER_MANAGEMENT_PORT, CLIPPER_MANAGEMENT_PORT)]
         },
@@ -56,14 +56,14 @@ DOCKER_COMPOSE_DICT = {
             'command': ['--redis_ip=redis', '--redis_port=%d' % REDIS_PORT],
             'depends_on': ['redis', 'mgmt_frontend'],
             'image':
-            'clipper/query_frontend:latest',
+            'acfb2112ae4e',  #'clipper/query_frontend:latest',
             'ports': [
                 '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                 '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)
             ]
         },
         'redis': {
-            'image': 'redis:alpine',
+            'image': '83638a6d3af2',  #'redis:alpine',
             'ports': ['%d:%d' % (REDIS_PORT, REDIS_PORT)]
         }
     },
@@ -278,26 +278,26 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         print(r.text)
 
-    def list_apps(self):
+    def list_apps(self, verbose=False):
         """List the names of all applications registered with Clipper.
 
         Returns
         -------
-        str
-            The string describing each registered application. If no
-            applications are found, an empty string is returned.
-        """
-        with hide("output", "running"):
-            result = local(
-                ("redis-cli -h {host} -p 6379 -n {db} keys \"*\"".format(
-                    host=self.host, db=REDIS_APPLICATION_DB_NUM)),
-                capture=True)
+        list
+            Returns a list of information about all apps registered to Clipper.
 
-            if len(result.stdout) > 0:
-                return result.stdout
-            else:
-                print("Clipper has no applications registered")
-                return ""
+            If `verbose` == False, the list contains the apps' names.
+            If `verbose` == True, the list contains application info dictionaries.
+            These dictionaries have the same attribute name-value pairs that were
+            provided to `register_application`.
+
+            If no apps are registered with Clipper, an empty list is returned.
+        """
+        url = "http://%s:1338/admin/get_applications" % self.host
+        req_json = json.dumps({"verbose": verbose})
+        headers = {'Content-type': 'application/json'}
+        r = requests.get(url, headers=headers, data=req_json)
+        return json.loads(r.text)
 
     def get_app_info(self, name):
         """Gets detailed information about a registered application.
@@ -310,25 +310,19 @@ class Clipper:
         Returns
         -------
         dict or None
-            Returns a dict with the application info if found. If the application
-            is not registered, None is returned.
+            Returns a dictionary with the specified application's info. This
+            will contain the attribute name-value pairs that were provided to
+            `register_application`. If no application with name `name` is
+            registered with Clipper, None is returned.
         """
-        with hide("output", "running"):
-            result = local(
-                "redis-cli -h {host} -p 6379 -n {db} hgetall {name}".format(
-                    host=self.host, name=name, db=REDIS_APPLICATION_DB_NUM),
-                capture=True)
-
-            if len(result.stdout) > 0:
-                splits = result.stdout.split("\n")
-                fmt_result = dict([(splits[i], splits[i + 1])
-                                   for i in range(0, len(splits), 2)])
-                pp = pprint.PrettyPrinter(indent=2)
-                pp.pprint(fmt_result)
-                return fmt_result
-            else:
-                warn("Application \"%s\" not found" % name)
-                return None
+        url = "http://%s:1338/admin/get_application" % self.host
+        req_json = json.dumps({"name": name})
+        headers = {'Content-type': 'application/json'}
+        r = requests.get(url, headers=headers, data=req_json)
+        app_info = json.loads(r.text)
+        if len(app_info) == 0:
+            return None
+        return app_info
 
     def inspect_selection_policy(self, app_name, uid):
         """Fetches a human-readable string with the current selection policy state.

--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -35,7 +35,8 @@ target_link_libraries(clipper boost zmqcpp redox pthread rapidjson spdlog)
 export(TARGETS clipper FILE ClipperConfig.cmake)
 
 
-
+# config_test resets the value of the config so it should always
+# be last in the list
 add_executable(libclippertests EXCLUDE_FROM_ALL
     test/test_main.cpp
     test/metrics_test.cpp
@@ -44,13 +45,13 @@ add_executable(libclippertests EXCLUDE_FROM_ALL
     test/input_test.cpp
     test/persistent_state_test.cpp
     test/redis_test.cpp
-    test/config_test.cpp
     test/selection_policies_test.cpp
     test/json_util_test.cpp
     test/logging_test.cpp
     test/future_test.cpp
     test/threadpool_test.cpp
-    test/task_executor_test.cpp )
+    test/task_executor_test.cpp
+    test/config_test.cpp )
 target_link_libraries(libclippertests clipper gtest gmock_main cxxopts)
 add_dependencies(unittests libclippertests)
 

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -1,15 +1,10 @@
 #ifndef CLIPPER_LIB_JSON_UTIL_H
 #define CLIPPER_LIB_JSON_UTIL_H
 
-#include <stdexcept>
-
-#include <boost/algorithm/string.hpp>
-
-#include <unordered_map>
-
 #include <rapidjson/document.h>
-
 #include <clipper/datatypes.hpp>
+#include <stdexcept>
+#include <unordered_map>
 
 using clipper::Input;
 using clipper::InputType;
@@ -131,7 +126,7 @@ std::string to_json_string(rapidjson::Document& d);
  */
 void set_json_doc_from_redis_app_metadata(
     rapidjson::Document& d,
-    std::unordered_map<std::string, std::string>& app_metadata);
+    const std::unordered_map<std::string, std::string>& app_metadata);
 
 }  // namespace json
 }  // namespace clipper

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -45,7 +45,12 @@ rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
                                            const char* key_name,
                                            Type expected_type);
 
-/* Getters with error handling for double, float, long, int, string */
+rapidjson::Value& check_kv_type_is_bool_and_return(rapidjson::Value& d,
+                                                   const char* key_name);
+
+/* Getters with error handling for bool, double, float, long, int, string */
+bool get_bool(rapidjson::Value& d, const char* key_name);
+
 double get_double(rapidjson::Value& d, const char* key_name);
 
 float get_float(rapidjson::Value& d, const char* key_name);
@@ -70,6 +75,8 @@ std::vector<VersionedModelId> get_candidate_models(rapidjson::Value& d,
                                                    const char* key_name);
 
 rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name);
+
+rapidjson::Value& get_array(rapidjson::Value& d, const char* key_name);
 
 void parse_json(const std::string& json_content, rapidjson::Document& d);
 
@@ -108,6 +115,23 @@ void add_object(rapidjson::Document& d, const char* key_name,
                 rapidjson::Document& to_add);
 
 std::string to_json_string(rapidjson::Document& d);
+
+/* Sets `d` to an array with the values in `string_vec` */
+void set_string_array_doc(std::vector<std::string>& string_vec,
+                          rapidjson::Document& d);
+
+/* Sets `d` to an array containing info from `candidate_models_redis_format`*/
+void set_candidate_models_doc(std::string& candidate_models_redis_format,
+                              rapidjson::Document& d);
+
+/* Sets `d` to an object containing reformatted info from `app_info`*/
+void set_app_info_doc(std::unordered_map<std::string, std::string>& app_info,
+                      rapidjson::Document& d);
+
+/* Sets `arr_doc` to an array of objects with info from`app_details` */
+void set_app_info_array_doc(
+    std::vector<std::unordered_map<std::string, std::string>>& app_details,
+    rapidjson::Document& arr_doc);
 
 }  // namespace json
 }  // namespace clipper

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -50,7 +50,11 @@ class json_semantic_error : public std::runtime_error {
 rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
                                            const char* key_name,
                                            Type expected_type);
-
+/**
+ * This method is needed because checking boolean fields requires
+ * matching against multiple types: rapidjson::kFalseType and
+ * rapidjson::kTrueType.
+ */
 rapidjson::Value& check_kv_type_is_bool_and_return(rapidjson::Value& d,
                                                    const char* key_name);
 
@@ -81,8 +85,6 @@ std::vector<VersionedModelId> get_candidate_models(rapidjson::Value& d,
                                                    const char* key_name);
 
 rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name);
-
-rapidjson::Value& get_array(rapidjson::Value& d, const char* key_name);
 
 void parse_json(const std::string& json_content, rapidjson::Document& d);
 
@@ -122,22 +124,14 @@ void add_object(rapidjson::Document& d, const char* key_name,
 
 std::string to_json_string(rapidjson::Document& d);
 
-/* Sets `d` to an array with the values in `string_vec` */
-void set_string_array_doc(std::vector<std::string>& string_vec,
-                          rapidjson::Document& d);
-
-/* Sets `d` to an array containing info from `candidate_models_redis_format`*/
-void set_candidate_models_doc(std::string& candidate_models_redis_format,
-                              rapidjson::Document& d);
-
-/* Sets `d` to an object containing reformatted info from `app_info`*/
-void set_app_info_doc(std::unordered_map<std::string, std::string>& app_info,
-                      rapidjson::Document& d);
-
-/* Sets `arr_doc` to an array of objects with info from`app_details` */
-void set_app_info_array_doc(
-    std::vector<std::unordered_map<std::string, std::string>>& app_details,
-    rapidjson::Document& arr_doc);
+/**
+ * Sets `d` to the publicly-facing representation of a given Clipper app.
+ * App data, provided in `app_metadata`, is assumed to be pulled from redis
+ * and therefore may need to be transformed to comply with desired formatting.
+ */
+void set_json_doc_from_redis_app_metadata(
+    rapidjson::Document& d,
+    std::unordered_map<std::string, std::string>& app_metadata);
 
 }  // namespace json
 }  // namespace clipper

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -3,6 +3,10 @@
 
 #include <stdexcept>
 
+#include <boost/algorithm/string.hpp>
+
+#include <unordered_map>
+
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>
 #include <rapidjson/stringbuffer.h>
@@ -45,22 +49,41 @@ class json_semantic_error : public std::runtime_error {
   ~json_semantic_error() throw(){};
 };
 
-/* Check for matching types else throw exception */
-rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
-                                           const char* key_name,
-                                           Type expected_type) {
+void check_document_is_object_and_key_exists(rapidjson::Value& d,
+                                             const char* key_name) {
   if (!d.IsObject()) {
     throw json_semantic_error("Can only get key-value pair from an object");
   } else if (!d.HasMember(key_name)) {
     throw json_semantic_error("JSON object does not have required key: " +
                               std::string(key_name));
   }
+}
+
+/* Check for matching types else throw exception */
+rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
+                                           const char* key_name,
+                                           Type expected_type) {
+  check_document_is_object_and_key_exists(d, key_name);
   rapidjson::Value& val = d[key_name];
   if (val.GetType() != expected_type) {
     throw json_semantic_error("Type mismatch! JSON key " +
                               std::string(key_name) + " expected type " +
                               kTypeNames[expected_type] + "but found type " +
                               kTypeNames[val.GetType()]);
+  }
+  return val;
+}
+
+/* Check for matching types else throw exception */
+rapidjson::Value& check_kv_type_is_bool_and_return(rapidjson::Value& d,
+                                                   const char* key_name) {
+  check_document_is_object_and_key_exists(d, key_name);
+  rapidjson::Value& val = d[key_name];
+  if (val.GetType() != rapidjson::kFalseType &&
+      val.GetType() != rapidjson::kTrueType) {
+    throw json_semantic_error(
+        "Type mismatch! JSON key " + std::string(key_name) +
+        " expected type bool but found type " + kTypeNames[val.GetType()]);
   }
   return val;
 }
@@ -114,6 +137,15 @@ std::string get_string(rapidjson::Value& d, const char* key_name) {
                               " is not of type string");
   }
   return std::string(v.GetString());
+}
+
+bool get_bool(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& v = check_kv_type_is_bool_and_return(d, key_name);
+  if (!v.IsBool()) {
+    throw json_semantic_error("Input of type " + kTypeNames[v.GetType()] +
+                              " is not of type bool");
+  }
+  return v.GetBool();
 }
 
 /* Getters with error handling for arrays of double, float, int, string */
@@ -212,6 +244,12 @@ rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name) {
   rapidjson::Value& object =
       check_kv_type_and_return(d, key_name, rapidjson::kObjectType);
   return object;
+}
+
+rapidjson::Value& get_array(rapidjson::Value& d, const char* key_name) {
+  rapidjson::Value& array =
+      check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
+  return array;
 }
 
 void parse_json(const std::string& json_content, rapidjson::Document& d) {
@@ -333,6 +371,82 @@ void add_string(rapidjson::Document& d, const char* key_name,
 void add_object(rapidjson::Document& d, const char* key_name,
                 rapidjson::Document& to_add) {
   add_kv_pair(d, key_name, to_add);
+}
+
+/* Sets `d` to an array with the values in `string_vec` */
+void set_string_array_doc(std::vector<std::string>& string_vec,
+                          rapidjson::Document& d) {
+  d.SetArray();
+
+  size_t num_elements = string_vec.size();
+  for (size_t i = 0; i < num_elements; i++) {
+    rapidjson::Value v(rapidjson::StringRef(string_vec.at(i).c_str(),
+                                            string_vec.at(i).length()));
+    d.PushBack(v, d.GetAllocator());
+  }
+}
+
+/* Sets `d` to an array containing info from `candidate_models_redis_format`*/
+void set_candidate_models_doc(std::string& candidate_models_redis_format,
+                              rapidjson::Document& d) {
+  d.SetArray();
+
+  std::vector<std::string> candidate_model_strings;
+  boost::split(candidate_model_strings, candidate_models_redis_format,
+               boost::is_any_of(","));
+
+  std::vector<std::string> candidate_model_components;
+  for (auto candidate_model_str : candidate_model_strings) {
+    boost::split(candidate_model_components, candidate_model_str,
+                 boost::is_any_of(":"));
+    std::string model_name = candidate_model_components[0];
+    int model_version = atoi(candidate_model_components[1].c_str());
+
+    rapidjson::Document candidate_model_doc(&d.GetAllocator());
+    candidate_model_doc.SetObject();
+    clipper::json::add_string(candidate_model_doc, "model_name", model_name);
+    clipper::json::add_int(candidate_model_doc, "model_version", model_version);
+    d.PushBack(candidate_model_doc, d.GetAllocator());
+  }
+}
+
+/* Sets `d` to an object containing reformatted info from `app_info`*/
+void set_app_info_doc(std::unordered_map<std::string, std::string>& app_info,
+                      rapidjson::Document& d) {
+  d.SetObject();
+
+  for (auto item : app_info) {
+    std::string key = item.first;
+    std::string value = item.second;
+    if (key == "name" || key == "input_type" || key == "policy") {
+      if (key == "policy") {
+        // Converts the Redis storage key to the publicly facing label
+        key = "selection_policy";
+      }
+      clipper::json::add_string(d, key.c_str(), value);
+    } else if (key == "latency_slo_micros") {
+      clipper::json::add_int(d, key.c_str(), atoi(value.c_str()));
+    } else {
+      // `item` corresponds to app's candidate_models. Need to convert the
+      // Redis candidate_models storage format to the publicly facing format
+      rapidjson::Document candidate_models_doc(&d.GetAllocator());
+      set_candidate_models_doc(value, candidate_models_doc);
+      clipper::json::add_object(d, "candidate_models", candidate_models_doc);
+    }
+  }
+}
+
+/* Sets `arr_doc` to an array of objects with info from`app_details` */
+void set_app_info_array_doc(
+    std::vector<std::unordered_map<std::string, std::string>>& app_details,
+    rapidjson::Document& arr_doc) {
+  arr_doc.SetArray();
+
+  for (auto app_info : app_details) {
+    rapidjson::Document d(&arr_doc.GetAllocator());
+    set_app_info_doc(app_info, d);
+    arr_doc.PushBack(d, arr_doc.GetAllocator());
+  }
 }
 
 std::string to_json_string(rapidjson::Document& d) {

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -24,7 +24,7 @@ const std::string LOGGING_TAG_REDIS = "REDIS";
 /**
  * Issues a command to Redis and checks return code.
  * \return Returns true if the command was successful.
- */
+*/
 template <class ReplyT>
 bool send_cmd_no_reply(redox::Redox& redis,
                        const std::vector<std::string>& cmd_vec) {
@@ -273,13 +273,13 @@ std::unordered_map<std::string, std::string> get_application_by_key(
     redox::Redox& redis, const std::string& key);
 
 /**
- * Subscribes to changes in the model table. The
- * callback is called with the string key of the model
- * that changed and the Redis event type. The key can
- * be used to look up the new value. The message type identifies
- * what type of change was detected. This allows subscribers
- * to differentiate between adds, updates, and deletes if necessary.
- */
+* Subscribes to changes in the model table. The
+* callback is called with the string key of the model
+* that changed and the Redis event type. The key can
+* be used to look up the new value. The message type identifies
+* what type of change was detected. This allows subscribers
+* to differentiate between adds, updates, and deletes if necessary.
+*/
 void subscribe_to_model_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
@@ -290,7 +290,7 @@ void subscribe_to_model_changes(
  * be used to look up the new value. The message type identifies
  * what type of change was detected. This allows subscribers
  * to differentiate between adds, updates, and deletes if necessary.
- */
+*/
 void subscribe_to_container_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
@@ -302,20 +302,20 @@ void subscribe_to_container_changes(
  * be used to look up the new value. The message type identifies
  * what type of change was detected. This allows subscribers
  * to differentiate between adds, updates, and deletes if necessary.
- */
+*/
 void subscribe_to_application_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
 
 /**
- * Subscribes to changes in model versions.
- *
- * The callback is called with the string key of the model
- * that changed and the Redis event type. The key can
- * be used to look up the new value. The message type identifies
- * what type of change was detected. This allows subscribers
- * to differentiate between adds, updates, and deletes if necessary.
- */
+* Subscribes to changes in model versions.
+*
+* The callback is called with the string key of the model
+* that changed and the Redis event type. The key can
+* be used to look up the new value. The message type identifies
+* what type of change was detected. This allows subscribers
+* to differentiate between adds, updates, and deletes if necessary.
+*/
 void subscribe_to_model_version_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -242,21 +242,6 @@ bool delete_application(redox::Redox& redis, const std::string& appname);
 std::vector<std::string> list_application_names(redox::Redox& redis);
 
 /**
- * Lists the full details of all applications registered with Clipper
- *
- *
- * \return Returns a vector of maps for each application. Each such
- * application map stores attribute name-value pairs as
- * strings. Any parsing of the attribute values from their string
- * format (e.g. to a numerical representation) must be done by the
- * caller of this function. The set of attributes stored for a
- * application can be found in the source for `add_application()`. If
- * no applications were found, an empty vector will be returned.
- */
-std::vector<std::unordered_map<std::string, std::string>>
-list_application_details(redox::Redox& redis);
-
-/**
  * Looks up an application based on its name.
  *
  * \return Returns a map of application attribute name-value pairs as
@@ -323,14 +308,14 @@ void subscribe_to_application_changes(
     std::function<void(const std::string&, const std::string&)> callback);
 
 /**
-* Subscribes to changes in model versions.
-*
-* The callback is called with the string key of the model
-* that changed and the Redis event type. The key can
-* be used to look up the new value. The message type identifies
-* what type of change was detected. This allows subscribers
-* to differentiate between adds, updates, and deletes if necessary.
-*/
+ * Subscribes to changes in model versions.
+ *
+ * The callback is called with the string key of the model
+ * that changed and the Redis event type. The key can
+ * be used to look up the new value. The message type identifies
+ * what type of change was detected. This allows subscribers
+ * to differentiate between adds, updates, and deletes if necessary.
+ */
 void subscribe_to_model_version_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -24,7 +24,7 @@ const std::string LOGGING_TAG_REDIS = "REDIS";
 /**
  * Issues a command to Redis and checks return code.
  * \return Returns true if the command was successful.
-*/
+ */
 template <class ReplyT>
 bool send_cmd_no_reply(redox::Redox& redis,
                        const std::vector<std::string>& cmd_vec) {
@@ -234,6 +234,29 @@ bool add_application(redox::Redox& redis, const std::string& appname,
 bool delete_application(redox::Redox& redis, const std::string& appname);
 
 /**
+ * Lists the names of all applications registered with Clipper.
+ *
+ * \return Returns a vector of application names as strings. If no
+ * applications were found, an empty vector will be returned.
+ */
+std::vector<std::string> list_application_names(redox::Redox& redis);
+
+/**
+ * Lists the full details of all applications registered with Clipper
+ *
+ *
+ * \return Returns a vector of maps for each application. Each such
+ * application map stores attribute name-value pairs as
+ * strings. Any parsing of the attribute values from their string
+ * format (e.g. to a numerical representation) must be done by the
+ * caller of this function. The set of attributes stored for a
+ * application can be found in the source for `add_application()`. If
+ * no applications were found, an empty vector will be returned.
+ */
+std::vector<std::unordered_map<std::string, std::string>>
+list_application_details(redox::Redox& redis);
+
+/**
  * Looks up an application based on its name.
  *
  * \return Returns a map of application attribute name-value pairs as
@@ -265,13 +288,13 @@ std::unordered_map<std::string, std::string> get_application_by_key(
     redox::Redox& redis, const std::string& key);
 
 /**
-* Subscribes to changes in the model table. The
-* callback is called with the string key of the model
-* that changed and the Redis event type. The key can
-* be used to look up the new value. The message type identifies
-* what type of change was detected. This allows subscribers
-* to differentiate between adds, updates, and deletes if necessary.
-*/
+ * Subscribes to changes in the model table. The
+ * callback is called with the string key of the model
+ * that changed and the Redis event type. The key can
+ * be used to look up the new value. The message type identifies
+ * what type of change was detected. This allows subscribers
+ * to differentiate between adds, updates, and deletes if necessary.
+ */
 void subscribe_to_model_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
@@ -282,7 +305,7 @@ void subscribe_to_model_changes(
  * be used to look up the new value. The message type identifies
  * what type of change was detected. This allows subscribers
  * to differentiate between adds, updates, and deletes if necessary.
-*/
+ */
 void subscribe_to_container_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
@@ -294,7 +317,7 @@ void subscribe_to_container_changes(
  * be used to look up the new value. The message type identifies
  * what type of change was detected. This allows subscribers
  * to differentiate between adds, updates, and deletes if necessary.
-*/
+ */
 void subscribe_to_application_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -24,7 +24,7 @@ const std::string LOGGING_TAG_REDIS = "REDIS";
 /**
  * Issues a command to Redis and checks return code.
  * \return Returns true if the command was successful.
-*/
+ */
 template <class ReplyT>
 bool send_cmd_no_reply(redox::Redox& redis,
                        const std::vector<std::string>& cmd_vec) {
@@ -212,6 +212,29 @@ bool add_application(redox::Redox& redis, const std::string& appname,
 bool delete_application(redox::Redox& redis, const std::string& appname);
 
 /**
+ * Lists the names of all applications registered with Clipper.
+ *
+ * \return Returns a vector of application names as strings. If no
+ * applications were found, an empty vector will be returned.
+ */
+std::vector<std::string> list_application_names(redox::Redox& redis);
+
+/**
+ * Lists the full details of all applications registered with Clipper
+ *
+ *
+ * \return Returns a vector of maps for each application. Each such
+ * application map stores attribute name-value pairs as
+ * strings. Any parsing of the attribute values from their string
+ * format (e.g. to a numerical representation) must be done by the
+ * caller of this function. The set of attributes stored for a
+ * application can be found in the source for `add_application()`. If
+ * no applications were found, an empty vector will be returned.
+ */
+std::vector<std::unordered_map<std::string, std::string>>
+list_application_details(redox::Redox& redis);
+
+/**
  * Looks up an application based on its name.
  *
  * \return Returns a map of application attribute name-value pairs as
@@ -243,13 +266,13 @@ std::unordered_map<std::string, std::string> get_application_by_key(
     redox::Redox& redis, const std::string& key);
 
 /**
-* Subscribes to changes in the model table. The
-* callback is called with the string key of the model
-* that changed and the Redis event type. The key can
-* be used to look up the new value. The message type identifies
-* what type of change was detected. This allows subscribers
-* to differentiate between adds, updates, and deletes if necessary.
-*/
+ * Subscribes to changes in the model table. The
+ * callback is called with the string key of the model
+ * that changed and the Redis event type. The key can
+ * be used to look up the new value. The message type identifies
+ * what type of change was detected. This allows subscribers
+ * to differentiate between adds, updates, and deletes if necessary.
+ */
 void subscribe_to_model_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
@@ -260,7 +283,7 @@ void subscribe_to_model_changes(
  * be used to look up the new value. The message type identifies
  * what type of change was detected. This allows subscribers
  * to differentiate between adds, updates, and deletes if necessary.
-*/
+ */
 void subscribe_to_container_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
@@ -272,7 +295,7 @@ void subscribe_to_container_changes(
  * be used to look up the new value. The message type identifies
  * what type of change was detected. This allows subscribers
  * to differentiate between adds, updates, and deletes if necessary.
-*/
+ */
 void subscribe_to_application_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);

--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -408,8 +408,8 @@ void add_app_candidate_model_names_from_redis(
   candidate_model_names_doc.SetArray();
   for (auto model_name : model_names) {
     rapidjson::Value string_val(
-            rapidjson::StringRef(model_name.c_str(), model_name.length()),
-            d.GetAllocator());
+        rapidjson::StringRef(model_name.c_str(), model_name.length()),
+        d.GetAllocator());
     candidate_model_names_doc.PushBack(string_val, d.GetAllocator());
   }
 

--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -7,8 +7,8 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
-#include <unordered_map>
 #include <boost/algorithm/string.hpp>
+#include <unordered_map>
 
 #include <clipper/datatypes.hpp>
 #include <clipper/json_util.hpp>
@@ -30,7 +30,7 @@ json_semantic_error::json_semantic_error(const std::string& what)
     : std::runtime_error(what) {}
 json_semantic_error::~json_semantic_error() throw() {}
 
-void _check_document_is_object_and_key_exists(rapidjson::Value& d,
+void check_document_is_object_and_key_exists(rapidjson::Value& d,
                                              const char* key_name) {
   if (!d.IsObject()) {
     throw json_semantic_error("Can only get key-value pair from an object");
@@ -43,7 +43,7 @@ void _check_document_is_object_and_key_exists(rapidjson::Value& d,
 rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
                                            const char* key_name,
                                            Type expected_type) {
-  _check_document_is_object_and_key_exists(d, key_name);
+  check_document_is_object_and_key_exists(d, key_name);
   rapidjson::Value& val = d[key_name];
   if (val.GetType() != expected_type) {
     throw json_semantic_error("Type mismatch! JSON key " +
@@ -56,13 +56,13 @@ rapidjson::Value& check_kv_type_and_return(rapidjson::Value& d,
 
 rapidjson::Value& check_kv_type_is_bool_and_return(rapidjson::Value& d,
                                                    const char* key_name) {
-  _check_document_is_object_and_key_exists(d, key_name);
+  check_document_is_object_and_key_exists(d, key_name);
   rapidjson::Value& val = d[key_name];
   if (val.GetType() != rapidjson::kFalseType &&
       val.GetType() != rapidjson::kTrueType) {
     throw json_semantic_error(
-            "Type mismatch! JSON key " + std::string(key_name) +
-            " expected type bool but found type " + kTypeNames[val.GetType()]);
+        "Type mismatch! JSON key " + std::string(key_name) +
+        " expected type bool but found type " + kTypeNames[val.GetType()]);
   }
   return val;
 }
@@ -226,12 +226,6 @@ rapidjson::Value& get_object(rapidjson::Value& d, const char* key_name) {
   return object;
 }
 
-rapidjson::Value& get_array(rapidjson::Value& d, const char* key_name) {
-  rapidjson::Value& array =
-          check_kv_type_and_return(d, key_name, rapidjson::kArrayType);
-  return array;
-}
-
 void parse_json(const std::string& json_content, rapidjson::Document& d) {
   rapidjson::ParseResult ok = d.Parse(json_content.c_str());
   if (!ok) {
@@ -366,76 +360,76 @@ std::string to_json_string(rapidjson::Document& d) {
   return buffer.GetString();
 }
 
-void set_string_array_doc(std::vector<std::string>& string_vec,
-                          rapidjson::Document& d) {
-  d.SetArray();
-
-  size_t num_elements = string_vec.size();
-  for (size_t i = 0; i < num_elements; i++) {
-    rapidjson::Value v(rapidjson::StringRef(string_vec.at(i).c_str(),
-                                            string_vec.at(i).length()));
-    d.PushBack(v, d.GetAllocator());
+void check_key_exists_in_map(
+    std::string& key, std::unordered_map<std::string, std::string>& map) {
+  if (map.find(key) == map.end()) {
+    throw std::invalid_argument("key `" + key + "` does not exist in map");
   }
 }
 
-void set_candidate_models_doc(std::string& candidate_models_redis_format,
-                              rapidjson::Document& d) {
-  d.SetArray();
-
-  std::vector<std::string> candidate_model_strings;
-  boost::split(candidate_model_strings, candidate_models_redis_format,
-               boost::is_any_of(","));
-
-  std::vector<std::string> candidate_model_components;
-  for (auto candidate_model_str : candidate_model_strings) {
-    boost::split(candidate_model_components, candidate_model_str,
-                 boost::is_any_of(":"));
-    std::string model_name = candidate_model_components[0];
-    int model_version = atoi(candidate_model_components[1].c_str());
-
-    rapidjson::Document candidate_model_doc(&d.GetAllocator());
-    candidate_model_doc.SetObject();
-    clipper::json::add_string(candidate_model_doc, "model_name", model_name);
-    clipper::json::add_int(candidate_model_doc, "model_version", model_version);
-    d.PushBack(candidate_model_doc, d.GetAllocator());
-  }
+void add_app_input_type_from_redis(
+    std::unordered_map<std::string, std::string>& app_metadata,
+    rapidjson::Document& d) {
+  std::string key = "input_type";
+  check_key_exists_in_map(key, app_metadata);
+  add_string(d, key.c_str(), app_metadata[key]);
 }
 
-void set_app_info_doc(std::unordered_map<std::string, std::string>& app_info,
-                      rapidjson::Document& d) {
+void add_app_selection_policy_from_redis(
+    std::unordered_map<std::string, std::string>& app_metadata,
+    rapidjson::Document& d) {
+  // selection_policy is stored under the column `policy` in the app table in
+  // redis
+  std::string redis_selection_policy_key = "policy";
+  check_key_exists_in_map(redis_selection_policy_key, app_metadata);
+  add_string(d, "selection_policy", app_metadata[redis_selection_policy_key]);
+}
+
+void add_app_default_output_from_redis(
+    std::unordered_map<std::string, std::string>& app_metadata,
+    rapidjson::Document& d) {
+  std::string key = "default_output";
+  check_key_exists_in_map(key, app_metadata);
+  add_string(d, key.c_str(), app_metadata[key]);
+}
+
+void add_app_latency_slo_micros_from_redis(
+    std::unordered_map<std::string, std::string>& app_metadata,
+    rapidjson::Document& d) {
+  // latency_slo_micros is stored as a string in redis
+  std::string key = "latency_slo_micros";
+  check_key_exists_in_map(key, app_metadata);
+  add_int(d, key.c_str(), atoi(app_metadata[key].c_str()));
+}
+
+void add_app_candidate_model_names_from_redis(
+    std::unordered_map<std::string, std::string>& app_metadata,
+    rapidjson::Document& d) {
+  std::string key = "candidate_model_names";
+  check_key_exists_in_map(key, app_metadata);
+  // Clipper currently only accepts a single candidate_model_name. It is stored
+  // as a string in redis
+  std::string model_name = app_metadata[key];
+
+  // Our external interface should put this candidate_model_name in an array
+  rapidjson::Document candidate_model_names_doc(&d.GetAllocator());
+  candidate_model_names_doc.SetArray();
+  rapidjson::Value string_val(
+      rapidjson::StringRef(model_name.c_str(), model_name.length()),
+      d.GetAllocator());
+  candidate_model_names_doc.PushBack(string_val, d.GetAllocator());
+  add_object(d, key.c_str(), candidate_model_names_doc);
+}
+
+void set_json_doc_from_redis_app_metadata(
+    rapidjson::Document& d,
+    std::unordered_map<std::string, std::string>& app_metadata) {
   d.SetObject();
-
-  for (auto item : app_info) {
-    std::string key = item.first;
-    std::string value = item.second;
-    if (key == "name" || key == "input_type" || key == "policy") {
-      if (key == "policy") {
-        // Converts the Redis storage key to the publicly facing label
-        key = "selection_policy";
-      }
-      clipper::json::add_string(d, key.c_str(), value);
-    } else if (key == "latency_slo_micros") {
-      clipper::json::add_int(d, key.c_str(), atoi(value.c_str()));
-    } else {
-      // `item` corresponds to app's candidate_models. Need to convert the
-      // Redis candidate_models storage format to the publicly facing format
-      rapidjson::Document candidate_models_doc(&d.GetAllocator());
-      set_candidate_models_doc(value, candidate_models_doc);
-      clipper::json::add_object(d, "candidate_models", candidate_models_doc);
-    }
-  }
-}
-
-void set_app_info_array_doc(
-        std::vector<std::unordered_map<std::string, std::string>>& app_details,
-        rapidjson::Document& arr_doc) {
-  arr_doc.SetArray();
-
-  for (auto app_info : app_details) {
-    rapidjson::Document d(&arr_doc.GetAllocator());
-    set_app_info_doc(app_info, d);
-    arr_doc.PushBack(d, arr_doc.GetAllocator());
-  }
+  add_app_input_type_from_redis(app_metadata, d);
+  add_app_selection_policy_from_redis(app_metadata, d);
+  add_app_default_output_from_redis(app_metadata, d);
+  add_app_latency_slo_micros_from_redis(app_metadata, d);
+  add_app_candidate_model_names_from_redis(app_metadata, d);
 }
 
 }  // namespace json

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -258,13 +258,22 @@ bool add_container(Redox& redis, const VersionedModelId& model_id,
           redis, {"SELECT", std::to_string(REDIS_CONTAINER_DB_NUM)})) {
     std::string replica_key = gen_model_replica_key(model_id, model_replica_id);
     std::string model_id_key = gen_versioned_model_key(model_id);
-    const vector<string> cmd_vec{
-        "HMSET", replica_key, "model_id", model_id_key, "model_name",
-        model_id.first, "model_version", std::to_string(model_id.second),
-        "model_replica_id", std::to_string(model_replica_id),
-        "zmq_connection_id", std::to_string(zmq_connection_id), "batch_size",
-        std::to_string(1), "input_type", get_readable_input_type(input_type)
-    };
+    const vector<string> cmd_vec{"HMSET",
+                                 replica_key,
+                                 "model_id",
+                                 model_id_key,
+                                 "model_name",
+                                 model_id.first,
+                                 "model_version",
+                                 std::to_string(model_id.second),
+                                 "model_replica_id",
+                                 std::to_string(model_replica_id),
+                                 "zmq_connection_id",
+                                 std::to_string(zmq_connection_id),
+                                 "batch_size",
+                                 std::to_string(1),
+                                 "input_type",
+                                 get_readable_input_type(input_type)};
     return send_cmd_no_reply<string>(redis, cmd_vec);
   } else {
     return false;

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -36,17 +36,6 @@ std::unordered_map<string, string> parse_redis_map(
   return parsed_map;
 }
 
-std::vector<string> parse_redis_vector(
-        const std::vector<string>& redis_data) {
-  return redis_data;
-  std::vector<string> parsed_vector;
-  for (auto m = redis_data.begin(); m != redis_data.end(); ++m) {
-    auto key = *m;
-    parsed_vector.push_back(key);
-  }
-  return parsed_vector;
-}
-
 std::string gen_model_replica_key(const VersionedModelId& key,
                                   int model_replica_id) {
   std::stringstream ss;
@@ -371,26 +360,10 @@ std::vector<std::string> list_application_names(Redox& redis) {
       application_names_data = *result;
     }
 
-    return parse_redis_vector(application_names_data);
+    return application_names_data;
   } else {
     return std::vector<std::string>{};
   }
-}
-
-std::vector<std::unordered_map<std::string, std::string>>
-list_application_details(redox::Redox& redis) {
-  std::vector<std::unordered_map<std::string, std::string>> application_details;
-  std::vector<std::string> application_names = list_application_names(redis);
-  if (application_names.size() == 0) {
-    return std::vector<std::unordered_map<std::string, std::string>>{};
-  }
-  for (const string& appname : application_names) {
-    std::unordered_map<std::string, std::string> app_info =
-        get_application(redis, appname);
-    app_info["name"] = appname;
-    application_details.push_back(app_info);
-  }
-  return application_details;
 }
 
 std::unordered_map<std::string, std::string> get_application(

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -34,6 +34,17 @@ std::unordered_map<string, string> parse_redis_map(
   return parsed_map;
 }
 
+std::vector<string> parse_redis_vector(
+        const std::vector<string>& redis_data) {
+  return redis_data;
+  std::vector<string> parsed_vector;
+  for (auto m = redis_data.begin(); m != redis_data.end(); ++m) {
+    auto key = *m;
+    parsed_vector.push_back(key);
+  }
+  return parsed_vector;
+}
+
 std::string gen_model_replica_key(const VersionedModelId& key,
                                   int model_replica_id) {
   std::stringstream ss;
@@ -204,7 +215,6 @@ bool add_container(Redox& redis, const VersionedModelId& model_id,
         "model_replica_id", std::to_string(model_replica_id),
         "zmq_connection_id", std::to_string(zmq_connection_id), "batch_size",
         std::to_string(1), "input_type", get_readable_input_type(input_type)
-
     };
     return send_cmd_no_reply<string>(redis, cmd_vec);
   } else {
@@ -285,6 +295,39 @@ bool delete_application(redox::Redox& redis, const std::string& appname) {
   } else {
     return false;
   }
+}
+
+std::vector<std::string> list_application_names(Redox& redis) {
+  if (send_cmd_no_reply<string>(
+          redis, {"SELECT", std::to_string(REDIS_APPLICATION_DB_NUM)})) {
+    const vector<string> cmd_vec{"KEYS", "*"};
+
+    std::vector<std::string> application_names_data;
+    auto result = send_cmd_with_reply<std::vector<std::string>>(redis, cmd_vec);
+    if (result) {
+      application_names_data = *result;
+    }
+
+    return parse_redis_vector(application_names_data);
+  } else {
+    return std::vector<std::string>{};
+  }
+}
+
+std::vector<std::unordered_map<std::string, std::string>>
+list_application_details(redox::Redox& redis) {
+  std::vector<std::unordered_map<std::string, std::string>> application_details;
+  std::vector<std::string> application_names = list_application_names(redis);
+  if (application_names.size() == 0) {
+    return std::vector<std::unordered_map<std::string, std::string>>{};
+  }
+  for (const string& appname : application_names) {
+    std::unordered_map<std::string, std::string> app_info =
+        get_application(redis, appname);
+    app_info["name"] = appname;
+    application_details.push_back(app_info);
+  }
+  return application_details;
 }
 
 std::unordered_map<std::string, std::string> get_application(

--- a/src/libclipper/test/json_util_test.cpp
+++ b/src/libclipper/test/json_util_test.cpp
@@ -1,9 +1,13 @@
 #include <gtest/gtest.h>
-
+#include <clipper/config.hpp>
 #include <clipper/datatypes.hpp>
 #include <clipper/json_util.hpp>
+#include <clipper/redis.hpp>
+#include <clipper/selection_policies.hpp>
 
+using namespace clipper;
 using namespace clipper::json;
+using namespace clipper::redis;
 
 /* Test JSON serialization utilities
  * Note:
@@ -221,59 +225,42 @@ TEST(JsonUtilTests, TestParseNestedObject) {
   EXPECT_EQ(get_double(twice_nested_object, "double_val"), double_val);
 }
 
-TEST(JsonUtilTests, TestSetJsonDocFromRedisAppMetadata) {
+class SetJsonDocTest : public ::testing::Test {
+ public:
+  SetJsonDocTest() : redis_(std::make_shared<redox::Redox>()) {
+    Config& conf = get_config();
+    redis_->connect(conf.get_redis_address(), conf.get_redis_port());
+
+    // delete all keys
+    send_cmd_no_reply<std::string>(*redis_, {"FLUSHALL"});
+  }
+
+  virtual ~SetJsonDocTest() { redis_->disconnect(); }
+
+  std::shared_ptr<redox::Redox> redis_;
+};
+
+TEST_F(SetJsonDocTest, TestSetJsonDocFromRedisAppMetadata) {
   // Application data in redis storage format
-  std::string input_type_redis_format = "doubles";
-  std::string selection_policy_redis_format = "my_selection_policy";
-  std::string default_output_redis_format = "1.0";
-  std::string latency_slo_micros_redis_format = "10000";
-  // For now, we only support adding one candidate model
-  std::string candidate_model_names_redis_format = "music_random_features";
+  std::string input_type = "doubles";
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
+  std::vector<std::string> candidate_model_names =
+      std::vector<std::string>{"m", "k"};
 
-  // Application data in desired externally-facing format
-  std::string input_type_public_format = "doubles";
-  std::string selection_policy_public_format = "my_selection_policy";
-  std::string default_output_public_format = "1.0";
-  int latency_slo_micros_public_format = 10000;
-  std::vector<std::string> candidate_model_names_public_format{
-      "music_random_features"};
-
-  // Field keys in redis storage format
-  std::string input_type_key_redis_format = "input_type";
-  std::string selection_policy_key_redis_format = "policy";
-  std::string default_output_key_redis_format = "default_output";
-  std::string latency_slo_micros_key_redis_format = "latency_slo_micros";
-  std::string candidate_model_names_key_redis_format = "candidate_model_names";
-
-  // Field keys in externally-facing format
-  std::string input_type_key_public_format = "input_type";
-  std::string selection_policy_key_public_format = "selection_policy";
-  std::string default_output_key_public_format = "default_output";
-  std::string latency_slo_micros_key_public_format = "latency_slo_micros";
-  std::string candidate_model_names_key_public_format = "candidate_model_names";
-
+  add_application(*redis_, "myappname", candidate_model_names,
+                  parse_input_type(input_type), selection_policy,
+                  default_output, latency_slo_micros);
   std::unordered_map<std::string, std::string> app_metadata =
-      std::unordered_map<std::string, std::string>{
-          {input_type_key_redis_format, input_type_redis_format},
-          {selection_policy_key_redis_format, selection_policy_redis_format},
-          {default_output_key_redis_format, default_output_redis_format},
-          {latency_slo_micros_key_redis_format,
-           latency_slo_micros_redis_format},
-          {candidate_model_names_key_redis_format,
-           candidate_model_names_redis_format}};
+      get_application(*redis_, "myappname");
 
   rapidjson::Document d;
   set_json_doc_from_redis_app_metadata(d, app_metadata);
 
-  EXPECT_EQ(get_string(d, input_type_key_public_format.c_str()),
-            input_type_public_format);
-  EXPECT_EQ(get_string(d, selection_policy_key_public_format.c_str()),
-            selection_policy_public_format);
-  EXPECT_EQ(get_string(d, default_output_key_public_format.c_str()),
-            default_output_public_format);
-  EXPECT_EQ(get_int(d, latency_slo_micros_key_public_format.c_str()),
-            latency_slo_micros_public_format);
-  EXPECT_EQ(
-      get_string_array(d, candidate_model_names_key_public_format.c_str()),
-      candidate_model_names_public_format);
+  EXPECT_EQ(get_string(d, "input_type"), input_type);
+  EXPECT_EQ(get_string(d, "default_output"), default_output);
+  EXPECT_EQ(get_int(d, "latency_slo_micros"), latency_slo_micros);
+  EXPECT_EQ(get_string_array(d, "candidate_model_names"),
+            candidate_model_names);
 }

--- a/src/libclipper/test/json_util_test.cpp
+++ b/src/libclipper/test/json_util_test.cpp
@@ -220,3 +220,60 @@ TEST(JsonUtilTests, TestParseNestedObject) {
       get_object(nested_object, "twice_nested_object");
   EXPECT_EQ(get_double(twice_nested_object, "double_val"), double_val);
 }
+
+TEST(JsonUtilTests, TestSetJsonDocFromRedisAppMetadata) {
+  // Application data in redis storage format
+  std::string input_type_redis_format = "doubles";
+  std::string selection_policy_redis_format = "my_selection_policy";
+  std::string default_output_redis_format = "1.0";
+  std::string latency_slo_micros_redis_format = "10000";
+  // For now, we only support adding one candidate model
+  std::string candidate_model_names_redis_format = "music_random_features";
+
+  // Application data in desired externally-facing format
+  std::string input_type_public_format = "doubles";
+  std::string selection_policy_public_format = "my_selection_policy";
+  std::string default_output_public_format = "1.0";
+  int latency_slo_micros_public_format = 10000;
+  std::vector<std::string> candidate_model_names_public_format{
+      "music_random_features"};
+
+  // Field keys in redis storage format
+  std::string input_type_key_redis_format = "input_type";
+  std::string selection_policy_key_redis_format = "policy";
+  std::string default_output_key_redis_format = "default_output";
+  std::string latency_slo_micros_key_redis_format = "latency_slo_micros";
+  std::string candidate_model_names_key_redis_format = "candidate_model_names";
+
+  // Field keys in externally-facing format
+  std::string input_type_key_public_format = "input_type";
+  std::string selection_policy_key_public_format = "selection_policy";
+  std::string default_output_key_public_format = "default_output";
+  std::string latency_slo_micros_key_public_format = "latency_slo_micros";
+  std::string candidate_model_names_key_public_format = "candidate_model_names";
+
+  std::unordered_map<std::string, std::string> app_metadata =
+      std::unordered_map<std::string, std::string>{
+          {input_type_key_redis_format, input_type_redis_format},
+          {selection_policy_key_redis_format, selection_policy_redis_format},
+          {default_output_key_redis_format, default_output_redis_format},
+          {latency_slo_micros_key_redis_format,
+           latency_slo_micros_redis_format},
+          {candidate_model_names_key_redis_format,
+           candidate_model_names_redis_format}};
+
+  rapidjson::Document d;
+  set_json_doc_from_redis_app_metadata(d, app_metadata);
+
+  EXPECT_EQ(get_string(d, input_type_key_public_format.c_str()),
+            input_type_public_format);
+  EXPECT_EQ(get_string(d, selection_policy_key_public_format.c_str()),
+            selection_policy_public_format);
+  EXPECT_EQ(get_string(d, default_output_key_public_format.c_str()),
+            default_output_public_format);
+  EXPECT_EQ(get_int(d, latency_slo_micros_key_public_format.c_str()),
+            latency_slo_micros_public_format);
+  EXPECT_EQ(
+      get_string_array(d, candidate_model_names_key_public_format.c_str()),
+      candidate_model_names_public_format);
+}

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -296,8 +296,8 @@ TEST_F(RedisTest, SubscriptionDetectModelDelete) {
   subscribe_to_model_changes(
       *subscriber_, [&notification_recv, &notification_mutex, &recv, model](
                         const std::string& key, const std::string& event_type) {
-        log_info_formatted(LOGGING_TAG_REDIS_TEST,
-                           "MODEL CHANGE DETECTED: ", event_type);
+        log_info_formatted(LOGGING_TAG_REDIS_TEST, "MODEL CHANGE DETECTED: ",
+                           event_type);
         ASSERT_TRUE(event_type == "hdel" || event_type == "del");
         std::unique_lock<std::mutex> l(notification_mutex);
         recv = true;
@@ -364,9 +364,9 @@ TEST_F(RedisTest, SubscriptionDetectContainerDelete) {
       *subscriber_,
       [&notification_recv, &notification_mutex, &recv, replica_key](
           const std::string& key, const std::string& event_type) {
-        log_info_formatted(
-            LOGGING_TAG_REDIS_TEST,
-            "CONTAINER DELETED CALLBACK. EVENT TYPE: ", event_type);
+        log_info_formatted(LOGGING_TAG_REDIS_TEST,
+                           "CONTAINER DELETED CALLBACK. EVENT TYPE: ",
+                           event_type);
         ASSERT_TRUE(event_type == "hdel" || event_type == "del");
         std::unique_lock<std::mutex> l(notification_mutex);
         recv = true;

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -216,6 +216,44 @@ TEST_F(RedisTest, DeleteApplication) {
   EXPECT_EQ(delete_result.size(), static_cast<size_t>(0));
 }
 
+TEST_F(RedisTest, ListApplicationNames) {
+  std::string name1 = "my_app_name1";
+  std::string name2 = "my_app_name2";
+  std::vector<std::string> model_names{"music_random_features", "simple_svm",
+                                       "music_cnn"};
+  InputType input_type = InputType::Doubles;
+  std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+
+  ASSERT_TRUE(add_application(*redis_, name1, model_names, input_type, policy,
+                              default_output, latency_slo_micros));
+  ASSERT_TRUE(add_application(*redis_, name2, model_names, input_type, policy,
+                              default_output, latency_slo_micros));
+
+  std::vector<std::string> result = list_application_names(*redis_);
+
+  // Two apps have been registered, so we list_application_names to give us
+  // a vector with 2 entries.
+  ASSERT_EQ(result.size(), static_cast<size_t>(2));
+
+  bool has_name_1 =
+      std::find(result.begin(), result.end(), name1) != result.end();
+  bool has_name_2 =
+      std::find(result.begin(), result.end(), name2) != result.end();
+
+  // Those entries should be the names of the two existing applications.
+  ASSERT_TRUE(has_name_1 && has_name_2);
+}
+
+TEST_F(RedisTest, ListApplicationNamesNoneRegistered) {
+  std::vector<std::string> result = list_application_names(*redis_);
+
+  // No apps have been registered, so we list_application_names to give us
+  // an empty vector
+  ASSERT_EQ(result.size(), static_cast<size_t>(0));
+}
+
 TEST_F(RedisTest, SubscriptionDetectModelAdd) {
   std::vector<std::string> labels{"ads", "images", "experimental"};
   VersionedModelId model = std::make_pair("m", 1);
@@ -258,8 +296,8 @@ TEST_F(RedisTest, SubscriptionDetectModelDelete) {
   subscribe_to_model_changes(
       *subscriber_, [&notification_recv, &notification_mutex, &recv, model](
                         const std::string& key, const std::string& event_type) {
-        log_info_formatted(LOGGING_TAG_REDIS_TEST, "MODEL CHANGE DETECTED: ",
-                           event_type);
+        log_info_formatted(LOGGING_TAG_REDIS_TEST,
+                           "MODEL CHANGE DETECTED: ", event_type);
         ASSERT_TRUE(event_type == "hdel" || event_type == "del");
         std::unique_lock<std::mutex> l(notification_mutex);
         recv = true;
@@ -326,9 +364,9 @@ TEST_F(RedisTest, SubscriptionDetectContainerDelete) {
       *subscriber_,
       [&notification_recv, &notification_mutex, &recv, replica_key](
           const std::string& key, const std::string& event_type) {
-        log_info_formatted(LOGGING_TAG_REDIS_TEST,
-                           "CONTAINER DELETED CALLBACK. EVENT TYPE: ",
-                           event_type);
+        log_info_formatted(
+            LOGGING_TAG_REDIS_TEST,
+            "CONTAINER DELETED CALLBACK. EVENT TYPE: ", event_type);
         ASSERT_TRUE(event_type == "hdel" || event_type == "del");
         std::unique_lock<std::mutex> l(notification_mutex);
         recv = true;

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -7,8 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include <boost/thread.hpp>
 
 #include <redox.hpp>
@@ -52,8 +50,8 @@ const std::string ADD_MODEL = ADMIN_PATH + "/add_model$";
 // const std::string ADD_CONTAINER = ADMIN_PATH + "/add_container$";
 const std::string GET_METRICS = ADMIN_PATH + "/metrics$";
 const std::string GET_SELECTION_STATE = ADMIN_PATH + "/get_state$";
-const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications";
-const std::string GET_APPLICATION = ADMIN_PATH + "/get_application";
+const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications$";
+const std::string GET_APPLICATION = ADMIN_PATH + "/get_application$";
 
 const std::string APPLICATION_JSON_SCHEMA = R"(
   {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -7,10 +7,14 @@
 #include <utility>
 #include <vector>
 
+#include <boost/range/adaptor/map.hpp>
+#include <boost/range/algorithm/copy.hpp>
 #include <boost/thread.hpp>
 
 #include <redox.hpp>
 #include <server_http.hpp>
+
+#include "rapidjson/document.h"
 
 #include <clipper/config.hpp>
 #include <clipper/datatypes.hpp>
@@ -24,6 +28,7 @@
 using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
 using clipper::VersionedModelId;
 using clipper::InputType;
+using clipper::json::get_bool;
 using clipper::json::get_candidate_models;
 using clipper::json::get_int;
 using clipper::json::get_string;
@@ -31,6 +36,10 @@ using clipper::json::get_string_array;
 using clipper::json::json_parse_error;
 using clipper::json::json_semantic_error;
 using clipper::json::parse_json;
+using clipper::json::set_app_info_doc;
+using clipper::json::set_app_info_array_doc;
+using clipper::json::set_string_array_doc;
+using clipper::json::to_json_string;
 
 namespace management {
 
@@ -44,7 +53,8 @@ const std::string SET_MODEL_VERSION = ADMIN_PATH + "/set_model_version$";
 // const std::string ADD_CONTAINER = ADMIN_PATH + "/add_container$";
 const std::string GET_METRICS = ADMIN_PATH + "/metrics$";
 const std::string GET_SELECTION_STATE = ADMIN_PATH + "/get_state$";
-const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications$";
+const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications";
+const std::string GET_APPLICATION = ADMIN_PATH + "/get_application";
 
 const std::string APPLICATION_JSON_SCHEMA = R"(
   {
@@ -53,6 +63,18 @@ const std::string APPLICATION_JSON_SCHEMA = R"(
    "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
    "default_output" := float,
    "latency_slo_micros" := int
+  }
+)";
+
+const std::string GET_APPLICATIONS_REQUESTS_SCHEMA = R"(
+  {
+    "verbose" := bool
+  }
+)";
+
+const std::string GET_APPLICATION_REQUESTS_SCHEMA = R"(
+  {
+    "name" := string
   }
 )";
 
@@ -180,6 +202,39 @@ class RequestHandler {
           } catch (const json_semantic_error& e) {
             std::string err_msg =
                 json_error_msg(e.what(), SET_VERSION_JSON_SCHEMA);
+    server_.add_endpoint(
+        GET_APPLICATIONS, "GET",
+        [this](std::shared_ptr<HttpServer::Response> response,
+               std::shared_ptr<HttpServer::Request> request) {
+          try {
+            std::string result = get_applications(request->content.string());
+            respond_http(result, "200 OK", response);
+          } catch (const json_parse_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), GET_APPLICATIONS_REQUESTS_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const json_semantic_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), GET_APPLICATIONS_REQUESTS_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const std::invalid_argument& e) {
+            respond_http(e.what(), "400 Bad Request", response);
+          }
+        });
+    server_.add_endpoint(
+        GET_APPLICATION, "GET",
+        [this](std::shared_ptr<HttpServer::Response> response,
+               std::shared_ptr<HttpServer::Request> request) {
+          try {
+            std::string result = get_application(request->content.string());
+            respond_http(result, "200 OK", response);
+          } catch (const json_parse_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), GET_APPLICATION_REQUESTS_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const json_semantic_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), GET_APPLICATION_REQUESTS_SCHEMA);
             respond_http(err_msg, "400 Bad Request", response);
           } catch (const std::invalid_argument& e) {
             respond_http(e.what(), "400 Bad Request", response);
@@ -311,6 +366,67 @@ class RequestHandler {
          << " already exists";
       throw std::invalid_argument(ss.str());
     }
+  }
+
+  /**
+   * Creates an endpoint that listens for requests to retrieve info about
+   * registered Clipper applications.
+   *
+   * JSON format:
+   * {
+   *  "verbose" := bool
+   * }
+   *
+   * \return Returns a JSON string that encodes a list with info about
+   * registered apps. If `verbose` == False, the encoded list has all registered
+   * apps' names. Else, the encoded map contains objects with full app
+   * information.
+   *
+   */
+  std::string get_applications(const std::string& json) {
+    rapidjson::Document d;
+    parse_json(json, d);
+
+    bool verbose = get_bool(d, "verbose");
+
+    rapidjson::Document response_doc;
+    if (verbose) {
+      std::vector<std::unordered_map<std::string, std::string>> app_details =
+          clipper::redis::list_application_details(redis_connection_);
+      set_app_info_array_doc(app_details, response_doc);
+    } else {
+      std::vector<std::string> app_names =
+          clipper::redis::list_application_names(redis_connection_);
+      set_string_array_doc(app_names, response_doc);
+    }
+    return to_json_string(response_doc);
+  }
+
+  /**
+   * Creates an endpoint that listens for requests to retrieve info about
+   * a specified Clipper application.
+   *
+   * JSON format:
+   * {
+   *  "name" := string
+   * }
+   *
+   * \return Returns a JSON string encoding a map of the specified application's
+   * attribute name-value pairs.
+   *
+   */
+  std::string get_application(const std::string& json) {
+    rapidjson::Document d;
+    parse_json(json, d);
+
+    std::string app_name = get_string(d, "name");
+    std::unordered_map<std::string, std::string> app_info =
+        clipper::redis::get_application(redis_connection_, app_name);
+    app_info["name"] = app_name;
+
+    rapidjson::Document response_doc;
+    set_app_info_doc(app_info, response_doc);
+    return to_json_string(response_doc);
   }
 
   /**

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -7,8 +7,6 @@
 #include <utility>
 #include <vector>
 
-#include <boost/range/adaptor/map.hpp>
-#include <boost/range/algorithm/copy.hpp>
 #include <boost/thread.hpp>
 
 #include <redox.hpp>
@@ -53,8 +51,8 @@ const std::string SET_MODEL_VERSION = ADMIN_PATH + "/set_model_version$";
 // const std::string ADD_CONTAINER = ADMIN_PATH + "/add_container$";
 const std::string GET_METRICS = ADMIN_PATH + "/metrics$";
 const std::string GET_SELECTION_STATE = ADMIN_PATH + "/get_state$";
-const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications";
-const std::string GET_APPLICATION = ADMIN_PATH + "/get_application";
+const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications$";
+const std::string GET_APPLICATION = ADMIN_PATH + "/get_application$";
 
 const std::string APPLICATION_JSON_SCHEMA = R"(
   {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -26,6 +26,7 @@
 using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
 using clipper::VersionedModelId;
 using clipper::InputType;
+using clipper::json::add_string;
 using clipper::json::get_bool;
 using clipper::json::get_candidate_models;
 using clipper::json::get_int;
@@ -34,9 +35,7 @@ using clipper::json::get_string_array;
 using clipper::json::json_parse_error;
 using clipper::json::json_semantic_error;
 using clipper::json::parse_json;
-using clipper::json::set_app_info_doc;
-using clipper::json::set_app_info_array_doc;
-using clipper::json::set_string_array_doc;
+using clipper::json::set_json_doc_from_redis_app_metadata;
 using clipper::json::to_json_string;
 
 namespace management {
@@ -51,7 +50,7 @@ const std::string SET_MODEL_VERSION = ADMIN_PATH + "/set_model_version$";
 // const std::string ADD_CONTAINER = ADMIN_PATH + "/add_container$";
 const std::string GET_METRICS = ADMIN_PATH + "/metrics$";
 const std::string GET_SELECTION_STATE = ADMIN_PATH + "/get_state$";
-const std::string GET_APPLICATIONS = ADMIN_PATH + "/get_applications$";
+const std::string GET_ALL_APPLICATIONS = ADMIN_PATH + "/get_all_applications$";
 const std::string GET_APPLICATION = ADMIN_PATH + "/get_application$";
 
 const std::string APPLICATION_JSON_SCHEMA = R"(
@@ -64,7 +63,7 @@ const std::string APPLICATION_JSON_SCHEMA = R"(
   }
 )";
 
-const std::string GET_APPLICATIONS_REQUESTS_SCHEMA = R"(
+const std::string GET_ALL_APPLICATIONS_REQUESTS_SCHEMA = R"(
   {
     "verbose" := bool
   }
@@ -199,26 +198,27 @@ class RequestHandler {
             respond_http(err_msg, "400 Bad Request", response);
           } catch (const json_semantic_error& e) {
             std::string err_msg =
-                    json_error_msg(e.what(), SET_VERSION_JSON_SCHEMA);
+                json_error_msg(e.what(), SET_VERSION_JSON_SCHEMA);
             respond_http(err_msg, "400 Bad Request", response);
           } catch (const std::invalid_argument& e) {
             respond_http(e.what(), "400 Bad Request", response);
           }
         });
     server_.add_endpoint(
-        GET_APPLICATIONS, "GET",
+        GET_ALL_APPLICATIONS, "GET",
         [this](std::shared_ptr<HttpServer::Response> response,
                std::shared_ptr<HttpServer::Request> request) {
           try {
-            std::string result = get_applications(request->content.string());
+            std::string result =
+                get_all_applications(request->content.string());
             respond_http(result, "200 OK", response);
           } catch (const json_parse_error& e) {
             std::string err_msg =
-                json_error_msg(e.what(), GET_APPLICATIONS_REQUESTS_SCHEMA);
+                json_error_msg(e.what(), GET_ALL_APPLICATIONS_REQUESTS_SCHEMA);
             respond_http(err_msg, "400 Bad Request", response);
           } catch (const json_semantic_error& e) {
             std::string err_msg =
-                json_error_msg(e.what(), GET_APPLICATIONS_REQUESTS_SCHEMA);
+                json_error_msg(e.what(), GET_ALL_APPLICATIONS_REQUESTS_SCHEMA);
             respond_http(err_msg, "400 Bad Request", response);
           } catch (const std::invalid_argument& e) {
             respond_http(e.what(), "400 Bad Request", response);
@@ -386,21 +386,34 @@ class RequestHandler {
    * information.
    *
    */
-  std::string get_applications(const std::string& json) {
+  std::string get_all_applications(const std::string& json) {
     rapidjson::Document d;
     parse_json(json, d);
 
     bool verbose = get_bool(d, "verbose");
 
+    std::vector<std::string> app_names =
+        clipper::redis::list_application_names(redis_connection_);
+
     rapidjson::Document response_doc;
+    response_doc.SetArray();
+
     if (verbose) {
-      std::vector<std::unordered_map<std::string, std::string>> app_details =
-          clipper::redis::list_application_details(redis_connection_);
-      set_app_info_array_doc(app_details, response_doc);
+      for (const string& app_name : app_names) {
+        std::unordered_map<std::string, std::string> app_metadata =
+            clipper::redis::get_application(redis_connection_, app_name);
+        rapidjson::Document app_doc(&response_doc.GetAllocator());
+        set_json_doc_from_redis_app_metadata(app_doc, app_metadata);
+        /* We need to add each app's name to its returned JSON object. */
+        add_string(app_doc, "name", app_name);
+        response_doc.PushBack(app_doc, response_doc.GetAllocator());
+      }
     } else {
-      std::vector<std::string> app_names =
-          clipper::redis::list_application_names(redis_connection_);
-      set_string_array_doc(app_names, response_doc);
+      for (const string& app_name : app_names) {
+        rapidjson::Value v(
+            rapidjson::StringRef(app_name.c_str(), app_name.length()));
+        response_doc.PushBack(v, response_doc.GetAllocator());
+      }
     }
     return to_json_string(response_doc);
   }
@@ -423,12 +436,20 @@ class RequestHandler {
     parse_json(json, d);
 
     std::string app_name = get_string(d, "name");
-    std::unordered_map<std::string, std::string> app_info =
+    std::unordered_map<std::string, std::string> app_metadata =
         clipper::redis::get_application(redis_connection_, app_name);
-    app_info["name"] = app_name;
 
     rapidjson::Document response_doc;
-    set_app_info_doc(app_info, response_doc);
+    response_doc.SetObject();
+
+    if (app_metadata.size() > 0) {
+      /* We assume that redis::get_application returns an empty map iff no app
+       * exists */
+      /* If an app does exist, we need to add its name to the map. */
+      set_json_doc_from_redis_app_metadata(response_doc, app_metadata);
+      add_string(response_doc, "name", app_name);
+    }
+
     return to_json_string(response_doc);
   }
 

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -43,12 +43,10 @@ class ManagementFrontendTest : public ::testing::Test {
   void set_add_app_request_doc(rapidjson::Document& d, std::string& name,
                                std::vector<std::string>& candidate_model_names,
                                std::string& input_type,
-                               std::string& selection_policy,
                                std::string& default_output,
                                int latency_slo_micros) {
     d.SetObject();
     add_string(d, "name", name);
-    add_string(d, "selection_policy", selection_policy);
     add_string_array(d, "candidate_model_names", candidate_model_names);
     add_string(d, "input_type", input_type);
     add_string(d, "default_output", default_output);
@@ -144,7 +142,6 @@ TEST_F(ManagementFrontendTest, TestAddApplicationMalformedJson) {
 TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
   std::string name = "my_app_name";
   std::string input_type = "doubles";
-  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   // For now, we only support adding one candidate model
@@ -152,8 +149,7 @@ TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
 
   rapidjson::Document add_app_json_document;
   set_add_app_request_doc(add_app_json_document, name, candidate_model_names,
-                          input_type, selection_policy, default_output,
-                          latency_slo_micros);
+                          input_type, default_output, latency_slo_micros);
   std::string add_app_json_string = to_json_string(add_app_json_document);
 
   ASSERT_EQ(rh_.add_application(add_app_json_string), "Success!");
@@ -171,10 +167,10 @@ TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
   ASSERT_EQ(add_app_json_document, response_doc);
 }
 
-TEST_F(ManagementFrontendTest, TestGetNonexistantApplicationCorrect) {
+TEST_F(ManagementFrontendTest, TestGetNonexistentApplicationCorrect) {
   std::string list_apps_json = R"(
   {
-    "name": "nonexistant_app"
+    "name": "nonexistent_app"
   }
   )";
   std::string json_response = rh_.get_application(list_apps_json);
@@ -195,7 +191,6 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsVerboseCorrect) {
   std::string name1 = "my_app_name1";
   std::string name2 = "my_app_name2";
   std::string input_type = "doubles";
-  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   // For now, we only support adding one candidate model
@@ -203,14 +198,12 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsVerboseCorrect) {
 
   rapidjson::Document add_app1_json_document;
   set_add_app_request_doc(add_app1_json_document, name1, candidate_model_names,
-                          input_type, selection_policy, default_output,
-                          latency_slo_micros);
+                          input_type, default_output, latency_slo_micros);
   std::string add_app1_json_string = to_json_string(add_app1_json_document);
 
   rapidjson::Document add_app2_json_document;
   set_add_app_request_doc(add_app2_json_document, name2, candidate_model_names,
-                          input_type, selection_policy, default_output,
-                          latency_slo_micros);
+                          input_type, default_output, latency_slo_micros);
   std::string add_app2_json_string = to_json_string(add_app2_json_document);
 
   ASSERT_EQ(rh_.add_application(add_app1_json_string), "Success!");
@@ -274,7 +267,6 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsNotVerboseCorrect) {
   std::string name1 = "my_app_name1";
   std::string name2 = "my_app_name2";
   std::string input_type = "doubles";
-  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   // For now, we only support adding one candidate model
@@ -282,14 +274,12 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsNotVerboseCorrect) {
 
   rapidjson::Document add_app1_json_document;
   set_add_app_request_doc(add_app1_json_document, name1, candidate_model_names,
-                          input_type, selection_policy, default_output,
-                          latency_slo_micros);
+                          input_type, default_output, latency_slo_micros);
   std::string add_app1_json_string = to_json_string(add_app1_json_document);
 
   rapidjson::Document add_app2_json_document;
   set_add_app_request_doc(add_app2_json_document, name2, candidate_model_names,
-                          input_type, selection_policy, default_output,
-                          latency_slo_micros);
+                          input_type, default_output, latency_slo_micros);
   std::string add_app2_json_string = to_json_string(add_app2_json_document);
 
   ASSERT_EQ(rh_.add_application(add_app1_json_string), "Success!");

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -13,6 +13,7 @@
 
 using namespace clipper;
 using namespace clipper::redis;
+using namespace clipper::json;
 using namespace management;
 
 namespace {
@@ -38,6 +39,29 @@ class ManagementFrontendTest : public ::testing::Test {
     subscriber_->disconnect();
     redis_->disconnect();
   }
+
+  void set_add_app_request_doc(rapidjson::Document& d, std::string& name,
+                               std::vector<std::string>& candidate_model_names,
+                               std::string& input_type,
+                               std::string& selection_policy,
+                               std::string& default_output,
+                               int latency_slo_micros) {
+    d.SetObject();
+    add_string(d, "name", name);
+    add_string(d, "selection_policy", selection_policy);
+    add_string_array(d, "candidate_model_names", candidate_model_names);
+    add_string(d, "input_type", input_type);
+    add_string(d, "default_output", default_output);
+    add_int(d, "latency_slo_micros", latency_slo_micros);
+  }
+
+  std::string get_app_json_request_string(std::string& name) {
+    rapidjson::Document d;
+    d.SetObject();
+    add_string(d, "name", name);
+    return to_json_string(d);
+  }
+
   RequestHandler rh_;
   std::shared_ptr<redox::Redox> redis_;
   std::shared_ptr<redox::Subscriber> subscriber_;
@@ -118,37 +142,44 @@ TEST_F(ManagementFrontendTest, TestAddApplicationMalformedJson) {
 }
 
 TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
-  std::string add_app_json = R"(
-  {
-    "name": "myappname",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
+  std::string name = "my_app_name";
+  std::string input_type = "doubles";
+  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  // For now, we only support adding one candidate model
+  std::vector<std::string> candidate_model_names{"music_random_features"};
 
-  std::string list_apps_json = R"(
-  {
-    "name": "myappname"
-  }
-  )";
-  std::string json_response = rh_.get_application(list_apps_json);
+  rapidjson::Document add_app_json_document;
+  set_add_app_request_doc(add_app_json_document, name, candidate_model_names,
+                          input_type, selection_policy, default_output,
+                          latency_slo_micros);
+  std::string add_app_json_string = to_json_string(add_app_json_document);
+
+  ASSERT_EQ(rh_.add_application(add_app_json_string), "Success!");
+
+  std::string get_app_json = get_app_json_request_string(name);
+
+  std::string json_response = rh_.get_application(get_app_json);
 
   rapidjson::Document response_doc;
   response_doc.SetObject();
   parse_json(json_response, response_doc);
 
-  rapidjson::Document request_doc;
-  request_doc.SetObject();
-  parse_json(add_app_json, request_doc);
-
   // The JSON provided for adding the app contains the same name-value
   // attribute pairs that should be returned by `get_application`.
-  ASSERT_EQ(request_doc, response_doc);
+  ASSERT_EQ(add_app_json_document, response_doc);
+}
+
+TEST_F(ManagementFrontendTest, TestGetNonexistantApplicationCorrect) {
+  std::string list_apps_json = R"(
+  {
+    "name": "nonexistant_app"
+  }
+  )";
+  std::string json_response = rh_.get_application(list_apps_json);
+  std::string expected_response = "{}";
+  ASSERT_EQ(json_response, expected_response);
 }
 
 TEST_F(ManagementFrontendTest, TestGetApplicationMalformedJson) {
@@ -160,89 +191,30 @@ TEST_F(ManagementFrontendTest, TestGetApplicationMalformedJson) {
   ASSERT_THROW(rh_.get_application(list_apps_json), json_parse_error);
 }
 
-TEST_F(ManagementFrontendTest, TestRedisListApplicationDetailsCorrect) {
-  std::string add_app1_json = R"(
-  {
-    "name": "myappname1",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  std::string add_app2_json = R"(
-  {
-    "name": "myappname2",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
-  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
-  std::unordered_map<std::string, std::string> expected_result_app1 =
-      std::unordered_map<std::string, std::string>{
-          {"latency_slo_micros", "10000"},
-          {"policy", "sample_policy"},
-          {"input_type", "integers"},
-          {"candidate_models", "m:4,image_model:3"},
-          {"name", "myappname1"}};
-  std::unordered_map<std::string, std::string> expected_result_app2 =
-      std::unordered_map<std::string, std::string>{
-          {"latency_slo_micros", "10000"},
-          {"policy", "sample_policy"},
-          {"input_type", "integers"},
-          {"candidate_models", "m:4,image_model:3"},
-          {"name", "myappname2"}};
+TEST_F(ManagementFrontendTest, TestGetAllApplicationsVerboseCorrect) {
+  std::string name1 = "my_app_name1";
+  std::string name2 = "my_app_name2";
+  std::string input_type = "doubles";
+  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  // For now, we only support adding one candidate model
+  std::vector<std::string> candidate_model_names{"music_random_features"};
 
-  std::vector<std::unordered_map<std::string, std::string>> result =
-      list_application_details(*redis_);
+  rapidjson::Document add_app1_json_document;
+  set_add_app_request_doc(add_app1_json_document, name1, candidate_model_names,
+                          input_type, selection_policy, default_output,
+                          latency_slo_micros);
+  std::string add_app1_json_string = to_json_string(add_app1_json_document);
 
-  // The app table has 2 entries, so we list_applications to give us
-  // a vector with 2 entries.
-  ASSERT_EQ(result.size(), static_cast<size_t>(2));
+  rapidjson::Document add_app2_json_document;
+  set_add_app_request_doc(add_app2_json_document, name2, candidate_model_names,
+                          input_type, selection_policy, default_output,
+                          latency_slo_micros);
+  std::string add_app2_json_string = to_json_string(add_app2_json_document);
 
-  bool has_app_1 =
-      (result[0] == expected_result_app1 || result[1] == expected_result_app1);
-  bool has_app_2 =
-      (result[0] == expected_result_app2 || result[1] == expected_result_app2);
-
-  // After registering the two applications, we expect that
-  // `list_application_details` returns a vector with entries
-  // `expected_result_app1` and `expected_result_app2`.
-  ASSERT_TRUE(has_app_1 && has_app_2);
-}
-
-TEST_F(ManagementFrontendTest, TestGetApplicationsVerboseCorrect) {
-  std::string add_app1_json = R"(
-  {
-    "name": "myappname1",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  std::string add_app2_json = R"(
-  {
-    "name": "myappname2",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
-  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app1_json_string), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app2_json_string), "Success!");
 
   std::string get_apps_verbose_json = R"(
   {
@@ -250,7 +222,7 @@ TEST_F(ManagementFrontendTest, TestGetApplicationsVerboseCorrect) {
   }
   )";
 
-  std::string json_response = rh_.get_applications(get_apps_verbose_json);
+  std::string json_response = rh_.get_all_applications(get_apps_verbose_json);
 
   rapidjson::Document response_doc;
   response_doc.SetArray();
@@ -261,95 +233,67 @@ TEST_F(ManagementFrontendTest, TestGetApplicationsVerboseCorrect) {
   rapidjson::Value temp;
 
   // Assign app_1_response_doc and app_2_response_doc to documentes of
-  // apps with names "myappname1", "myappname2", respectively.
-  if (get_string(app2_response_doc, "name") == "myappname1") {
+  // apps with names `name1`, `name2`, respectively.
+  if (get_string(app2_response_doc, "name") == name1) {
     temp = app1_response_doc;
     app1_response_doc = app2_response_doc;
     app2_response_doc = temp;
   }
 
-  // Confirm that the JSON response provided app info that
-  // corresponds to the two registered applications.
-  ASSERT_EQ(get_string(app1_response_doc, "name"), "myappname1");
-  ASSERT_EQ(get_string(app2_response_doc, "name"), "myappname2");
-
-  rapidjson::Document app1_request_doc;
-  app1_request_doc.SetObject();
-  parse_json(add_app1_json, app1_request_doc);
-  ASSERT_EQ(app1_request_doc, app1_response_doc);
-
-  rapidjson::Document app2_request_doc;
-  app2_request_doc.SetObject();
-  parse_json(add_app2_json, app2_request_doc);
-  ASSERT_EQ(app2_request_doc, app2_response_doc);
+  // Confirm that the JSON response provided app metadata that
+  // matches the information provided upon their registration
+  ASSERT_EQ(add_app1_json_document, app1_response_doc);
+  ASSERT_EQ(add_app2_json_document, app2_response_doc);
 }
 
-TEST_F(ManagementFrontendTest, TestRedisListApplicationNamesCorrect) {
-  std::string add_app1_json = R"(
+TEST_F(ManagementFrontendTest,
+       TestGetAllApplicationsVerboseNoneRegisteredCorrect) {
+  std::string get_apps_verbose_json = R"(
   {
-    "name": "myappname1",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
+    "verbose": true
   }
   )";
-  std::string add_app2_json = R"(
-  {
-    "name": "myappname2",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
-  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
-
-  std::vector<std::string> result = list_application_names(*redis_);
-
-  // The app table has 2 entries, so we list_applications to give us
-  // a vector with 2 entries.
-  ASSERT_EQ(result.size(), static_cast<size_t>(2));
-
-  bool has_name_1 =
-      std::find(result.begin(), result.end(), "myappname1") != result.end();
-  bool has_name_2 =
-      std::find(result.begin(), result.end(), "myappname2") != result.end();
-
-  // Those entries should be the names of the two existing applications.
-  ASSERT_TRUE(has_name_1 && has_name_2);
+  std::string json_response = rh_.get_all_applications(get_apps_verbose_json);
+  std::string expected_response = "[]";
+  ASSERT_EQ(json_response, expected_response);
 }
 
-TEST_F(ManagementFrontendTest, TestGetApplicationsCorrect) {
-  std::string add_app1_json = R"(
+TEST_F(ManagementFrontendTest,
+       TestGetAllApplicationsNotVerboseNoneRegisteredCorrect) {
+  std::string get_apps_verbose_json = R"(
   {
-    "name": "myappname1",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
+    "verbose": false
   }
   )";
-  std::string add_app2_json = R"(
-  {
-    "name": "myappname2",
-    "candidate_models": [
-        {"model_name": "m", "model_version": 4},
-        {"model_name": "image_model", "model_version": 3}],
-    "input_type": "integers",
-    "selection_policy": "sample_policy",
-    "latency_slo_micros": 10000
-  }
-  )";
-  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
-  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
+  std::string json_response = rh_.get_all_applications(get_apps_verbose_json);
+  std::string expected_response = "[]";
+  ASSERT_EQ(json_response, expected_response);
+}
+
+TEST_F(ManagementFrontendTest, TestGetAllApplicationsNotVerboseCorrect) {
+  std::string name1 = "my_app_name1";
+  std::string name2 = "my_app_name2";
+  std::string input_type = "doubles";
+  std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  // For now, we only support adding one candidate model
+  std::vector<std::string> candidate_model_names{"music_random_features"};
+
+  rapidjson::Document add_app1_json_document;
+  set_add_app_request_doc(add_app1_json_document, name1, candidate_model_names,
+                          input_type, selection_policy, default_output,
+                          latency_slo_micros);
+  std::string add_app1_json_string = to_json_string(add_app1_json_document);
+
+  rapidjson::Document add_app2_json_document;
+  set_add_app_request_doc(add_app2_json_document, name2, candidate_model_names,
+                          input_type, selection_policy, default_output,
+                          latency_slo_micros);
+  std::string add_app2_json_string = to_json_string(add_app2_json_document);
+
+  ASSERT_EQ(rh_.add_application(add_app1_json_string), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app2_json_string), "Success!");
 
   std::string get_apps_json = R"(
   {
@@ -357,28 +301,28 @@ TEST_F(ManagementFrontendTest, TestGetApplicationsCorrect) {
   }
   )";
 
-  std::string json_response = rh_.get_applications(get_apps_json);
+  std::string json_response = rh_.get_all_applications(get_apps_json);
 
   rapidjson::Document d;
   d.SetArray();
   parse_json(json_response, d);
   std::string el1 = d[0].GetString();
   std::string el2 = d[1].GetString();
-  bool has_name_1 = (el1 == "myappname1" || el2 == "myappname1");
-  bool has_name_2 = (el1 == "myappname2" || el2 == "myappname2");
+  bool has_name_1 = (el1 == name1 || el2 == name1);
+  bool has_name_2 = (el1 == name2 || el2 == name2);
 
   // The JSON response should contain the names of the two apps
   // that were registered.
   ASSERT_TRUE(has_name_1 && has_name_2);
 }
 
-TEST_F(ManagementFrontendTest, TestGetApplicationsMalformedJson) {
+TEST_F(ManagementFrontendTest, TestGetAllApplicationsMalformedJson) {
   std::string get_apps_json = R"(
    {
      "verbose": flalse
    }
    )";
-  ASSERT_THROW(rh_.get_applications(get_apps_json), json_parse_error);
+  ASSERT_THROW(rh_.get_all_applications(get_apps_json), json_parse_error);
 }
 
 TEST_F(ManagementFrontendTest, TestAddModelCorrect) {

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -117,6 +117,270 @@ TEST_F(ManagementFrontendTest, TestAddApplicationMalformedJson) {
   ASSERT_THROW(rh_.add_application(add_app_json), json_parse_error);
 }
 
+TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
+  std::string add_app_json = R"(
+  {
+    "name": "myappname",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
+
+  std::string list_apps_json = R"(
+  {
+    "name": "myappname"
+  }
+  )";
+  std::string json_response = rh_.get_application(list_apps_json);
+
+  rapidjson::Document response_doc;
+  response_doc.SetObject();
+  parse_json(json_response, response_doc);
+
+  rapidjson::Document request_doc;
+  request_doc.SetObject();
+  parse_json(add_app_json, request_doc);
+
+  // The JSON provided for adding the app contains the same name-value
+  // attribute pairs that should be returned by `get_application`.
+  ASSERT_EQ(request_doc, response_doc);
+}
+
+TEST_F(ManagementFrontendTest, TestGetApplicationMalformedJson) {
+  std::string list_apps_json = R"(
+  {
+    "app": not a string
+  }
+  )";
+  ASSERT_THROW(rh_.get_application(list_apps_json), json_parse_error);
+}
+
+TEST_F(ManagementFrontendTest, TestRedisListApplicationDetailsCorrect) {
+  std::string add_app1_json = R"(
+  {
+    "name": "myappname1",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  std::string add_app2_json = R"(
+  {
+    "name": "myappname2",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
+  std::unordered_map<std::string, std::string> expected_result_app1 =
+      std::unordered_map<std::string, std::string>{
+          {"latency_slo_micros", "10000"},
+          {"policy", "sample_policy"},
+          {"input_type", "integers"},
+          {"candidate_models", "m:4,image_model:3"},
+          {"name", "myappname1"}};
+  std::unordered_map<std::string, std::string> expected_result_app2 =
+      std::unordered_map<std::string, std::string>{
+          {"latency_slo_micros", "10000"},
+          {"policy", "sample_policy"},
+          {"input_type", "integers"},
+          {"candidate_models", "m:4,image_model:3"},
+          {"name", "myappname2"}};
+
+  std::vector<std::unordered_map<std::string, std::string>> result =
+      list_application_details(*redis_);
+
+  // The app table has 2 entries, so we list_applications to give us
+  // a vector with 2 entries.
+  ASSERT_EQ(result.size(), static_cast<size_t>(2));
+
+  bool has_app_1 =
+      (result[0] == expected_result_app1 || result[1] == expected_result_app1);
+  bool has_app_2 =
+      (result[0] == expected_result_app2 || result[1] == expected_result_app2);
+
+  // After registering the two applications, we expect that
+  // `list_application_details` returns a vector with entries
+  // `expected_result_app1` and `expected_result_app2`.
+  ASSERT_TRUE(has_app_1 && has_app_2);
+}
+
+TEST_F(ManagementFrontendTest, TestGetApplicationsVerboseCorrect) {
+  std::string add_app1_json = R"(
+  {
+    "name": "myappname1",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  std::string add_app2_json = R"(
+  {
+    "name": "myappname2",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
+
+  std::string get_apps_verbose_json = R"(
+  {
+    "verbose": true
+  }
+  )";
+
+  std::string json_response = rh_.get_applications(get_apps_verbose_json);
+
+  rapidjson::Document response_doc;
+  response_doc.SetArray();
+  parse_json(json_response, response_doc);
+
+  rapidjson::Value app1_response_doc(response_doc[0].GetObject());
+  rapidjson::Value app2_response_doc(response_doc[1].GetObject());
+  rapidjson::Value temp;
+
+  // Assign app_1_response_doc and app_2_response_doc to documentes of
+  // apps with names "myappname1", "myappname2", respectively.
+  if (get_string(app2_response_doc, "name") == "myappname1") {
+    temp = app1_response_doc;
+    app1_response_doc = app2_response_doc;
+    app2_response_doc = temp;
+  }
+
+  // Confirm that the JSON response provided app info that
+  // corresponds to the two registered applications.
+  ASSERT_EQ(get_string(app1_response_doc, "name"), "myappname1");
+  ASSERT_EQ(get_string(app2_response_doc, "name"), "myappname2");
+
+  rapidjson::Document app1_request_doc;
+  app1_request_doc.SetObject();
+  parse_json(add_app1_json, app1_request_doc);
+  ASSERT_EQ(app1_request_doc, app1_response_doc);
+
+  rapidjson::Document app2_request_doc;
+  app2_request_doc.SetObject();
+  parse_json(add_app2_json, app2_request_doc);
+  ASSERT_EQ(app2_request_doc, app2_response_doc);
+}
+
+TEST_F(ManagementFrontendTest, TestRedisListApplicationNamesCorrect) {
+  std::string add_app1_json = R"(
+  {
+    "name": "myappname1",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  std::string add_app2_json = R"(
+  {
+    "name": "myappname2",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
+
+  std::vector<std::string> result = list_application_names(*redis_);
+
+  // The app table has 2 entries, so we list_applications to give us
+  // a vector with 2 entries.
+  ASSERT_EQ(result.size(), static_cast<size_t>(2));
+
+  bool has_name_1 =
+      std::find(result.begin(), result.end(), "myappname1") != result.end();
+  bool has_name_2 =
+      std::find(result.begin(), result.end(), "myappname2") != result.end();
+
+  // Those entries should be the names of the two existing applications.
+  ASSERT_TRUE(has_name_1 && has_name_2);
+}
+
+TEST_F(ManagementFrontendTest, TestGetApplicationsCorrect) {
+  std::string add_app1_json = R"(
+  {
+    "name": "myappname1",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  std::string add_app2_json = R"(
+  {
+    "name": "myappname2",
+    "candidate_models": [
+        {"model_name": "m", "model_version": 4},
+        {"model_name": "image_model", "model_version": 3}],
+    "input_type": "integers",
+    "selection_policy": "sample_policy",
+    "latency_slo_micros": 10000
+  }
+  )";
+  ASSERT_EQ(rh_.add_application(add_app1_json), "Success!");
+  ASSERT_EQ(rh_.add_application(add_app2_json), "Success!");
+
+  std::string get_apps_json = R"(
+  {
+    "verbose": false
+  }
+  )";
+
+  std::string json_response = rh_.get_applications(get_apps_json);
+
+  rapidjson::Document d;
+  d.SetArray();
+  parse_json(json_response, d);
+  std::string el1 = d[0].GetString();
+  std::string el2 = d[1].GetString();
+  bool has_name_1 = (el1 == "myappname1" || el2 == "myappname1");
+  bool has_name_2 = (el1 == "myappname2" || el2 == "myappname2");
+
+  // The JSON response should contain the names of the two apps
+  // that were registered.
+  ASSERT_TRUE(has_name_1 && has_name_2);
+}
+
+TEST_F(ManagementFrontendTest, TestGetApplicationsMalformedJson) {
+  std::string get_apps_json = R"(
+   {
+     "verbose": flalse
+   }
+   )";
+  ASSERT_THROW(rh_.get_applications(get_apps_json), json_parse_error);
+}
+
 TEST_F(ManagementFrontendTest, TestAddModelCorrect) {
   std::string add_model_json = R"(
   {


### PR DESCRIPTION
Replacement for https://github.com/ucbrise/clipper/pull/119.

_Changes since @Corey-Zumar's code review:_ 

Made the recommended changes and:

- Moved function implementations out of json_util.hpp to json_util.cpp
- Renamed relevant function, most notably set_app_info_doc —> set_json_doc_from_redis_app_metadata.
- set_json_doc_from_redis_app_metadata now makes use of several helper functions dedicated to transforming specific fields from their redis format to their publicly facing format
- Updated this transformation for the changed candidate model storage
- moved get_all_applications logic out of redis.cpp. Before, I had a function in redis.cpp iterating and making requests to redis. This seems like the sort of thing that shouldn’t exist in an adapter.
- Added/updated the following tests:

**Management front-end tests**
TestGetApplicationCorrect
TestGetNonexistantApplicationCorrect
TestGetApplicationMalformedJson

TestGetAllApplicationsVerboseCorrect
TestGetAllApplicationsVerboseNoneRegisteredCorrect

TestGetAllApplicationsNotVerboseCorrect
TestGetAllApplicationsNotVerboseNoneRegisteredCorrect

TestGetAllApplicationsMalformedJson

**Redis tests**
ListApplicationNames
ListApplicationNamesNoneRegistered

**JSON util tests**
TestSetJsonDocFromRedisAppMetadata

Running the code formatting script made some changes in the files I touched. I included those changes here but I'm happy to remove them if the previous formatting was intentional.

https://clipper.atlassian.net/browse/CLIPPER-117