### PR TITLE
[CLIPPER-167] Fix to listing apps in tutorial

### DIFF
--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -170,7 +170,7 @@
    },
    "outputs": [],
    "source": [
-    "clipper.list_apps()"
+    "clipper.get_all_apps()"
    ]
   },
   {
@@ -235,7 +235,7 @@
    },
    "outputs": [],
    "source": [
-    "clipper.list_apps()"
+    "clipper.get_all_apps()"
    ]
   },
   {

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -304,7 +304,7 @@ class Clipper:
             Returns a list of information about all apps registered to Clipper.
             If no apps are registered with Clipper, an empty list is returned.
         """
-        url = "http://%s:1338/admin/get_all_applications$" % self.host
+        url = "http://%s:1338/admin/get_all_applications" % self.host
         req_json = json.dumps({"verbose": verbose})
         headers = {'Content-type': 'application/json'}
         r = requests.get(url, headers=headers, data=req_json)


### PR DESCRIPTION
`list_apps` was replaced by `get_all_apps` in https://github.com/ucbrise/clipper/pull/125, but the tutorial wasn't updated accordingly.

https://clipper.atlassian.net/browse/CLIPPER-167

Fix to clipper_manager's `get_all_apps` added here so that this doesn't get merged before `get_all_apps` is functional.