### PR TITLE
[CLIPPER-155] Restart containers, persistent & remote redis

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 
 services:
   redis:
+    restart: always
     image: redis:alpine
     cpuset: "0"
     ports:
@@ -11,6 +12,7 @@ services:
 
 
   query_frontend:
+    restart: always
     image: "clipper/query_frontend"
     depends_on:
       - redis
@@ -25,6 +27,7 @@ services:
       - "ai.clipper.container.label"
 
   mgmt_frontend:
+    restart: always
     image: "clipper/management_frontend"
     depends_on:
       - redis

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,17 +2,16 @@ version: '2'
 
 services:
   redis:
-    restart: always
     image: redis:alpine
     cpuset: "0"
     ports:
       - "6379:6379"
     labels:
       - "ai.clipper.container.label"
-
+    volumes:
+      - /tmp/clipper_redis_data:/data
 
   query_frontend:
-    restart: always
     image: "clipper/query_frontend"
     depends_on:
       - redis
@@ -27,7 +26,6 @@ services:
       - "ai.clipper.container.label"
 
   mgmt_frontend:
-    restart: always
     image: "clipper/management_frontend"
     depends_on:
       - redis

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -28,10 +28,8 @@ class BenchmarkException(Exception):
     def __str__(self):
         return repr(self.parameter)
 
-
 # range of ports where available ports can be found
 PORT_RANGE = [34256, 40000]
-
 
 def find_unbound_port():
     """
@@ -45,7 +43,6 @@ def find_unbound_port():
             return port
         except socket.error:
             print("randomly generated port %d is bound. Trying again." % port)
-
 
 def init_clipper():
     clipper = cm.Clipper("localhost", redis_port=find_unbound_port())

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -28,8 +28,10 @@ class BenchmarkException(Exception):
     def __str__(self):
         return repr(self.parameter)
 
+
 # range of ports where available ports can be found
 PORT_RANGE = [34256, 40000]
+
 
 def find_unbound_port():
     """
@@ -43,6 +45,7 @@ def find_unbound_port():
             return port
         except socket.error:
             print("randomly generated port %d is bound. Trying again." % port)
+
 
 def init_clipper():
     clipper = cm.Clipper("localhost", redis_port=find_unbound_port())

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -116,8 +116,10 @@ class Clipper:
             },
             'services': {
                 'mgmt_frontend': {
-                    'command':
-                    ['--redis_ip=%s' % self.redis_ip, '--redis_port=%d' % self.redis_port],
+                    'command': [
+                        '--redis_ip=%s' % self.redis_ip,
+                        '--redis_port=%d' % self.redis_port
+                    ],
                     'image':
                     'clipper/management_frontend:latest',
                     'ports': [
@@ -129,8 +131,10 @@ class Clipper:
                     }
                 },
                 'query_frontend': {
-                    'command':
-                    ['--redis_ip=%s' % self.redis_ip, '--redis_port=%d' % self.redis_port],
+                    'command': [
+                        '--redis_ip=%s' % self.redis_ip,
+                        '--redis_port=%d' % self.redis_port
+                    ],
                     'depends_on': ['mgmt_frontend'],
                     'image':
                     'clipper/query_frontend:latest',
@@ -145,20 +149,27 @@ class Clipper:
         start_redis = (self.redis_ip == DEFAULT_REDIS_IP)
         if start_redis:
             self.docker_compost_dict['services']['redis'] = {
-                    'image': 'redis:alpine',
-                    'ports': ['%d:%d' % (self.redis_port, self.redis_port)],
-                    'command': "redis-server --port %d" % self.redis_port
-                }
-            self.docker_compost_dict['services']['mgmt_frontend']['depends_on'] = ['redis']
-            self.docker_compost_dict['services']['query_frontend']['depends_on'].append('redis')
+                'image': 'redis:alpine',
+                'ports': ['%d:%d' % (self.redis_port, self.redis_port)],
+                'command': "redis-server --port %d" % self.redis_port
+            }
+            self.docker_compost_dict['services']['mgmt_frontend'][
+                'depends_on'] = ['redis']
+            self.docker_compost_dict['services']['query_frontend'][
+                'depends_on'].append('redis')
             if redis_persistence_path:
-                self.docker_compost_dict['services']['redis']['volumes'] = ['%s:/data' % redis_persistence_path]
+                self.docker_compost_dict['services']['redis']['volumes'] = [
+                    '%s:/data' % redis_persistence_path
+                ]
 
         if restart_containers:
-            self.docker_compost_dict['services']['mgmt_frontend']['restart'] = 'always'
-            self.docker_compost_dict['services']['query_frontend']['restart'] = 'always'
+            self.docker_compost_dict['services']['mgmt_frontend'][
+                'restart'] = 'always'
+            self.docker_compost_dict['services']['query_frontend'][
+                'restart'] = 'always'
             if start_redis:
-                self.docker_compost_dict['services']['redis']['restart'] = 'always'
+                self.docker_compost_dict['services']['redis'][
+                    'restart'] = 'always'
 
         self.sudo = sudo
         self.host = host

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -73,6 +73,18 @@ class Clipper:
         The SSH port to use. Default is port 22.
     check_for_docker : bool, optional
         If True, checks that Docker is running on the host machine. Default is True.
+    redis_port : int, optional
+        The port to use for connecting to redis. Default is port 6379.
+    redis_ip : string, optional
+        The ip address of the redis instance that Clipper should use.
+        If unspecified, a docker container running redis will be started
+        on `host` at the port specified by `redis_port`
+    redis_persistence_path : string, optional
+        The path to which redis data should be persisted. If unspecified,
+        redis will not persist data to disk
+    restart_containers : bool, optional
+        If true, containers will restart on failure. If false, containers
+        will not restart automatically.
 
     Sets up the machine for running Clipper. This includes verifying
     SSH credentials and initializing Docker.

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -80,9 +80,8 @@ class Clipper:
         If unspecified, a docker container running redis will be started
         on `host` at the port specified by `redis_port`.
     redis_persistence_path : string, optional
-        The directory path to which redis data should be persisted. If the
-        directory does not already exist, it will be created. If unspecified,
-        redis will not persist data to disk. 
+        The directory path to which redis data should be persisted. The directory
+        should not already exist. If unspecified, redis will not persist data to disk. 
     restart_containers : bool, optional
         If true, containers will restart on failure. If false, containers
         will not restart automatically.
@@ -159,9 +158,16 @@ class Clipper:
             self.docker_compost_dict['services']['query_frontend'][
                 'depends_on'].append('redis')
             if redis_persistence_path:
-                self.docker_compost_dict['services']['redis']['volumes'] = [
-                    '%s:/data' % redis_persistence_path
-                ]
+                if not os.path.exists(redis_persistence_path):
+                    self.docker_compost_dict['services']['redis'][
+                        'volumes'] = ['%s:/data' % redis_persistence_path]
+                else:
+                    print(
+                        "The directory specified by the redis persistence path already exists"
+                    )
+                    raise ClipperManagerException(
+                        "The directory specified by the redis persistence path already exists"
+                    )
 
         if restart_containers:
             self.docker_compost_dict['services']['mgmt_frontend'][

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -78,10 +78,10 @@ class Clipper:
     redis_ip : string, optional
         The ip address of the redis instance that Clipper should use.
         If unspecified, a docker container running redis will be started
-        on `host` at the port specified by `redis_port`
+        on `host` at the port specified by `redis_port`.
     redis_persistence_path : string, optional
         The path to which redis data should be persisted. If unspecified,
-        redis will not persist data to disk
+        redis will not persist data to disk.
     restart_containers : bool, optional
         If true, containers will restart on failure. If false, containers
         will not restart automatically.

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -87,7 +87,8 @@ class Clipper:
                  sudo=False,
                  ssh_port=22,
                  check_for_docker=True,
-                 redis_port=REDIS_PORT):
+                 redis_port=REDIS_PORT,
+                 restart_containers=False):
 
         self.redis_port = redis_port
         self.docker_compost_dict = {
@@ -138,6 +139,9 @@ class Clipper:
             },
             'version': '2'
         }
+        if restart_containers:
+            self.docker_compost_dict['services']['mgmt_frontend']['restart'] = 'always'
+
         self.sudo = sudo
         self.host = host
         if self._host_is_local():

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -138,7 +138,6 @@ class Clipper:
             },
             'version': '2'
         }
-
         self.sudo = sudo
         self.host = host
         if self._host_is_local():

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -80,8 +80,9 @@ class Clipper:
         If unspecified, a docker container running redis will be started
         on `host` at the port specified by `redis_port`.
     redis_persistence_path : string, optional
-        The path to which redis data should be persisted. If unspecified,
-        redis will not persist data to disk.
+        The directory path to which redis data should be persisted. If the
+        directory does not already exist, it will be created. If unspecified,
+        redis will not persist data to disk. 
     restart_containers : bool, optional
         If true, containers will restart on failure. If false, containers
         will not restart automatically.
@@ -100,10 +101,10 @@ class Clipper:
                  sudo=False,
                  ssh_port=22,
                  check_for_docker=True,
-                 redis_port=DEFAULT_REDIS_PORT,
                  redis_ip=DEFAULT_REDIS_IP,
+                 redis_port=DEFAULT_REDIS_PORT,
                  redis_persistence_path=None,
-                 restart_containers=False):
+                 restart_containers=True):
         self.redis_ip = redis_ip
         self.redis_port = redis_port
         self.docker_compost_dict = {
@@ -854,7 +855,8 @@ class Clipper:
         Returns
         ----------
         bool
-            Whether or not the container was added successfully
+            True if the container was added successfully and False
+            if the container could not be added.
         """
         with hide("warnings", "output", "running"):
             # Look up model info in Redis


### PR DESCRIPTION
Adds support for automatic restarting of containers in the case of failure. Additionally, modifies Clipper manager to support specification of a remote redis server or a path for redis data persistence (if redis was started in a docker container by the manager).