### PR TITLE
Fix small text error on tutorial_part_one.ipynb

### DIFF
--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -183,7 +183,7 @@
    "source": [
     "# Create an application\n",
     "\n",
-    "In order to send query Clipper for predictions, you need to create an application. Each application specifies a name, a set of models it can query, the query input datatype, the selection policy, and a latency service level objective. Once you register an application with Clipper, the system will create two REST endpoints: one for requesting predictions and for providing feedback.\n",
+    "In order to query Clipper for predictions, you need to create an application. Each application specifies a name, a set of models it can query, the query input datatype, the selection policy, and a latency service level objective. Once you register an application with Clipper, the system will create two REST endpoints: one for requesting predictions and for providing feedback.\n",
     "\n",
     "By associating the query interface with a specific application, Clipper allows frontend developers the flexibility to have multiple applications running in the same Clipper instance. Applications can request predictions from any model in Clipper. This allows a single Clipper instance to serve multiple machine-learning applications. It also provides a convenient mechanism for beta-testing or incremental rollout by creating experimental and stable applications for the same set of queries.\n",
     "\n",


### PR DESCRIPTION
On the section **Create an application**, fix the phrase:

In order to send query Clipper for predictions...

To:

In order to query Clipper for predictions...