### PR TITLE
Fix container starvation issue

### DIFF
--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -114,11 +114,11 @@ function run_frontend_tests {
 }
 
 function run_all_tests {
-  run_management_tests
-  redis-cli -p $REDIS_PORT "flushall"
   run_libclipper_tests
   redis-cli -p $REDIS_PORT "flushall"
   run_frontend_tests
+  redis-cli -p $REDIS_PORT "flushall"
+  run_management_tests
   redis-cli -p $REDIS_PORT "flushall"
   run_jvm_container_tests
   redis-cli -p $REDIS_PORT "flushall"

--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -19,6 +19,7 @@ function usage {
     -f, --frontend              Run tests only for frontend folder.
     -j, --jvm-container         Run tests only for jvm container folder.
     -r, --rpc-container         Run tests only for rpc container folder.
+    -i, --integration_tests     Run integration tests.
     -h, --help                  Display this message and exit.
 
 $@
@@ -113,6 +114,12 @@ function run_frontend_tests {
   ./src/frontends/frontendtests --redis_port $REDIS_PORT
 }
 
+function run_integration_tests {
+  echo -e "\nRunning integration tests\n\n"
+  cd $DIR
+  python ../integration-tests/light_load_all_functionality.py
+}
+
 function run_all_tests {
   run_libclipper_tests
   redis-cli -p $REDIS_PORT "flushall"
@@ -123,6 +130,8 @@ function run_all_tests {
   run_jvm_container_tests
   redis-cli -p $REDIS_PORT "flushall"
   run_rpc_container_tests
+  redis-cli -p $REDIS_PORT "flushall"
+  run_integration_tests
 }
 
 if [ "$#" == 0 ]
@@ -150,6 +159,9 @@ case $args in
                             ;;
     -r | --rpc-container )  set_test_environment
                             run_rpc_container_tests
+                            ;;
+    -i | --integration_tests )  set_test_environment
+                            run_integration_tests
                             ;;
     -h | --help )           usage
                             ;;

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -80,13 +80,6 @@ def cleanup():
     subprocess.call("docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)", shell=True)
 
 if __name__=="__main__":
-    # app_name = "aa_app"
-    # response = requests.post("http://localhost:1337/%s/predict" % app_name,
-    #         headers=headers,
-    #         data=json.dumps({'uid': 0, 'input': list(np.random.random(30))}))
-    # result = response.json()
-    # print(response.text)
-
     clipper = init_clipper()
     try:
         create_and_test_app(clipper, "aa")
@@ -100,7 +93,8 @@ if __name__=="__main__":
     except BenchmarkException as e:
         print_clipper_state(clipper)
         print(e)
+        cleanup()
+        sys.exit(1)
     else:
-        print_clipper_state(clipper)
         cleanup()
 

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -1,0 +1,106 @@
+from __future__ import print_function
+import os
+import sys
+import requests
+import json
+import numpy as np
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath('%s/../management/' % cur_dir))
+import clipper_manager as cm
+import time
+import subprocess32 as subprocess
+import pprint
+
+headers = {'Content-type': 'application/json'}
+fake_model_data = "/tmp/test123456"
+try:
+    os.mkdir(fake_model_data)
+except OSError:
+    pass
+
+class BenchmarkException(Exception):
+    def __init__(self, value):
+        self.parameter = value
+    def __str__(self):
+        return repr(self.parameter)
+
+def init_clipper():
+    clipper = cm.Clipper("localhost")
+    clipper.start()
+    time.sleep(1)
+    return clipper
+
+def print_clipper_state(clipper):
+    pp = pprint.PrettyPrinter(indent=4)
+    print("APPLICATIONS")
+    pp.pprint(clipper.get_all_apps(verbose=True))
+    print("\nMODELS")
+    pp.pprint(clipper.get_all_models(verbose=True))
+    print("\nCONTAINERS")
+    pp.pprint(clipper.get_all_containers(verbose=True))
+
+def deploy_model(clipper, name, version):
+    app_name = "%s_app" % name
+    model_name = "%s_model" % name
+    clipper.deploy_model(model_name, version, fake_model_data, "clipper/noop-container", [name], "doubles", num_containers=1)
+    time.sleep(20)
+    num_preds = 25
+    num_defaults = 0
+    for i in range(num_preds):
+        response = requests.post("http://localhost:1337/%s/predict" % app_name,
+                headers=headers,
+                data=json.dumps({'uid': 0, 'input': list(np.random.random(30))}))
+        result = response.json()
+        if response.status_code == requests.codes.ok and result["default"] == True:
+            num_defaults += 1
+    if num_defaults > 0:
+        print("Error: %d/%d predictions were default" % (num_defaults, num_preds))
+    if num_defaults > num_preds / 2:
+        raise BenchmarkException("Error querying APP %s, MODEL %s:%d" % (app_name, model_name, version))
+
+def create_and_test_app(clipper, name):
+    app_name = "%s_app" % name
+    model_name = "%s_model" % name
+    clipper.register_application(app_name, model_name, "doubles", "default_pred", 50000)
+    time.sleep(1)
+    response = requests.post("http://localhost:1337/%s/predict" % app_name,
+            headers=headers,
+            data=json.dumps({'uid': 0, 'input': list(np.random.random(30))}))
+    result = response.json()
+    if response.status_code != requests.codes.ok:
+        print("Error: %s" % response.text)
+        raise BenchmarkException("Error creating app %s" % app_name)
+
+    for i in range(8):
+        deploy_model(clipper, name, i)
+        time.sleep(1)
+
+
+def cleanup():
+    subprocess.call("docker stop $(docker ps -a -q) && docker rm $(docker ps -a -q)", shell=True)
+
+if __name__=="__main__":
+    # app_name = "aa_app"
+    # response = requests.post("http://localhost:1337/%s/predict" % app_name,
+    #         headers=headers,
+    #         data=json.dumps({'uid': 0, 'input': list(np.random.random(30))}))
+    # result = response.json()
+    # print(response.text)
+
+    clipper = init_clipper()
+    try:
+        create_and_test_app(clipper, "aa")
+        create_and_test_app(clipper, "bb")
+        create_and_test_app(clipper, "cc")
+        create_and_test_app(clipper, "dd")
+        create_and_test_app(clipper, "ee")
+        create_and_test_app(clipper, "ff")
+        create_and_test_app(clipper, "gg")
+        print("SUCCESS")
+    except BenchmarkException as e:
+        print_clipper_state(clipper)
+        print(e)
+    else:
+        print_clipper_state(clipper)
+        cleanup()
+

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -37,13 +37,14 @@ def find_unbound_port():
     """
     Returns an unbound port number on 127.0.0.1.
     """
-    port = random.randint(*PORT_RANGE)
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    try:
-        sock.bind(("127.0.0.1", port))
-    except socket.error:
-        port = get_port()
-    return port
+    while True:
+        port = random.randint(*PORT_RANGE)
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.bind(("127.0.0.1", port))
+            return port
+        except socket.error:
+            print("randomly generated port %d is bound. Trying again." % port)
 
 
 def init_clipper():
@@ -73,7 +74,7 @@ def deploy_model(clipper, name, version):
         "clipper/noop-container", [name],
         "doubles",
         num_containers=1)
-    time.sleep(20)
+    time.sleep(10)
     num_preds = 25
     num_defaults = 0
     for i in range(num_preds):

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -28,8 +28,10 @@ class BenchmarkException(Exception):
     def __str__(self):
         return repr(self.parameter)
 
+
 # range of ports where available ports can be found
-PORT_RANGE = [34256,40000]
+PORT_RANGE = [34256, 40000]
+
 
 def find_unbound_port():
     """
@@ -42,6 +44,7 @@ def find_unbound_port():
     except socket.error:
         port = get_port()
     return port
+
 
 def init_clipper():
     clipper = cm.Clipper("localhost", redis_port=find_unbound_port())

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -44,6 +44,10 @@ LOCAL_HOST_NAMES = ["local", "localhost", "127.0.0.1"]
 EXTERNALLY_MANAGED_MODEL = "EXTERNAL"
 
 
+class ClipperManagerException(Exception):
+    pass
+
+
 class Clipper:
     """
     Connection to a Clipper instance for administrative purposes.
@@ -131,7 +135,9 @@ class Clipper:
                 print(
                     "user and key_path must be specified when instantiating Clipper with a nonlocal host"
                 )
-                raise
+                raise ClipperManagerException(
+                    "user and key_path must be specified when instantiating Clipper with a nonlocal host"
+                )
             env.user = user
             env.key_filename = key_path
             env.host_string = "%s:%d" % (host, ssh_port)
@@ -150,7 +156,8 @@ class Clipper:
                 "docker-compose --version", warn_only=True)
             if dc_installed.return_code != 0:
                 print("docker-compose not installed on host.")
-                raise  # TODO raise real exception
+                raise ClipperManagerException(
+                    "docker-compose not installed on host.")
             nw_create_command = ("docker network create --driver bridge {nw}"
                                  .format(nw=DOCKER_NW))
             self._execute_root(nw_create_command, warn_only=True)

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -39,7 +39,6 @@ aws_access_key_id = {access_key}
 aws_secret_access_key = {secret_key}
 """
 
-
 LOCAL_HOST_NAMES = ["local", "localhost", "127.0.0.1"]
 
 EXTERNALLY_MANAGED_MODEL = "EXTERNAL"
@@ -83,40 +82,44 @@ class Clipper:
 
         self.redis_port = redis_port
         self.docker_compost_dict = {
-                'networks': {
-                    'default': {
-                        'external': {
-                            'name': DOCKER_NW
-                            }
-                        }
-                    },
-                'services': {
-                    'mgmt_frontend': {
-                        'command': ['--redis_ip=redis', '--redis_port=%d' % self.redis_port],
-                        'depends_on': ['redis'],
-                        'image': 'clipper/management_frontend:latest',
-                        'ports':
-                        ['%d:%d' % (CLIPPER_MANAGEMENT_PORT, CLIPPER_MANAGEMENT_PORT)]
-                        },
-                    'query_frontend': {
-                        'command': ['--redis_ip=redis', '--redis_port=%d' % self.redis_port],
-                        'depends_on': ['redis', 'mgmt_frontend'],
-                        'image':
-                        'clipper/query_frontend:latest',
-                        'ports': [
-                            '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
-                            '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)
-                            ]
-                        },
-                    'redis': {
-                        'image': 'redis:alpine',
-                        'ports': ['%d:%d' % (self.redis_port, self.redis_port)],
-                        'command': "redis-server --port %d" % self.redis_port
-                        }
-                    },
-                'version': '2'
+            'networks': {
+                'default': {
+                    'external': {
+                        'name': DOCKER_NW
+                    }
                 }
-
+            },
+            'services': {
+                'mgmt_frontend': {
+                    'command':
+                    ['--redis_ip=redis', '--redis_port=%d' % self.redis_port],
+                    'depends_on': ['redis'],
+                    'image':
+                    'clipper/management_frontend:latest',
+                    'ports': [
+                        '%d:%d' % (CLIPPER_MANAGEMENT_PORT,
+                                   CLIPPER_MANAGEMENT_PORT)
+                    ]
+                },
+                'query_frontend': {
+                    'command':
+                    ['--redis_ip=redis', '--redis_port=%d' % self.redis_port],
+                    'depends_on': ['redis', 'mgmt_frontend'],
+                    'image':
+                    'clipper/query_frontend:latest',
+                    'ports': [
+                        '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
+                        '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)
+                    ]
+                },
+                'redis': {
+                    'image': 'redis:alpine',
+                    'ports': ['%d:%d' % (self.redis_port, self.redis_port)],
+                    'command': "redis-server --port %d" % self.redis_port
+                }
+            },
+            'version': '2'
+        }
 
         self.sudo = sudo
         self.host = host
@@ -147,7 +150,7 @@ class Clipper:
                 "docker-compose --version", warn_only=True)
             if dc_installed.return_code != 0:
                 print("docker-compose not installed on host.")
-                raise # TODO raise real exception
+                raise  # TODO raise real exception
             nw_create_command = ("docker network create --driver bridge {nw}"
                                  .format(nw=DOCKER_NW))
             self._execute_root(nw_create_command, warn_only=True)
@@ -794,8 +797,12 @@ class Clipper:
             # Look up model info in Redis
             model_key = "{mn}:{mv}".format(mn=model_name, mv=model_version)
             result = local(
-                "redis-cli -h {host} -p {redis_port} -n {db} hgetall {key}".format(
-                    host=self.host, redis_port=self.redis_port, key=model_key, db=REDIS_MODEL_DB_NUM),
+                "redis-cli -h {host} -p {redis_port} -n {db} hgetall {key}".
+                format(
+                    host=self.host,
+                    redis_port=self.redis_port,
+                    key=model_key,
+                    db=REDIS_MODEL_DB_NUM),
                 capture=True)
 
             if "nil" in result.stdout:

--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -39,6 +39,7 @@ export(TARGETS clipper FILE ClipperConfig.cmake)
 # be last in the list
 add_executable(libclippertests EXCLUDE_FROM_ALL
     test/test_main.cpp
+    test/threadpool_test.cpp
     test/container_test.cpp
     test/metrics_test.cpp
     test/rpc_service_test.cpp
@@ -50,7 +51,6 @@ add_executable(libclippertests EXCLUDE_FROM_ALL
     test/json_util_test.cpp
     test/logging_test.cpp
     test/future_test.cpp
-    test/threadpool_test.cpp
     test/task_executor_test.cpp
     test/config_test.cpp
     )

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -113,10 +113,12 @@ class ModelQueue {
   ~ModelQueue() = default;
 
   void add_task(PredictTask task) {
-    std::unique_lock<std::mutex> l(queue_mutex_);
+    std::lock_guard<std::mutex> lock(queue_mutex_);
     Deadline deadline = std::chrono::system_clock::now() +
                         std::chrono::microseconds(task.latency_slo_micros_);
     queue_.emplace(deadline, std::move(task));
+    // TODO: is there a good reason to prefer notify_one or notify_all?
+    condition_.notify_one();
   }
 
   int get_size() {
@@ -124,29 +126,35 @@ class ModelQueue {
     return queue_.size();
   }
 
-  // TODO: If we implement the scheduler so that it calls
-  // get_earliest_deadline(), then uses that to compute the batch size,
-  // then calls dequeue with that batch size, it's possible for a new
-  // task with an earlier deadline to be submitted. I'm not sure what the
-  // correct behavior here should be.
-  boost::optional<Deadline> get_earliest_deadline() {
-    std::unique_lock<std::mutex> l(queue_mutex_);
-    remove_tasks_with_elapsed_deadlines();
-    if (!queue_.empty()) {
-      return boost::optional<Deadline>(queue_.top().first);
-    } else {
-      return boost::optional<Deadline>{};
-    }
-  }
+  // // TODO: If we implement the scheduler so that it calls
+  // // get_earliest_deadline(), then uses that to compute the batch size,
+  // // then calls dequeue with that batch size, it's possible for a new
+  // // task with an earlier deadline to be submitted. I'm not sure what the
+  // // correct behavior here should be.
+  // //
+  // //
+  // #<{(|*
+  //  * Blocks until the queue is non-empty
+  //  |)}>#
+  // Deadline get_earliest_deadline() {
+  //   std::unique_lock<std::mutex> lock(queue_mutex_);
+  //   remove_tasks_with_elapsed_deadlines();
+  //   condition_.wait(lock, [this]() { return !queue_.empty(); });
+  //   return queue_.top().first;
+  //   // if (!queue_.empty()) {
+  //   //   return boost::optional<Deadline>(queue_.top().first);
+  //   // } else {
+  //   //   return boost::optional<Deadline>{};
+  //   // }
+  // }
 
-  // Dequeues up to max_batch_size tasks from the queue without blocking
-  std::vector<PredictTask> get_batch(int max_batch_size) {
-    // NOTE: Because the queue lock is released and reacquired between a
-    // call to get_earliest_deadline() (which blocks until the queue is
-    // not empty) and the call to this method, it's possible for the queue
-    // to be empty, in which case the returned vector will have size 0.
-    std::unique_lock<std::mutex> l(queue_mutex_);
+  std::vector<PredictTask> get_batch(
+      std::function<int(Deadline)> &&get_batch_size) {
+    std::unique_lock<std::mutex> lock(queue_mutex_);
     remove_tasks_with_elapsed_deadlines();
+    condition_.wait(lock, [this]() { return !queue_.empty(); });
+    Deadline deadline = queue_.top().first;
+    int max_batch_size = get_batch_size(deadline);
     std::vector<PredictTask> batch;
     while (batch.size() < (size_t)max_batch_size && queue_.size() > 0) {
       batch.push_back(queue_.top().second);
@@ -154,6 +162,22 @@ class ModelQueue {
     }
     return batch;
   }
+
+  // // Dequeues up to max_batch_size tasks from the queue without blocking
+  // std::vector<PredictTask> get_batch(int max_batch_size) {
+  //   // NOTE: Because the queue lock is released and reacquired between a
+  //   // call to get_earliest_deadline() (which blocks until the queue is
+  //   // not empty) and the call to this method, it's possible for the queue
+  //   // to be empty, in which case the returned vector will have size 0.
+  //   std::unique_lock<std::mutex> l(queue_mutex_);
+  //   remove_tasks_with_elapsed_deadlines();
+  //   std::vector<PredictTask> batch;
+  //   while (batch.size() < (size_t)max_batch_size && queue_.size() > 0) {
+  //     batch.push_back(queue_.top().second);
+  //     queue_.pop();
+  //   }
+  //   return batch;
+  // }
 
  private:
   // Min PriorityQueue so that the task with the earliest
@@ -164,6 +188,7 @@ class ModelQueue {
                           DeadlineCompare>;
   ModelPQueue queue_;
   std::mutex queue_mutex_;
+  std::condition_variable condition_;
 
   // Deletes tasks with deadlines prior or equivalent to the
   // current system time. This method should only be called
@@ -409,6 +434,10 @@ class TaskExecutor {
           "TaskExecutor failed to find previously registered active "
           "container!");
     }
+
+    // TODO TODO TODO: we acquire this lock then potentially block. Can we
+    // unlock it?
+    // I think we can get a deadlock otherwise.
     boost::shared_lock<boost::shared_mutex> l(model_queues_mutex_);
     auto model_queue_entry = model_queues_.find(container->model_);
     if (model_queue_entry == model_queues_.end()) {
@@ -417,52 +446,89 @@ class TaskExecutor {
           "container!");
     }
 
-    boost::optional<Deadline> earliest_deadline =
-        model_queue_entry->second.get_earliest_deadline();
-    if (earliest_deadline) {
-      size_t batch_size = container->get_batch_size(earliest_deadline.get());
-      auto batch = model_queue_entry->second.get_batch(batch_size);
-      if (batch.size() > 0) {
-        // move the lock up here, so that nothing can pull from the
-        // inflight_messages_
-        // map between the time a message is sent and when it gets inserted
-        // into the map
-        std::unique_lock<std::mutex> l(inflight_messages_mutex_);
-        std::vector<InflightMessage> cur_batch;
-        rpc::PredictionRequest prediction_request(container->input_type_);
-        std::stringstream query_ids_in_batch;
-        for (auto b : batch) {
-          prediction_request.add_input(b.input_);
-          cur_batch.emplace_back(b.recv_time_, container->container_id_,
-                                 b.model_, container->replica_id_, b.input_);
-          query_ids_in_batch << b.query_id_ << " ";
-        }
-        int message_id = rpc_->send_message(prediction_request.serialize(),
-                                            container->container_id_);
-        // TODO TODO TODO: but this isn't!!
-        // I wonder if on_container_ready isn't being called?
-        log_info_formatted(
-            LOGGING_TAG_TASK_EXECUTOR,
-            "Sending batch to model: {} replica {}."
-            "Batch size: {}. Query IDs: {}",
-            versioned_model_to_str(model_id), std::to_string(replica_id),
-            std::to_string(batch.size()), query_ids_in_batch.str());
-        inflight_messages_.emplace(message_id, std::move(cur_batch));
-        return;
+    std::vector<PredictTask> batch =
+        model_queue_entry->second.get_batch([container](Deadline deadline) {
+          return container->get_batch_size(deadline);
+        });
+
+    if (batch.size() > 0) {
+      // move the lock up here, so that nothing can pull from the
+      // inflight_messages_
+      // map between the time a message is sent and when it gets inserted
+      // into the map
+      std::unique_lock<std::mutex> l(inflight_messages_mutex_);
+      std::vector<InflightMessage> cur_batch;
+      rpc::PredictionRequest prediction_request(container->input_type_);
+      std::stringstream query_ids_in_batch;
+      for (auto b : batch) {
+        prediction_request.add_input(b.input_);
+        cur_batch.emplace_back(b.recv_time_, container->container_id_, b.model_,
+                               container->replica_id_, b.input_);
+        query_ids_in_batch << b.query_id_ << " ";
       }
+      int message_id = rpc_->send_message(prediction_request.serialize(),
+                                          container->container_id_);
+      log_info_formatted(
+          LOGGING_TAG_TASK_EXECUTOR,
+          "Sending batch to model: {} replica {}."
+          "Batch size: {}. Query IDs: {}",
+          versioned_model_to_str(model_id), std::to_string(replica_id),
+          std::to_string(batch.size()), query_ids_in_batch.str());
+      inflight_messages_.emplace(message_id, std::move(cur_batch));
+
+    } else {
+      log_error_formatted(
+          LOGGING_TAG_TASK_EXECUTOR,
+          "ModelQueue returned empty batch for model {}, replica {}",
+          versioned_model_to_str(model_id), std::to_string(replica_id));
     }
 
-    TaskExecutionThreadPool::submit_job(
-        model_id, replica_id,
-        [ this, model_id, replica_id, task_executor_valid = active_ ]() {
-          if (*task_executor_valid) {
-            on_container_ready(model_id, replica_id);
-          } else {
-            log_info(LOGGING_TAG_TASK_EXECUTOR,
-                     "Not running on_container_ready callback because "
-                     "TaskExecutor has been destroyed.");
-          }
-        });
+    // boost::optional<Deadline> earliest_deadline =
+    //     model_queue_entry->second.get_earliest_deadline();
+
+    // if (earliest_deadline) {
+    //   size_t batch_size = container->get_batch_size(earliest_deadline.get());
+    //   auto batch = model_queue_entry->second.get_batch(batch_size);
+    //   if (batch.size() > 0) {
+    //     // move the lock up here, so that nothing can pull from the
+    //     // inflight_messages_
+    //     // map between the time a message is sent and when it gets inserted
+    //     // into the map
+    //     std::unique_lock<std::mutex> l(inflight_messages_mutex_);
+    //     std::vector<InflightMessage> cur_batch;
+    //     rpc::PredictionRequest prediction_request(container->input_type_);
+    //     std::stringstream query_ids_in_batch;
+    //     for (auto b : batch) {
+    //       prediction_request.add_input(b.input_);
+    //       cur_batch.emplace_back(b.recv_time_, container->container_id_,
+    //                              b.model_, container->replica_id_, b.input_);
+    //       query_ids_in_batch << b.query_id_ << " ";
+    //     }
+    //     int message_id = rpc_->send_message(prediction_request.serialize(),
+    //                                         container->container_id_);
+    //     log_info_formatted(
+    //         LOGGING_TAG_TASK_EXECUTOR,
+    //         "Sending batch to model: {} replica {}."
+    //         "Batch size: {}. Query IDs: {}",
+    //         versioned_model_to_str(model_id), std::to_string(replica_id),
+    //         std::to_string(batch.size()), query_ids_in_batch.str());
+    //     inflight_messages_.emplace(message_id, std::move(cur_batch));
+    //     return;
+    //   }
+    // }
+    //
+    // // TODO TODO TODO: need to block on condition variable
+    // TaskExecutionThreadPool::submit_job(
+    //     model_id, replica_id,
+    //     [ this, model_id, replica_id, task_executor_valid = active_ ]() {
+    //       if (*task_executor_valid) {
+    //         on_container_ready(model_id, replica_id);
+    //       } else {
+    //         log_info(LOGGING_TAG_TASK_EXECUTOR,
+    //                  "Not running on_container_ready callback because "
+    //                  "TaskExecutor has been destroyed.");
+    //       }
+    //     });
   }
 
   void on_response_recv(rpc::RPCResponse response) {

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -400,8 +400,7 @@ class TaskExecutor {
     return queue_created;
   }
 
-  void on_container_ready(VersionedModelId model_id, int replica_id,
-                          int iteration_count = 0) {
+  void on_container_ready(VersionedModelId model_id, int replica_id) {
     std::shared_ptr<ModelContainer> container =
         active_containers_->get_model_replica(model_id, replica_id);
     if (!container) {
@@ -455,7 +454,7 @@ class TaskExecutor {
     TaskExecutionThreadPool::submit_job(
         [ this, model_id, replica_id, task_executor_valid = active_ ]() {
           if (*task_executor_valid) {
-            on_container_ready(model_id, replica_id, iteration_count + 1);
+            on_container_ready(model_id, replica_id);
           } else {
             log_info(LOGGING_TAG_TASK_EXECUTOR,
                      "Not running on_container_ready callback because "

--- a/src/libclipper/include/clipper/threadpool.hpp
+++ b/src/libclipper/include/clipper/threadpool.hpp
@@ -225,13 +225,15 @@ class ThreadPool {
       log_error(LOGGING_TAG_THREADPOOL, error_msg.str());
       throw std::runtime_error(error_msg.str());
     }
-    // work_queue_.push(std::make_unique<TaskType>(std::move(task)));
     return result_future;
   }
 
   static size_t get_queue_id(const VersionedModelId& vm, const int replica_id) {
-    return std::hash<std::string>()(vm.first) ^ std::hash<int>()(vm.second) ^
-           std::hash<int>()(replica_id);
+    std::size_t seed = 0;
+    boost::hash_combine(seed, vm.first);
+    boost::hash_combine(seed, vm.second);
+    boost::hash_combine(seed, replica_id);
+    return seed;
   }
 
  private:
@@ -283,7 +285,6 @@ class ThreadPool {
   boost::shared_mutex queues_mutex_;
   std::unordered_map<size_t, ThreadSafeQueue<std::unique_ptr<IThreadTask>>>
       queues_;
-  // ThreadSafeQueue<std::unique_ptr<IThreadTask>> work_queue_;
   std::unordered_map<size_t, std::thread> threads_;
 };
 
@@ -312,6 +313,6 @@ inline void create_queue(VersionedModelId vm, int replica_id) {
 }
 
 }  // namespace DefaultThreadPool
-}
+}  // namespace clipper
 
 #endif  // CLIPPER_LIB_THREADPOOL_HPP

--- a/src/libclipper/include/clipper/threadpool.hpp
+++ b/src/libclipper/include/clipper/threadpool.hpp
@@ -188,9 +188,10 @@ class ThreadPool {
     } else {
       queues_.emplace(std::piecewise_construct, std::forward_as_tuple(queue_id),
                       std::forward_as_tuple());
-      threads_.emplace(std::piecewise_construct,
-                       std::forward_as_tuple(queue_id),
-                       std::forward_as_tuple(&ThreadPool::worker, this));
+      // std::thread t([this]() {worker();});
+      threads_.emplace(
+          std::piecewise_construct, std::forward_as_tuple(queue_id),
+          std::forward_as_tuple(&ThreadPool::worker, this, queue_id));
     }
   }
 

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -11,7 +11,10 @@
 namespace clipper {
 
 size_t versioned_model_hash(const VersionedModelId &key) {
-  return std::hash<std::string>()(key.first) ^ std::hash<int>()(key.second);
+  std::size_t seed = 0;
+  boost::hash_combine(seed, key.first);
+  boost::hash_combine(seed, key.second);
+  return seed;
 }
 
 std::string versioned_model_to_str(const VersionedModelId &model) {

--- a/src/libclipper/src/rpc_service.cpp
+++ b/src/libclipper/src/rpc_service.cpp
@@ -261,6 +261,8 @@ void RPCService::receive_message(
         connections_containers_map.emplace(
             connection_id,
             std::pair<VersionedModelId, int>(model, cur_replica_id));
+
+        TaskExecutionThreadPool::create_queue(model, cur_replica_id);
         zmq_connection_id += 1;
       }
     } break;

--- a/src/libclipper/src/rpc_service.cpp
+++ b/src/libclipper/src/rpc_service.cpp
@@ -287,10 +287,12 @@ void RPCService::receive_message(
         std::pair<VersionedModelId, int> container_info =
             container_info_entry->second;
 
-        TaskExecutionThreadPool::submit_job(new_response_callback_, response);
-        TaskExecutionThreadPool::submit_job(container_ready_callback_,
-                                            container_info.first,
-                                            container_info.second);
+        VersionedModelId vm = container_info.first;
+        int replica_id = container_info.second;
+        TaskExecutionThreadPool::submit_job(vm, replica_id,
+                                            new_response_callback_, response);
+        TaskExecutionThreadPool::submit_job(
+            vm, replica_id, container_ready_callback_, vm, replica_id);
 
         response_queue_->push(response);
       }

--- a/src/libclipper/test/data_serialization_tests.cpp
+++ b/src/libclipper/test/data_serialization_tests.cpp
@@ -135,7 +135,8 @@ TEST(InputSerializationTests, IntSerialization) {
   ASSERT_EQ(static_cast<size_t>(raw_input_header_size[0]), input_header.size());
   long* raw_input_content_size =
       reinterpret_cast<long*>(input_content_size.data());
-  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_content_size[0]),
+            input_content.size());
 
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
@@ -189,10 +190,11 @@ TEST(InputSerializationTests, FloatSerialization) {
 
   long* raw_input_header_size =
       reinterpret_cast<long*>(input_header_size.data());
-  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_header_size[0]), input_header.size());
   long* raw_input_content_size =
       reinterpret_cast<long*>(input_content_size.data());
-  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_content_size[0]),
+            input_content.size());
 
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
@@ -247,10 +249,11 @@ TEST(InputSerializationTests, DoubleSerialization) {
 
   long* raw_input_header_size =
       reinterpret_cast<long*>(input_header_size.data());
-  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_header_size[0]), input_header.size());
   long* raw_input_content_size =
       reinterpret_cast<long*>(input_content_size.data());
-  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_content_size[0]),
+            input_content.size());
 
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
@@ -305,10 +308,11 @@ TEST(InputSerializationTests, StringSerialization) {
 
   long* raw_input_header_size =
       reinterpret_cast<long*>(input_header_size.data());
-  ASSERT_EQ(raw_input_header_size[0], input_header.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_header_size[0]), input_header.size());
   long* raw_input_content_size =
       reinterpret_cast<long*>(input_content_size.data());
-  ASSERT_EQ(raw_input_content_size[0], input_content.size());
+  ASSERT_EQ(static_cast<size_t>(raw_input_content_size[0]),
+            input_content.size());
 
   uint32_t* raw_request_type =
       reinterpret_cast<uint32_t*>(request_header.data());
@@ -550,7 +554,7 @@ TEST(OutputDeserializationTests, PredictionResponseDeserialization) {
 
   rpc::PredictionResponse response =
       rpc::PredictionResponse::deserialize_prediction_response(buf);
-  ASSERT_EQ(response.outputs_.size(), 2);
+  ASSERT_EQ(response.outputs_.size(), static_cast<size_t>(2));
   ASSERT_EQ(response.outputs_[0], first_string);
   ASSERT_EQ(response.outputs_[1], second_string);
 }

--- a/src/libclipper/test/task_executor_test.cpp
+++ b/src/libclipper/test/task_executor_test.cpp
@@ -62,102 +62,64 @@ TEST(TaskExecutorTests, TestDeadlineComparisonsWorkCorrectly) {
 }
 
 TEST(ModelQueueTests, TestGetBatchQueueNotEmpty) {
-  // TODO
+  PredictTask task_a = create_predict_task(1, 10000);
+  PredictTask task_b = create_predict_task(2, 10000);
+  PredictTask task_c = create_predict_task(3, 10000);
+
+  ModelQueue model_queue;
+
+  model_queue.add_task(task_a);
+  model_queue.add_task(task_b);
+  model_queue.add_task(task_c);
+
+  std::vector<PredictTask> tasks =
+      model_queue.get_batch([](Deadline) { return 3; });
+
+  // Because we added tasks a through c in alphabetical
+  // order with the same latency slos, we expect the model
+  // queue's get_batch() function to return them in the same order
+  ASSERT_EQ(tasks[0].query_id_, task_a.query_id_);
+  ASSERT_EQ(tasks[1].query_id_, task_b.query_id_);
+  ASSERT_EQ(tasks[2].query_id_, task_c.query_id_);
 }
 
-TEST(ModelQueueTests, TestGetBatchQueueEmpty) {
-  // TODO
-}
+TEST(ModelQueueTests, TestGetBatchOrdersByEarliestDeadline) {
+  PredictTask task_a = create_predict_task(1, 20000);
+  PredictTask task_b = create_predict_task(2, 10000);
+  PredictTask task_c = create_predict_task(3, 30000);
 
-TEST(ModelQueueTests, TestGetBatchOrdersOnEarliestDeadline) {
-  // TODO
+  ModelQueue model_queue;
+
+  model_queue.add_task(task_a);
+  model_queue.add_task(task_b);
+  model_queue.add_task(task_c);
+
+  std::vector<PredictTask> tasks =
+      model_queue.get_batch([](Deadline) { return 3; });
+
+  // Because we added tasks a through c in alphabetical
+  // order with the same latency slos, we expect the model
+  // queue's get_batch() function to return them in the same order
+  ASSERT_EQ(tasks[0].query_id_, task_b.query_id_);
+  ASSERT_EQ(tasks[1].query_id_, task_a.query_id_);
+  ASSERT_EQ(tasks[2].query_id_, task_c.query_id_);
 }
 
 TEST(ModelQueueTests, TestGetBatchRemovesTasksWithElapsedDeadline) {
-  // TODO
-}
+  PredictTask task_a = create_predict_task(1, 0);
+  PredictTask task_b = create_predict_task(2, 0);
+  PredictTask task_c = create_predict_task(3, 10000);
 
-// TEST(TaskExecutorTests, ModelQueueOrdersElementsOnEarliestDeadline) {
-//   PredictTask task_a = create_predict_task(1, 10000);
-//   PredictTask task_b = create_predict_task(2, 10000);
-//   PredictTask task_c = create_predict_task(3, 10000);
-//
-//   ModelQueue model_queue;
-//
-//   model_queue.add_task(task_a);
-//   model_queue.add_task(task_b);
-//   model_queue.add_task(task_c);
-//
-//   PredictTask first_task = model_queue.get_batch(1)[0];
-//   PredictTask second_task = model_queue.get_batch(1)[0];
-//   PredictTask third_task = model_queue.get_batch(1)[0];
-//
-//   // Because we added tasks a through c in alphabetical
-//   // order with the same latency slos, we expect the model
-//   // queue's get_batch() function to return them in the same order
-//   ASSERT_EQ(first_task.query_id_, task_a.query_id_);
-//   ASSERT_EQ(second_task.query_id_, task_b.query_id_);
-//   ASSERT_EQ(third_task.query_id_, task_c.query_id_);
-//
-//   std::vector<PredictTask> curr_batch = model_queue.get_batch(1);
-//   ASSERT_TRUE(curr_batch.empty());
-//
-//   model_queue.add_task(task_c);
-//   model_queue.add_task(task_b);
-//   model_queue.add_task(task_a);
-//
-//   first_task = model_queue.get_batch(1)[0];
-//   second_task = model_queue.get_batch(1)[0];
-//   third_task = model_queue.get_batch(1)[0];
-//
-//   // Because we added tasks a through c in reverse alphabetical
-//   // order with the same latency slos, we expect the model
-//   // queue's get_batch() function to return them in reverse alphabetical
-//   order
-//   ASSERT_EQ(first_task.query_id_, task_c.query_id_);
-//   ASSERT_EQ(second_task.query_id_, task_b.query_id_);
-//   ASSERT_EQ(third_task.query_id_, task_a.query_id_);
-// }
-//
-// TEST(TaskExecutorTests, ModelQueueGetBatchRemovesTasksWithElapsedDeadlines) {
-//   PredictTask task_a = create_predict_task(1, 0);
-//   PredictTask task_b = create_predict_task(2, 0);
-//   PredictTask task_c = create_predict_task(3, 100000);
-//
-//   ModelQueue model_queue;
-//
-//   model_queue.add_task(task_a);
-//   model_queue.add_task(task_b);
-//   model_queue.add_task(task_c);
-//
-//   std::vector<PredictTask> tasks = model_queue.get_batch(3);
-//   // Tasks A and B have elapsed deadlines, so the model queue
-//   // should return a batch containing only Task C
-//   ASSERT_EQ(tasks.size(), 1);
-//   ASSERT_EQ(tasks[0].query_id_, task_c.query_id_);
-// }
-//
-// TEST(TaskExecutorTests,
-//      ModelQueueGetEarliestDeadlineRemovesTasksWithElapsedDeadlines) {
-//   PredictTask task_a = create_predict_task(1, 0);
-//   PredictTask task_b = create_predict_task(2, 0);
-//   PredictTask task_c = create_predict_task(3, 100000);
-//
-//   ModelQueue model_queue;
-//
-//   model_queue.add_task(task_a);
-//   model_queue.add_task(task_b);
-//
-//   // Tasks A and B have elapsed deadlines, so the model queue
-//   // should indicate that there is no earliest deadline
-//   boost::optional<Deadline> earliest_deadline =
-//       model_queue.get_earliest_deadline();
-//   ASSERT_FALSE(earliest_deadline);
-//
-//   model_queue.add_task(task_c);
-//   earliest_deadline = model_queue.get_earliest_deadline();
-//   // Task C's deadline has not elapsed, so the model queue
-//   // should return an earliest deadline
-//   ASSERT_TRUE(earliest_deadline);
-// }
+  ModelQueue model_queue;
+
+  model_queue.add_task(task_a);
+  model_queue.add_task(task_b);
+  model_queue.add_task(task_c);
+
+  std::vector<PredictTask> tasks =
+      model_queue.get_batch([](Deadline) { return 3; });
+
+  ASSERT_EQ(tasks.size(), (size_t)1);
+  ASSERT_EQ(tasks[0].query_id_, task_c.query_id_);
+}
 }

--- a/src/libclipper/test/task_executor_test.cpp
+++ b/src/libclipper/test/task_executor_test.cpp
@@ -61,6 +61,22 @@ TEST(TaskExecutorTests, TestDeadlineComparisonsWorkCorrectly) {
   ASSERT_TRUE(later_greater_than_earlier);
 }
 
+TEST(ModelQueueTests, TestGetBatchQueueNotEmpty) {
+  // TODO
+}
+
+TEST(ModelQueueTests, TestGetBatchQueueEmpty) {
+  // TODO
+}
+
+TEST(ModelQueueTests, TestGetBatchOrdersOnEarliestDeadline) {
+  // TODO
+}
+
+TEST(ModelQueueTests, TestGetBatchRemovesTasksWithElapsedDeadline) {
+  // TODO
+}
+
 // TEST(TaskExecutorTests, ModelQueueOrdersElementsOnEarliestDeadline) {
 //   PredictTask task_a = create_predict_task(1, 10000);
 //   PredictTask task_b = create_predict_task(2, 10000);

--- a/src/libclipper/test/task_executor_test.cpp
+++ b/src/libclipper/test/task_executor_test.cpp
@@ -61,86 +61,87 @@ TEST(TaskExecutorTests, TestDeadlineComparisonsWorkCorrectly) {
   ASSERT_TRUE(later_greater_than_earlier);
 }
 
-TEST(TaskExecutorTests, ModelQueueOrdersElementsOnEarliestDeadline) {
-  PredictTask task_a = create_predict_task(1, 10000);
-  PredictTask task_b = create_predict_task(2, 10000);
-  PredictTask task_c = create_predict_task(3, 10000);
-
-  ModelQueue model_queue;
-
-  model_queue.add_task(task_a);
-  model_queue.add_task(task_b);
-  model_queue.add_task(task_c);
-
-  PredictTask first_task = model_queue.get_batch(1)[0];
-  PredictTask second_task = model_queue.get_batch(1)[0];
-  PredictTask third_task = model_queue.get_batch(1)[0];
-
-  // Because we added tasks a through c in alphabetical
-  // order with the same latency slos, we expect the model
-  // queue's get_batch() function to return them in the same order
-  ASSERT_EQ(first_task.query_id_, task_a.query_id_);
-  ASSERT_EQ(second_task.query_id_, task_b.query_id_);
-  ASSERT_EQ(third_task.query_id_, task_c.query_id_);
-
-  std::vector<PredictTask> curr_batch = model_queue.get_batch(1);
-  ASSERT_TRUE(curr_batch.empty());
-
-  model_queue.add_task(task_c);
-  model_queue.add_task(task_b);
-  model_queue.add_task(task_a);
-
-  first_task = model_queue.get_batch(1)[0];
-  second_task = model_queue.get_batch(1)[0];
-  third_task = model_queue.get_batch(1)[0];
-
-  // Because we added tasks a through c in reverse alphabetical
-  // order with the same latency slos, we expect the model
-  // queue's get_batch() function to return them in reverse alphabetical order
-  ASSERT_EQ(first_task.query_id_, task_c.query_id_);
-  ASSERT_EQ(second_task.query_id_, task_b.query_id_);
-  ASSERT_EQ(third_task.query_id_, task_a.query_id_);
-}
-
-TEST(TaskExecutorTests, ModelQueueGetBatchRemovesTasksWithElapsedDeadlines) {
-  PredictTask task_a = create_predict_task(1, 0);
-  PredictTask task_b = create_predict_task(2, 0);
-  PredictTask task_c = create_predict_task(3, 100000);
-
-  ModelQueue model_queue;
-
-  model_queue.add_task(task_a);
-  model_queue.add_task(task_b);
-  model_queue.add_task(task_c);
-
-  std::vector<PredictTask> tasks = model_queue.get_batch(3);
-  // Tasks A and B have elapsed deadlines, so the model queue
-  // should return a batch containing only Task C
-  ASSERT_EQ(tasks.size(), 1);
-  ASSERT_EQ(tasks[0].query_id_, task_c.query_id_);
-}
-
-TEST(TaskExecutorTests,
-     ModelQueueGetEarliestDeadlineRemovesTasksWithElapsedDeadlines) {
-  PredictTask task_a = create_predict_task(1, 0);
-  PredictTask task_b = create_predict_task(2, 0);
-  PredictTask task_c = create_predict_task(3, 100000);
-
-  ModelQueue model_queue;
-
-  model_queue.add_task(task_a);
-  model_queue.add_task(task_b);
-
-  // Tasks A and B have elapsed deadlines, so the model queue
-  // should indicate that there is no earliest deadline
-  boost::optional<Deadline> earliest_deadline =
-      model_queue.get_earliest_deadline();
-  ASSERT_FALSE(earliest_deadline);
-
-  model_queue.add_task(task_c);
-  earliest_deadline = model_queue.get_earliest_deadline();
-  // Task C's deadline has not elapsed, so the model queue
-  // should return an earliest deadline
-  ASSERT_TRUE(earliest_deadline);
-}
+// TEST(TaskExecutorTests, ModelQueueOrdersElementsOnEarliestDeadline) {
+//   PredictTask task_a = create_predict_task(1, 10000);
+//   PredictTask task_b = create_predict_task(2, 10000);
+//   PredictTask task_c = create_predict_task(3, 10000);
+//
+//   ModelQueue model_queue;
+//
+//   model_queue.add_task(task_a);
+//   model_queue.add_task(task_b);
+//   model_queue.add_task(task_c);
+//
+//   PredictTask first_task = model_queue.get_batch(1)[0];
+//   PredictTask second_task = model_queue.get_batch(1)[0];
+//   PredictTask third_task = model_queue.get_batch(1)[0];
+//
+//   // Because we added tasks a through c in alphabetical
+//   // order with the same latency slos, we expect the model
+//   // queue's get_batch() function to return them in the same order
+//   ASSERT_EQ(first_task.query_id_, task_a.query_id_);
+//   ASSERT_EQ(second_task.query_id_, task_b.query_id_);
+//   ASSERT_EQ(third_task.query_id_, task_c.query_id_);
+//
+//   std::vector<PredictTask> curr_batch = model_queue.get_batch(1);
+//   ASSERT_TRUE(curr_batch.empty());
+//
+//   model_queue.add_task(task_c);
+//   model_queue.add_task(task_b);
+//   model_queue.add_task(task_a);
+//
+//   first_task = model_queue.get_batch(1)[0];
+//   second_task = model_queue.get_batch(1)[0];
+//   third_task = model_queue.get_batch(1)[0];
+//
+//   // Because we added tasks a through c in reverse alphabetical
+//   // order with the same latency slos, we expect the model
+//   // queue's get_batch() function to return them in reverse alphabetical
+//   order
+//   ASSERT_EQ(first_task.query_id_, task_c.query_id_);
+//   ASSERT_EQ(second_task.query_id_, task_b.query_id_);
+//   ASSERT_EQ(third_task.query_id_, task_a.query_id_);
+// }
+//
+// TEST(TaskExecutorTests, ModelQueueGetBatchRemovesTasksWithElapsedDeadlines) {
+//   PredictTask task_a = create_predict_task(1, 0);
+//   PredictTask task_b = create_predict_task(2, 0);
+//   PredictTask task_c = create_predict_task(3, 100000);
+//
+//   ModelQueue model_queue;
+//
+//   model_queue.add_task(task_a);
+//   model_queue.add_task(task_b);
+//   model_queue.add_task(task_c);
+//
+//   std::vector<PredictTask> tasks = model_queue.get_batch(3);
+//   // Tasks A and B have elapsed deadlines, so the model queue
+//   // should return a batch containing only Task C
+//   ASSERT_EQ(tasks.size(), 1);
+//   ASSERT_EQ(tasks[0].query_id_, task_c.query_id_);
+// }
+//
+// TEST(TaskExecutorTests,
+//      ModelQueueGetEarliestDeadlineRemovesTasksWithElapsedDeadlines) {
+//   PredictTask task_a = create_predict_task(1, 0);
+//   PredictTask task_b = create_predict_task(2, 0);
+//   PredictTask task_c = create_predict_task(3, 100000);
+//
+//   ModelQueue model_queue;
+//
+//   model_queue.add_task(task_a);
+//   model_queue.add_task(task_b);
+//
+//   // Tasks A and B have elapsed deadlines, so the model queue
+//   // should indicate that there is no earliest deadline
+//   boost::optional<Deadline> earliest_deadline =
+//       model_queue.get_earliest_deadline();
+//   ASSERT_FALSE(earliest_deadline);
+//
+//   model_queue.add_task(task_c);
+//   earliest_deadline = model_queue.get_earliest_deadline();
+//   // Task C's deadline has not elapsed, so the model queue
+//   // should return an earliest deadline
+//   ASSERT_TRUE(earliest_deadline);
+// }
 }


### PR DESCRIPTION
The `TaskExecutor::on_container_ready()` method repeatedly called itself if there was no work for a given container. This could lead to containers for inactive models starving other containers by filling up the ThreadPool queue.

This change creates a queue and worker in the threadpool for each active container to prevent starvation. I think this change plus the one in #153 should fix #148.