### PR TITLE
Remove conda from clipper_admin pip dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 
 setup(
     name='clipper_admin',
-    version='0.1.1',
+    version='0.1.2',
     description='Admin commands for the Clipper prediction-serving system',
     author='Dan Crankshaw',
     author_email='crankshaw@cs.berkeley.edu',
@@ -12,5 +12,5 @@ setup(
     keywords=['clipper', 'prediction', 'model', 'management'],
     install_requires=[
         'requests', 'pyparsing', 'appdirs', 'pprint', 'subprocess32',
-        'sklearn', 'numpy', 'scipy', 'fabric', 'conda', 'pyyaml'
+        'sklearn', 'numpy', 'scipy', 'fabric', 'pyyaml'
     ])


### PR DESCRIPTION
With conda as a dep, when you `pip install clipper_admin` pip installs conda as well which ends up breaking conda with this message:

```
ERROR: The install method you used for conda--probably either `pip install conda`
or `easy_install conda`--is not compatible with using conda as an application.
If your intention is to install conda as a standalone application, currently
supported install methods include the Anaconda installer and the miniconda
installer.  You can download the miniconda installer from
https://conda.io/miniconda.html.
```