### PR TITLE
Added redis persistence

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     labels:
       - "ai.clipper.container.label"
     volumes:
-      - /tmp/clipper_redis_data:/data
+      - redisdata:/data
 
   query_frontend:
     image: "clipper/query_frontend"
@@ -36,3 +36,6 @@ services:
       - "--redis_port=6379"
     labels:
       - "ai.clipper.container.label"
+
+volumes:
+  redisdata:


### PR DESCRIPTION
If `redis_persistence_path` is set, redis will persist data to disk.

I also removed unnecessary check for existence of redis path. Docker will use the volume if it exists.