### PR TITLE
Makes integration test length configurable

### DIFF
--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -117,7 +117,7 @@ function run_frontend_tests {
 function run_integration_tests {
   echo -e "\nRunning integration tests\n\n"
   cd $DIR
-  python ../integration-tests/light_load_all_functionality.py
+  python ../integration-tests/light_load_all_functionality.py 2 3
 }
 
 function run_all_tests {

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -96,7 +96,7 @@ def deploy_model(clipper, name, version):
                                  (app_name, model_name, version))
 
 
-def create_and_test_app(clipper, name):
+def create_and_test_app(clipper, name, num_models):
     app_name = "%s_app" % name
     model_name = "%s_model" % name
     clipper.register_application(app_name, model_name, "doubles",
@@ -114,22 +114,29 @@ def create_and_test_app(clipper, name):
         print("Error: %s" % response.text)
         raise BenchmarkException("Error creating app %s" % app_name)
 
-    for i in range(8):
+    for i in range(num_models):
         deploy_model(clipper, name, i)
         time.sleep(1)
 
 
 if __name__ == "__main__":
+    num_apps = 6
+    num_models = 8
+    try:
+        if len(sys.argv) > 1:
+            num_apps = int(sys.argv[1])
+        if len(sys.argv) > 2:
+            num_models = int(sys.argv[2])
+    except:
+        # it's okay to pass here, just use the default values
+        # for num_apps and num_models
+        pass
     try:
         clipper = init_clipper()
         try:
-            create_and_test_app(clipper, "aa")
-            create_and_test_app(clipper, "bb")
-            create_and_test_app(clipper, "cc")
-            create_and_test_app(clipper, "dd")
-            create_and_test_app(clipper, "ee")
-            create_and_test_app(clipper, "ff")
-            create_and_test_app(clipper, "gg")
+            print("Running integration test with %d apps and %d models" % (num_apps, num_models))
+            for a in range(num_apps):
+                create_and_test_app(clipper, "app_%s" % a, num_models)
             print(clipper.get_clipper_logs())
             print("SUCCESS")
         except BenchmarkException as e:

--- a/integration-tests/light_load_all_functionality.py
+++ b/integration-tests/light_load_all_functionality.py
@@ -134,7 +134,8 @@ if __name__ == "__main__":
     try:
         clipper = init_clipper()
         try:
-            print("Running integration test with %d apps and %d models" % (num_apps, num_models))
+            print("Running integration test with %d apps and %d models" %
+                  (num_apps, num_models))
             for a in range(num_apps):
                 create_and_test_app(clipper, "app_%s" % a, num_models)
             print(clipper.get_clipper_logs())

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -141,7 +141,10 @@ class Clipper:
                     'ports': [
                         '%d:%d' % (CLIPPER_RPC_PORT, CLIPPER_RPC_PORT),
                         '%d:%d' % (CLIPPER_QUERY_PORT, CLIPPER_QUERY_PORT)
-                    ]
+                    ],
+                    'labels': {
+                        CLIPPER_DOCKER_LABEL: ""
+                    }
                 }
             },
             'version': '2'
@@ -151,7 +154,10 @@ class Clipper:
             self.docker_compost_dict['services']['redis'] = {
                 'image': 'redis:alpine',
                 'ports': ['%d:%d' % (self.redis_port, self.redis_port)],
-                'command': "redis-server --port %d" % self.redis_port
+                'command': "redis-server --port %d" % self.redis_port,
+                'labels': {
+                    CLIPPER_DOCKER_LABEL: ""
+                    }
             }
             self.docker_compost_dict['services']['mgmt_frontend'][
                 'depends_on'] = ['redis']

--- a/management/clipper_manager.py
+++ b/management/clipper_manager.py
@@ -157,7 +157,7 @@ class Clipper:
                 'command': "redis-server --port %d" % self.redis_port,
                 'labels': {
                     CLIPPER_DOCKER_LABEL: ""
-                    }
+                }
             }
             self.docker_compost_dict['services']['mgmt_frontend'][
                 'depends_on'] = ['redis']


### PR DESCRIPTION
This reduces the length of the integration tests so our PRBs run faster. It also adds back in the docker container labeling that accidentally got lost in a merge.