### PR TITLE
Reduce query frontend cpu

### DIFF
--- a/src/libclipper/include/clipper/timers.hpp
+++ b/src/libclipper/include/clipper/timers.hpp
@@ -2,6 +2,7 @@
 #define CLIPPER_LIB_TIMERS_H
 
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <mutex>
 #include <queue>
@@ -117,18 +118,26 @@ class TimerSystem {
   TimerSystem &operator=(TimerSystem &&) = default;
 
   void start() {
-    manager_thread_ = boost::thread(&TimerSystem::manage_timers, this);
+    manager_thread_ = std::thread(&TimerSystem::manage_timers, this);
     initialized_ = true;
   }
 
   void manage_timers() {
-    log_info(LOGGING_TAG_TIMERS, "In timer event loop");
+    log_info(LOGGING_TAG_TIMERS, "Starting timer event loop");
     while (!shutdown_) {
       // wait for next timer to expire
       //    auto cur_time = high_resolution_clock::now();
       auto cur_time = clock_.now();
-      std::unique_lock<std::mutex> l(queue_mutex_);
+      std::unique_lock<std::mutex> lock(queue_mutex_);
+
+      if (queue_.empty()) {
+        log_info(LOGGING_TAG_TIMERS, "Timer queue empty");
+        queue_not_empty_condition_.wait_for(
+            lock, std::chrono::milliseconds(100),
+            [this]() { return !queue_.empty(); });
+      }
       if (queue_.size() > 0) {
+        // log_info(LOGGING_TAG_TIMERS, "Timer found");
         auto earliest_timer = queue_.top();
         auto duration_ms =
             std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -156,6 +165,7 @@ class TimerSystem {
     //  Timer timer{tp, promise};
     std::unique_lock<std::mutex> l(queue_mutex_);
     queue_.emplace(std::make_shared<Timer>(tp, std::move(promise)));
+    queue_not_empty_condition_.notify_all();
     return f;
   }
 
@@ -169,9 +179,10 @@ class TimerSystem {
  private:
   std::atomic<bool> shutdown_{false};
   std::atomic<bool> initialized_{false};
-  boost::thread manager_thread_;
+  std::thread manager_thread_;
 
   std::mutex queue_mutex_;
+  std::condition_variable queue_not_empty_condition_;
   TimerPQueue queue_;
 };
 

--- a/src/libclipper/include/clipper/timers.hpp
+++ b/src/libclipper/include/clipper/timers.hpp
@@ -4,10 +4,10 @@
 #include <atomic>
 #include <cassert>
 #include <chrono>
+#include <condition_variable>
 #include <mutex>
 #include <queue>
 #include <thread>
-#include <condition_variable>
 
 #include <boost/thread.hpp>
 

--- a/src/libclipper/test/timers_test.cpp
+++ b/src/libclipper/test/timers_test.cpp
@@ -85,11 +85,8 @@ TEST_F(TimerSystemTests, ManyTimers) {
   int num_timers = 10000;
   for (int i = 0; i < num_timers; ++i) {
     int expiration_time = dist(generator);
-    // std::cout << expiration_time << ", ";
     created_timers.emplace(expiration_time, ts_.set_timer(expiration_time));
   }
-  // std::this_thread::sleep_for(10ms);
-  // std::cout << std::endl;
   int time_increment = 10;
   for (int cur_time = 0; cur_time <= max_time; cur_time += time_increment) {
     ts_.clock_.increment(time_increment);
@@ -107,8 +104,3 @@ TEST_F(TimerSystemTests, ManyTimers) {
 }
 
 }  // namespace
-
-// int main(int argc, char** argv) {
-//   ::testing::InitGoogleTest(&argc, argv);
-//   return RUN_ALL_TESTS();
-// }


### PR DESCRIPTION
This PR removes all busy waits and dramatically reduces the query_frontend's CPU usage when Clipper is idle. From testing on an ubuntu server, the `clipper/query_frontend` docker container uses 200% CPU while idle (no applications or models registered, no containers connect) before this change, and about 1.5% CPU after this change.

I think this should fix #154.