### PR TITLE
[CLIPPER-156] Fix segfault in on_container_ready

### DIFF
--- a/bench/bench_init.py
+++ b/bench/bench_init.py
@@ -3,6 +3,7 @@ import os
 import errno
 sys.path.append(os.path.abspath("../management"))
 sys.path.append(os.path.abspath("../examples"))
+sys.path.insert(0, os.path.abspath('../containers/python/'))
 
 import clipper_manager
 from tutorial import cifar_utils


### PR DESCRIPTION
I believe this fixes the problem. After the fix I can't reproduce the segfault and logging indicates that this is catching a problem.

The sys path line in `bench_init.py` is hacky, but it's no more hacky than our existing Python path management.