### PR TITLE
[WIP] Add support to Python 3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,19 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "debian/testing64"
 
+  config.vm.provider "virtualbox" do |v|
+    v.name = "clipper"
+  end
+
+  config.vm.provider "virtualbox" do |v|
+    v.memory = 2048
+    v.cpus = 2
+  end
+
+  config.vm.network "forwarded_port", guest: 8888, host: 8888
+
+  config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+
   # Enable provisioning with a shell script. Additional provisioners such as
   # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
   # documentation for more information about their specific syntax and use.
@@ -12,6 +25,23 @@ Vagrant.configure("2") do |config|
     sudo apt-get upgrade -y
     sudo apt-get install -y cmake redis-server libhiredis-dev libev-dev libboost-all-dev libzmq3-dev g++ git openjdk-8-jdk maven python-zmq python-numpy libzmq-jni
     echo 'export JZMQ_HOME=/usr/lib/x86_64-linux-gnu/jni' >> ~/.bashrc
+
+    # Allow running the tutorials notebooks inside the virtual machine
+    sudo apt-get install -y python3-pip libffi-dev libssl-dev
+    cd /vagrant/examples/tutorial
+    sudo pip3 install -r requirements.txt
+
+    # Installing docker
+    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common
+    curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+    sudo add-apt-repository \
+       "deb [arch=amd64] https://download.docker.com/linux/debian \
+          $(lsb_release -cs) \
+             stable"
+    sudo apt-get update
+    sudo apt-get install -y docker-ce docker-compose
+    sudo groupadd docker
+    sudo usermod -aG docker vagrant
 
     cd /vagrant
     ./configure

--- a/examples/tutorial/cifar_utils.py
+++ b/examples/tutorial/cifar_utils.py
@@ -39,7 +39,7 @@ def show_example_images(images, labels, num_rows):
     for i, idx in enumerate(idxs):
         image = recover_pixels(images[idx])
         label = labels[idx]
-        cur_ax = axes[i / imgs_per_row][i % imgs_per_row]
+        cur_ax = axes[int(i / imgs_per_row)][i % imgs_per_row]
         cur_ax.imshow(image.astype(np.ubyte), interpolation="nearest")
         cur_ax.axis('off')
         if label == 0:
@@ -54,7 +54,7 @@ def load_cifar(cifar_location, cifar_filename="cifar_train.data", norm=True):
     # print("Source file: %s" % cifar_path)
     df = pd.read_csv(cifar_path, sep=",", header=None)
     data = df.values
-    print("Number of image files: %d" % len(data))
+    print("Number of image files: {}".format(len(data)))
     y = data[:, 0]
     X = data[:, 1:]
     Z = X
@@ -97,7 +97,7 @@ def cifar_update(host, app, uid, x, y, print_result=False):
     end = datetime.now()
     latency = (end - start).total_seconds() * 1000.0
     if print_result:
-        print("'%s', %f ms" % (r.text, latency))
+        print("'{}', {} ms".format(r.text, latency))
 
 
 def parse_pred(p):
@@ -163,7 +163,7 @@ def run_iteration(host, app, uid, test_x, test_y):
         elif correct_y == 1 and pred_y == 0:
             false_neg += 1
         else:
-            print "predicted: {p}, correct: {c}".format(p=pred_y, c=correct_y)
+            print("predicted: {p}, correct: {c}".format(p=pred_y, c=correct_y))
         latencies.append(latency)
     total = float(total)
     return (float(correct) / total, float(false_pos) / total,

--- a/examples/tutorial/download_cifar.py
+++ b/examples/tutorial/download_cifar.py
@@ -1,7 +1,11 @@
-import urllib
-import sys
 import os
 import tarfile
+import sys
+
+if sys.version_info >= (3, 0):
+    import urllib.request as url
+else:
+    import urllib as url
 
 
 def download_cifar(loc):
@@ -10,10 +14,8 @@ def download_cifar(loc):
         os.makedirs(loc)
     if not os.path.exists(os.path.join(loc, 'cifar-10-python.tar.gz')):
         print("CIFAR10 dataset not found, downloading...")
-        # http://stackoverflow.com/a/19602990
-        testfile = urllib.URLopener()
         tar_file_path = os.path.join(loc, 'cifar-10-python.tar.gz')
-        testfile.retrieve(
+        url.urlretrieve(
             'https://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz',
             tar_file_path)
         tar = tarfile.open(tar_file_path)

--- a/examples/tutorial/extract_cifar.py
+++ b/examples/tutorial/extract_cifar.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import cPickle
-import sys
+
+try:
+    import cPickle as pickle
+except:
+    import pickle
+
 import numpy as np
 import os
 import tarfile
+import sys
 
 
 # Taken from https://www.cs.toronto.edu/~kriz/cifar.html
-def unpickle(file):
-    fo = open(file, 'rb')
-    dict = cPickle.load(fo)
-    fo.close()
-    return dict
+def unpickle(pickle_file):
+    with open(pickle_file, 'rb') as fo:
+        if sys.version_info >= (3, 0):
+            pickle_dict = pickle.load(fo, encoding='bytes')
+        else:
+            pickle_dict = pickle.load(fo)
+    return pickle_dict
 
 
 def extract_cifar(loc):
@@ -26,13 +33,13 @@ def extract_cifar(loc):
         if 'data_batch' in filename:
             print(file_path)
             batch_dict = unpickle(file_path)
-            data.append(batch_dict['data'])
-            labels.append(batch_dict['labels'])
+            data.append(batch_dict[b'data'])
+            labels.append(batch_dict[b'labels'])
         elif filename == 'test_batch':
             print(file_path)
             batch_dict = unpickle(file_path)
-            test_data = batch_dict['data']
-            test_labels = np.array(batch_dict['labels'])
+            test_data = batch_dict[b'data']
+            test_labels = np.array(batch_dict[b'labels'])
 
     data = np.vstack(data)
     labels = np.hstack(labels)

--- a/examples/tutorial/requirements.txt
+++ b/examples/tutorial/requirements.txt
@@ -1,5 +1,6 @@
 cloudpickle==0.2.2
-Fabric==1.13.1
+Fabric==1.13.1; python_version <= '2.7'
+Fabric3==1.13.1.post1; python_version >='3.0'
 ipython==5.1.0
 jupyter==1.0.0
 matplotlib==2.0.0
@@ -11,5 +12,5 @@ requests==2.12.4
 scikit-learn==0.18.1
 scipy==0.18.1
 seaborn==0.7.1
-subprocess32==3.2.7
+subprocess32==3.2.7; python_version <= '2.7'
 tensorflow==0.12.1

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -5,12 +5,21 @@ import os
 import requests
 import json
 import yaml
-import pprint
-import subprocess32 as subprocess
+
+try:
+    import subprocess
+except:
+    import subprocess32 as subprocess
+
 import shutil
 from sklearn import base
 from sklearn.externals import joblib
-from cStringIO import StringIO
+
+try:
+    from cStringIO import StringIO
+except:
+    from io import StringIO
+
 import sys
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.abspath('%s../../containers/python/' % cur_dir))


### PR DESCRIPTION
This MR ports Clipper python files to support Python 3, which is related to #138 . However, there is something that I am not sure what is the best approach.

The [fabric](https://github.com/fabric/fabric) lib is currently only available for Python 2. Although they are currently porting it to Python 3, [fabric v2](https://github.com/fabric/fabric/tree/v2), the work is far from over.

However, there is a port for fabric to Python 3, named [fabric3](https://github.com/mathiasertl/fabric/).  This fork is discussed in an [issue](https://github.com/fabric/fabric/issues/1424) about the support for Python 3.

If this is not the best approach, I can try to see if it possible to replace **fabric** or just wait for the new version to be available.