### PR TITLE
Python3 issue in clipper_manager.deploy_predict_function

### DIFF
--- a/clipper_admin/check_and_write_deps.py
+++ b/clipper_admin/check_and_write_deps.py
@@ -28,11 +28,11 @@ def _write_out_dependencies(directory, conda_dep_fname, pip_dep_fname,
 
     with open(conda_dep_abs_path, 'w') as f:
         for item in conda_deps:
-            f.write("%s\n" % '='.join(item.split()), encoding="UTF8")
+            f.write("%s\n" % '='.join(item.split()))
 
     with open(pip_dep_abs_path, 'w') as f:
         for item in pip_deps:
-            f.write("%s\n" % item, encoding="UTF8")
+            f.write("%s\n" % item)
 
 
 def check_solvability_write_deps(env_path, directory, platform,

--- a/clipper_admin/check_and_write_deps.py
+++ b/clipper_admin/check_and_write_deps.py
@@ -28,11 +28,11 @@ def _write_out_dependencies(directory, conda_dep_fname, pip_dep_fname,
 
     with open(conda_dep_abs_path, 'wb') as f:
         for item in conda_deps:
-            f.write("%s\n" % '='.join(item.split()))
+            f.write(bytes("%s\n" % '='.join(item.split()), encoding="UTF8"))
 
     with open(pip_dep_abs_path, 'wb') as f:
         for item in pip_deps:
-            f.write("%s\n" % item)
+            f.write(bytes("%s\n" % item, encoding="UTF8"))
 
 
 def check_solvability_write_deps(env_path, directory, platform,

--- a/clipper_admin/check_and_write_deps.py
+++ b/clipper_admin/check_and_write_deps.py
@@ -26,13 +26,13 @@ def _write_out_dependencies(directory, conda_dep_fname, pip_dep_fname,
     conda_dep_abs_path = os.path.join(directory, conda_dep_fname)
     pip_dep_abs_path = os.path.join(directory, pip_dep_fname)
 
-    with open(conda_dep_abs_path, 'wb') as f:
+    with open(conda_dep_abs_path, 'w') as f:
         for item in conda_deps:
-            f.write(bytes("%s\n" % '='.join(item.split()), encoding="UTF8"))
+            f.write("%s\n" % '='.join(item.split()), encoding="UTF8")
 
-    with open(pip_dep_abs_path, 'wb') as f:
+    with open(pip_dep_abs_path, 'w') as f:
         for item in pip_deps:
-            f.write(bytes("%s\n" % item, encoding="UTF8"))
+            f.write("%s\n" % item, encoding="UTF8")
 
 
 def check_solvability_write_deps(env_path, directory, platform,


### PR DESCRIPTION
If user's default python environment is python3 then the scrip to check conda dependencies will fail.  

This PR addresses the issue by casting strings to UTF8 bytes.