### PR TITLE
Add options to run unittests separately

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,8 @@ Vagrant.configure("2") do |config|
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     sudo apt-get update
     sudo apt-get upgrade -y
-    sudo apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git
+    sudo apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git openjdk-8-jdk maven python-zmq python-numpy libzmq-jni
+    echo 'export JZMQ_HOME=/usr/lib/x86_64-linux-gnu/jni' >> ~/.bashrc
 
     cd /vagrant
     ./configure

--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -4,6 +4,26 @@ set -e
 set -u
 set -o pipefail
 
+function usage {
+    cat <<EOF
+    usage: run_unittests.sh
+
+    This script is used to run Clipper tests. By default, it will run all possible
+    tests
+
+    Options:
+
+    -a, --all                   Run all tests
+    -l, --libclipper            Run tests only for libclipper folder.
+    -m, --management            Run tests only for management folder.
+    -f, --frontend              Run tests only for frotend folder.
+    -j, --java-container        Run tests only for java container folder.
+    -r, --rpc-container         Run tests only for rpc container folder.
+
+$@
+EOF
+}
+
 function clean_up {
     # Perform program exit housekeeping
     # echo Background jobs: $(jobs -l)
@@ -42,37 +62,94 @@ unset CDPATH
 # the script.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Let the user start this script from anywhere in the filesystem.
-cd $DIR/..
-./configure
-cd debug
-# make all to make sure all the binaries compile
-make -j2 all unittests
-if ! type "redis-server" &> /dev/null; then
-    echo -e "\nERROR:"
-    echo -e "\tUnit tests require Redis. Please install redis-server"
-    echo -e "\tand make sure it's on your PATH.\n"
-    exit 1
+function set_test_environment {
+  # Let the user start this script from anywhere in the filesystem.
+  cd $DIR/..
+  ./configure
+  cd debug
+  # make all to make sure all the binaries compile
+  make -j2 all unittests
+  if ! type "redis-server" &> /dev/null; then
+      echo -e "\nERROR:"
+      echo -e "\tUnit tests require Redis. Please install redis-server"
+      echo -e "\tand make sure it's on your PATH.\n"
+      exit 1
+  fi
+
+  randomize_redis_port
+
+  # start Redis on the test port if it's not already running
+  redis-server --port $REDIS_PORT &> /dev/null &
+}
+
+function run_java_container_tests {
+  echo "Running Java container tests..."
+  cd $DIR
+  cd ../containers/java/clipper-java-container
+  mvn test
+}
+
+function run_rpc_container_tests {
+  echo "Testing container RPC protocol correctness..."
+  cd $DIR
+  cd ../containers/test/
+  ./test_container_rpc.sh $REDIS_PORT
+}
+
+function run_libclipper_tests {
+  echo -e "\nRunning libclipper tests\n\n"
+  ./src/libclipper/libclippertests --redis_port $REDIS_PORT
+}
+
+function run_management_tests {
+  echo -e "\nRunning management tests\n\n"
+  ./src/management/managementtests --redis_port $REDIS_PORT
+}
+
+function run_frontend_tests {
+  echo -e "\nRunning frontend tests\n\n"
+  ./src/frontends/frontendtests --redis_port $REDIS_PORT
+}
+
+function run_all_tests {
+  run_management_tests
+  redis-cli -p $REDIS_PORT "flushall"
+  run_libclipper_tests
+  redis-cli -p $REDIS_PORT "flushall"
+  run_frontend_tests
+  redis-cli -p $REDIS_PORT "flushall"
+  run_java_container_tests
+  redis-cli -p $REDIS_PORT "flushall"
+  run_rpc_container_tests
+}
+
+if [ "$#" == 0 ]
+then
+  args="--all"
+else
+  args=$1
 fi
 
-randomize_redis_port
-
-set -e
-
-# start Redis on the test port if it's not already running
-redis-server --port $REDIS_PORT &> /dev/null &
-
-./src/libclipper/libclippertests --redis_port $REDIS_PORT
-redis-cli -p $REDIS_PORT "flushall"
-./src/frontends/frontendtests --redis_port $REDIS_PORT
-redis-cli -p $REDIS_PORT "flushall"
-./src/management/managementtests --redis_port $REDIS_PORT
-
-echo "Running Java container tests..."
-cd $DIR
-cd ../containers/java/clipper-java-container
-mvn test
-
-echo "Testing container RPC protocol correctness..."
-cd ../../test/
-./test_container_rpc.sh $REDIS_PORT
+case $args in
+    -a | --all )            set_test_environment
+                            run_all_tests
+                            ;;
+    -l | --libclipper )     set_test_environment
+                            run_libclipper_tests
+                            ;;
+    -m | --management )     set_test_environment
+                            run_management_tests
+                            ;;
+    -f | --frontend )       set_test_environment
+                            run_frontend_tests
+                            ;;
+    -j | --java-container ) set_test_environment
+                            run_java_container_tests
+                            ;;
+    -r | --rpc-container )  set_test_environment
+                            run_rpc_container_tests
+                            ;;
+    -h | --help )           usage
+                            ;;
+    * )                     usage
+esac


### PR DESCRIPTION
This MR adds the option for running only a subset of Clipper tests. For example, this modification allow users to only execute the frontend tests by running:

```
./bin/run_unittests.sh -f
```

This is also true for both libclipper and management tests.