### PR TITLE
Fix query frontend crash after multiple models added

### DIFF
--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -39,6 +39,7 @@ export(TARGETS clipper FILE ClipperConfig.cmake)
 # be last in the list
 add_executable(libclippertests EXCLUDE_FROM_ALL
     test/test_main.cpp
+    test/container_test.cpp
     test/metrics_test.cpp
     test/rpc_service_test.cpp
     test/timers_test.cpp
@@ -51,7 +52,6 @@ add_executable(libclippertests EXCLUDE_FROM_ALL
     test/future_test.cpp
     test/threadpool_test.cpp
     test/task_executor_test.cpp
-    test/container_test.cpp
     test/config_test.cpp
     )
 

--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -20,7 +20,8 @@ using Deadline = std::chrono::time_point<std::chrono::system_clock>;
 class ModelContainer {
  public:
   ~ModelContainer() = default;
-  ModelContainer(VersionedModelId model, int id, InputType input_type);
+  ModelContainer(VersionedModelId model, int container_id, int replica_id,
+                 InputType input_type);
   // disallow copy
   ModelContainer(const ModelContainer &) = delete;
   ModelContainer &operator=(const ModelContainer &) = delete;
@@ -35,6 +36,7 @@ class ModelContainer {
 
   VersionedModelId model_;
   int container_id_;
+  int replica_id_;
   InputType input_type_;
 
  private:

--- a/src/libclipper/src/containers.cpp
+++ b/src/libclipper/src/containers.cpp
@@ -18,13 +18,21 @@
 
 namespace clipper {
 
+const std::string LOGGING_TAG_CONTAINERS = "CONTAINERS";
+
 ModelContainer::ModelContainer(VersionedModelId model, int container_id,
-                               InputType input_type)
+                               int replica_id, InputType input_type)
     : model_(model),
       container_id_(container_id),
+      replica_id_(replica_id),
       input_type_(input_type),
       avg_throughput_per_milli_(0),
-      throughput_buffer_(THROUGHPUT_BUFFER_CAPACITY) {}
+      throughput_buffer_(THROUGHPUT_BUFFER_CAPACITY) {
+  std::string model_str = versioned_model_to_str(model);
+  log_info_formatted(LOGGING_TAG_CONTAINERS,
+                     "Creating new ModelContainer for model {}, id: {}",
+                     model_str, std::to_string(container_id));
+}
 
 void ModelContainer::update_throughput(size_t batch_size,
                                        long total_latency_micros) {
@@ -90,24 +98,40 @@ ActiveContainers::ActiveContainers()
 
 void ActiveContainers::add_container(VersionedModelId model, int connection_id,
                                      int replica_id, InputType input_type) {
-  log_info_formatted(
-      LOGGING_TAG_CLIPPER,
-      "Adding new container - model: {}, version: {}, ID: {}, input_type: {}",
-      model.first, model.second, connection_id,
-      get_readable_input_type(input_type));
+  log_info_formatted(LOGGING_TAG_CONTAINERS,
+                     "Adding new container - model: {}, version: {}, "
+                     "connection ID: {}, replica ID: {}, input_type: {}",
+                     model.first, model.second, connection_id, replica_id,
+                     get_readable_input_type(input_type));
   boost::unique_lock<boost::shared_mutex> l{m_};
-  auto new_container =
-      std::make_shared<ModelContainer>(model, connection_id, input_type);
+  auto new_container = std::make_shared<ModelContainer>(model, connection_id,
+                                                        replica_id, input_type);
   auto entry = containers_[new_container->model_];
   entry.emplace(replica_id, new_container);
   containers_[new_container->model_] = entry;
   assert(containers_[new_container->model_].size() > 0);
+  std::stringstream log_msg;
+  log_msg << "\nActive containers:\n";
+  // log_info(LOGGING_TAG_CONTAINERS, "All active containers:");
+  for (auto model : containers_) {
+    log_msg << "\tModel: " << versioned_model_to_str(model.first) << "\n";
+    for (auto r : model.second) {
+      log_msg << "\t\trep_id: " << r.first
+              << ", container_id: " << r.second->container_id_ << "\n";
+    }
+  }
+  log_info(LOGGING_TAG_CONTAINERS, log_msg.str());
 }
 
 std::shared_ptr<ModelContainer> ActiveContainers::get_model_replica(
     const VersionedModelId &model, const int replica_id) {
+  boost::shared_lock<boost::shared_mutex> l{m_};
+
   auto replicas_map_entry = containers_.find(model);
   if (replicas_map_entry == containers_.end()) {
+    log_error_formatted(LOGGING_TAG_CONTAINERS,
+                        "Requested replica {} for model {} NOT FOUND",
+                        replica_id, versioned_model_to_str(model));
     return nullptr;
   }
 
@@ -117,6 +141,9 @@ std::shared_ptr<ModelContainer> ActiveContainers::get_model_replica(
   if (replica_entry != replicas_map.end()) {
     return replica_entry->second;
   } else {
+    log_error_formatted(LOGGING_TAG_CONTAINERS,
+                        "Requested replica {} for model {} NOT FOUND",
+                        replica_id, versioned_model_to_str(model));
     return nullptr;
   }
 }

--- a/src/libclipper/src/containers.cpp
+++ b/src/libclipper/src/containers.cpp
@@ -112,7 +112,6 @@ void ActiveContainers::add_container(VersionedModelId model, int connection_id,
   assert(containers_[new_container->model_].size() > 0);
   std::stringstream log_msg;
   log_msg << "\nActive containers:\n";
-  // log_info(LOGGING_TAG_CONTAINERS, "All active containers:");
   for (auto model : containers_) {
     log_msg << "\tModel: " << versioned_model_to_str(model.first) << "\n";
     for (auto r : model.second) {

--- a/src/libclipper/test/container_test.cpp
+++ b/src/libclipper/test/container_test.cpp
@@ -8,7 +8,7 @@ namespace {
 
 TEST(ModelContainerTests, AverageThroughputUpdatesCorrectlyFewSamples) {
   VersionedModelId model("test", 1);
-  ModelContainer container(model, 0, InputType::Doubles);
+  ModelContainer container(model, 0, 0, InputType::Doubles);
   std::array<long, 4> single_task_latencies_micros = {{500, 2000, 3000, 5000}};
   long avg_latency = 0;
   double avg_throughput_millis = 0;
@@ -25,7 +25,7 @@ TEST(ModelContainerTests, AverageThroughputUpdatesCorrectlyFewSamples) {
 
 TEST(ModelContainerTests, AverageThroughputUpdatesCorrectlyManySamples) {
   VersionedModelId model("test", 1);
-  ModelContainer container(model, 0, InputType::Doubles);
+  ModelContainer container(model, 0, 0, InputType::Doubles);
   double avg_throughput_millis = 0;
   for (int i = 3; i < 103; i++) {
     double throughput_millis = 1 / static_cast<double>(1000 * i);

--- a/src/libclipper/test/container_test.cpp
+++ b/src/libclipper/test/container_test.cpp
@@ -6,11 +6,10 @@ using namespace clipper;
 
 namespace {
 
-TEST(ContainerTests,
-     ModelContainerAverageThroughputUpdatesCorrectlyFewSamples) {
+TEST(ModelContainerTests, AverageThroughputUpdatesCorrectlyFewSamples) {
   VersionedModelId model("test", 1);
   ModelContainer container(model, 0, InputType::Doubles);
-  std::array<long, 4> single_task_latencies_micros = {500, 2000, 3000, 5000};
+  std::array<long, 4> single_task_latencies_micros = {{500, 2000, 3000, 5000}};
   long avg_latency = 0;
   double avg_throughput_millis = 0;
   for (long latency : single_task_latencies_micros) {
@@ -24,8 +23,7 @@ TEST(ContainerTests,
                    avg_throughput_millis);
 }
 
-TEST(ContainerTests,
-     ModelContainerAverageThroughputUpdatesCorrectlyManySamples) {
+TEST(ModelContainerTests, AverageThroughputUpdatesCorrectlyManySamples) {
   VersionedModelId model("test", 1);
   ModelContainer container(model, 0, InputType::Doubles);
   double avg_throughput_millis = 0;
@@ -39,5 +37,103 @@ TEST(ContainerTests,
   }
   ASSERT_DOUBLE_EQ(container.get_average_throughput_per_millisecond(),
                    avg_throughput_millis);
+}
+
+TEST(ActiveContainerTests, AddContainer) {
+  VersionedModelId m1 = std::make_pair("m", 1);
+  int rep_id = 0;
+  int conn_id = 0;
+  std::shared_ptr<ActiveContainers> active_containers =
+      std::make_shared<ActiveContainers>();
+
+  active_containers->add_container(m1, conn_id, rep_id, InputType::Doubles);
+  std::shared_ptr<ModelContainer> result =
+      active_containers->get_model_replica(m1, rep_id);
+  ASSERT_EQ(result->model_, m1);
+  ASSERT_EQ(result->container_id_, conn_id);
+}
+
+TEST(ActiveContainerTests, AddMultipleContainersDifferentModels) {
+  VersionedModelId m1 = std::make_pair("m", 1);
+  int m1rep_id = 0;
+  int m1conn_id = 0;
+
+  VersionedModelId j1 = std::make_pair("j", 1);
+  int j1rep_id = 0;
+  int j1conn_id = 1;
+  std::shared_ptr<ActiveContainers> active_containers =
+      std::make_shared<ActiveContainers>();
+
+  active_containers->add_container(m1, m1conn_id, m1rep_id, InputType::Doubles);
+  std::shared_ptr<ModelContainer> m1result =
+      active_containers->get_model_replica(m1, m1rep_id);
+  ASSERT_EQ(m1result->model_, m1);
+  ASSERT_EQ(m1result->container_id_, m1conn_id);
+
+  active_containers->add_container(j1, j1conn_id, j1rep_id, InputType::Doubles);
+  std::shared_ptr<ModelContainer> m1result2 =
+      active_containers->get_model_replica(m1, m1rep_id);
+  ASSERT_EQ(m1result2->model_, m1);
+  ASSERT_EQ(m1result2->container_id_, m1conn_id);
+
+  std::shared_ptr<ModelContainer> j1result =
+      active_containers->get_model_replica(j1, j1rep_id);
+  ASSERT_EQ(j1result->model_, j1);
+  ASSERT_EQ(j1result->container_id_, j1conn_id);
+}
+
+TEST(ActiveContainerTests, AddMultipleContainersSameModelSameVersion) {
+  VersionedModelId vm = std::make_pair("m", 1);
+  int firstrep_id = 0;
+  int firstconn_id = 0;
+
+  int secondrep_id = 1;
+  int secondconn_id = 1;
+  std::shared_ptr<ActiveContainers> active_containers =
+      std::make_shared<ActiveContainers>();
+
+  active_containers->add_container(vm, firstconn_id, firstrep_id,
+                                   InputType::Doubles);
+
+  active_containers->add_container(vm, secondconn_id, secondrep_id,
+                                   InputType::Doubles);
+
+  std::shared_ptr<ModelContainer> secondresult =
+      active_containers->get_model_replica(vm, secondrep_id);
+  ASSERT_EQ(secondresult->model_, vm);
+  ASSERT_EQ(secondresult->container_id_, secondconn_id);
+
+  std::shared_ptr<ModelContainer> firstresult =
+      active_containers->get_model_replica(vm, firstrep_id);
+  ASSERT_EQ(firstresult->model_, vm);
+  ASSERT_EQ(firstresult->container_id_, firstconn_id);
+}
+
+TEST(ActiveContainerTests, AddMultipleContainersSameModelDifferentVersions) {
+  VersionedModelId vm1 = std::make_pair("m", 1);
+  int firstrep_id = 0;
+  int firstconn_id = 0;
+
+  VersionedModelId vm2 = std::make_pair("m", 2);
+  int secondrep_id = 1;
+  int secondconn_id = 1;
+  std::shared_ptr<ActiveContainers> active_containers =
+      std::make_shared<ActiveContainers>();
+
+  active_containers->add_container(vm1, firstconn_id, firstrep_id,
+                                   InputType::Doubles);
+
+  active_containers->add_container(vm2, secondconn_id, secondrep_id,
+                                   InputType::Doubles);
+
+  std::shared_ptr<ModelContainer> secondresult =
+      active_containers->get_model_replica(vm2, secondrep_id);
+  ASSERT_EQ(secondresult->model_, vm2);
+  ASSERT_EQ(secondresult->container_id_, secondconn_id);
+
+  std::shared_ptr<ModelContainer> firstresult =
+      active_containers->get_model_replica(vm1, firstrep_id);
+  ASSERT_EQ(firstresult->model_, vm1);
+  ASSERT_EQ(firstresult->container_id_, firstconn_id);
 }
 }


### PR DESCRIPTION
Fixes #149. The issue was a mixup between the __replica_id__ and __container_id__ assigned to a container.