### PR TITLE
App/model links (add only)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,6 @@ Success!
 >>> clipper.get_all_apps()
 [u'hello_world']
 
-# Let Clipper know that queries to your app should be served by
-# a model with name "feature_sum_model".
->>> clipper.link_model_to_app("hello_world", "feature_sum_model")
-Success!
-
 # Define a simple model that just returns the sum of each feature vector.
 # Note that the prediction function takes a list of feature vectors as
 # input and returns a list of strings.
@@ -68,6 +63,11 @@ Success!
 
 # Deploy the model, naming it "feature_sum_model" and giving it version 1
 >>> clipper.deploy_predict_function("feature_sum_model", 1, feature_sum_function, "doubles")
+
+# Let Clipper know that queries to your app should be served by
+# your newly deployed model.
+>>> clipper.link_model_to_app("hello_world", "feature_sum_model")
+Success!
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,19 @@ Checking if Docker is running...
 >>> clipper.start()
 Clipper is running
 
-# Register an application called "hello_world" that will query a model
-# called "feature_sum_model". This will create a prediction REST endpoint at
-# http://localhost:1337/hello_world/predict
+# Register an application called "hello_world". This will create
+# a prediction REST endpoint at http://localhost:1337/hello_world/predict
 >>> clipper.register_application("hello_world", "feature_sum_model", "doubles", "-1.0", 100000)
 Success!
 
 # Inspect Clipper to see the registered apps
 >>> clipper.get_all_apps()
 [u'hello_world']
+
+# Let Clipper know that queries to your app should be served by
+# a model with name "feature_sum_model".
+>>> clipper.link_model_to_app("hello_world", "feature_sum_model")
+Success!
 
 # Define a simple model that just returns the sum of each feature vector.
 # Note that the prediction function takes a list of feature vectors as

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Clipper is running
 
 # Register an application called "hello_world". This will create
 # a prediction REST endpoint at http://localhost:1337/hello_world/predict
->>> clipper.register_application("hello_world", "feature_sum_model", "doubles", "-1.0", 100000)
+>>> clipper.register_application("hello_world", "doubles", "-1.0", 100000)
 Success!
 
 # Inspect Clipper to see the registered apps

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -379,7 +379,7 @@ class Clipper:
             The name of the model to link to the application
         """
         url = "http://%s:%d/admin/add_app_links" % (self.host,
-                                      CLIPPER_MANAGEMENT_PORT)
+                                                    CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "app_name": app_name,
             "model_names": [model_name]
@@ -395,16 +395,18 @@ class Clipper:
         ----------
         app_name : str
             The name of the application
+
+        Returns
+        -------
+        list
+            Returns a list of the names of models linked to the app
         """
         url = "http://%s:%d/admin/get_app_links" % (self.host,
-                                      CLIPPER_MANAGEMENT_PORT)
-        req_json = json.dumps({
-            "app_name": app_name
-        })
+                                                    CLIPPER_MANAGEMENT_PORT)
+        req_json = json.dumps({"app_name": app_name})
         headers = {'Content-type': 'application/json'}
         r = requests.post(url, headers=headers, data=req_json)
-        print(r.text)
-
+        return r.json()
 
     def get_all_apps(self, verbose=False):
         """Gets information about all applications registered with Clipper.

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -369,7 +369,9 @@ class Clipper:
         return r.status_code == requests.codes.ok
 
     def link_model_to_app(self, app_name, model_name):
-        """Allows the model to be used by app
+        """
+        Allows the model with `model_name` to be used by the app with `app_name`.
+        The model and app should both be registered with Clipper.
 
         Parameters
         ----------
@@ -391,11 +393,10 @@ class Clipper:
         })
         headers = {'Content-type': 'application/json'}
         r = requests.post(url, headers=headers, data=req_json)
-        print(r.text)
         return r.status_code == requests.codes.ok
 
     def get_linked_models(self, app_name):
-        """Retrieves the models linked to the app
+        """Retrieves the models linked to the specified application
 
         Parameters
         ----------
@@ -405,14 +406,19 @@ class Clipper:
         Returns
         -------
         list
-            Returns a list of the names of models linked to the app
+            Returns a list of the names of models linked to the app.
+            If no models are linked to the specified app, None is returned.
         """
         url = "http://%s:%d/admin/get_linked_models" % (
             self.host, CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({"app_name": app_name})
         headers = {'Content-type': 'application/json'}
         r = requests.post(url, headers=headers, data=req_json)
-        return r.json()
+        if r.status_code == requests.codes.ok:
+            return r.json()
+        else:
+            print(r.text)
+            return None
 
     def get_all_apps(self, verbose=False):
         """Gets information about all applications registered with Clipper.
@@ -429,7 +435,7 @@ class Clipper:
         -------
         list
             Returns a list of information about all apps registered to Clipper.
-            If no apps are registered with Clipper, an empty list is returned.
+            If no apps are registered with Clipper, None is returned.
         """
         url = "http://%s:1338/admin/get_all_applications" % self.host
         req_json = json.dumps({"verbose": verbose})
@@ -928,7 +934,7 @@ class Clipper:
         -------
         list
             Returns a list of information about all apps registered to Clipper.
-            If no models are registered with Clipper, an empty list is returned.
+            If no models are registered with Clipper, None is returned.
         """
         url = "http://%s:1338/admin/get_all_models" % self.host
         req_json = json.dumps({"verbose": verbose})
@@ -989,7 +995,7 @@ class Clipper:
         -------
         list
             Returns a list of information about all apps registered to Clipper.
-            If no containerss are registered with Clipper, an empty list is returned.
+            If no containerss are registered with Clipper, None is returned.
         """
         url = "http://%s:1338/admin/get_all_containers" % self.host
         req_json = json.dumps({"verbose": verbose})

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -322,7 +322,7 @@ class Clipper:
             self._execute_root("docker-compose up -d query_frontend")
             print("Clipper is running")
 
-    def register_application(self, name, model, input_type, default_output,
+    def register_application(self, name, input_type, default_output,
                              slo_micros):
         """
         Submits a request to register a new Clipper application and returns whether or
@@ -332,8 +332,6 @@ class Clipper:
         ----------
         name : str
             The name of the application.
-        model : str
-            The name of the model this application will query.
         input_type : str
             One of "integers", "floats", "doubles", "bytes", or "strings".
         default_output : string
@@ -361,7 +359,6 @@ class Clipper:
                                               CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "name": name,
-            "candidate_model_names": [model],
             "input_type": input_type,
             "default_output": default_output,
             "latency_slo_micros": slo_micros
@@ -370,6 +367,44 @@ class Clipper:
         r = requests.post(url, headers=headers, data=req_json)
         print(r.text)
         return r.status_code == requests.codes.ok
+
+    def link_model_to_app(self, app_name, model_name):
+        """Allows the model to be used by app
+
+        Parameters
+        ----------
+        app_name : str
+            The name of the application
+        model_name : str
+            The name of the model to link to the application
+        """
+        url = "http://%s:%d/admin/add_app_links" % (self.host,
+                                      CLIPPER_MANAGEMENT_PORT)
+        req_json = json.dumps({
+            "app_name": app_name,
+            "model_names": [model_name]
+        })
+        headers = {'Content-type': 'application/json'}
+        r = requests.post(url, headers=headers, data=req_json)
+        print(r.text)
+
+    def get_linked_models(self, app_name):
+        """Retrieves the models linked to the app
+
+        Parameters
+        ----------
+        app_name : str
+            The name of the application
+        """
+        url = "http://%s:%d/admin/get_app_links" % (self.host,
+                                      CLIPPER_MANAGEMENT_PORT)
+        req_json = json.dumps({
+            "app_name": app_name
+        })
+        headers = {'Content-type': 'application/json'}
+        r = requests.post(url, headers=headers, data=req_json)
+        print(r.text)
+
 
     def get_all_apps(self, verbose=False):
         """Gets information about all applications registered with Clipper.

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -804,15 +804,15 @@ class Clipper:
                 "Application registration unsuccessful. Will not deploy model or link it to app."
             )
             return False
-        print("Application registration sucessful! Linking it to model.")
+        print("Application registration sucessful! Deploying model.")
+        return True
 
-        time.sleep(1)
-        if not self.link_model_to_app(name, name):
-            print(
-                "Linking model to app was unsuccessful. Will not deploy model.")
+    def _link_model_to_app_and_check_success(self, app_name, model_name):
+        if not self.link_model_to_app(app_name, model_name):
+            print("Linking model to app was unsuccessful.")
             return False
 
-        print("Linking model to app was successful! Deploying model.")
+        print("Linking model to app was successful!")
         return True
 
     def register_app_and_deploy_predict_function(
@@ -857,9 +857,16 @@ class Clipper:
                 name, input_type, default_output, slo_micros):
             return False
 
-        return self.deploy_predict_function(name, model_version,
-                                            predict_function, input_type,
-                                            labels, num_containers)
+        if not self.deploy_predict_function(
+                name, model_version, predict_function, input_type, labels,
+                num_containers):
+            return False
+
+        time.sleep(1)
+        if not self._link_model_to_app_and_check_success(name, name):
+            return False
+
+        return True
 
     def register_app_and_deploy_pyspark_model(
             self,
@@ -917,9 +924,16 @@ class Clipper:
                 name, input_type, default_output, slo_micros):
             return False
 
-        return self.deploy_pyspark_model(name, model_version, predict_function,
+        if not self.deploy_pyspark_model(name, model_version, predict_function,
                                          pyspark_model, sc, input_type, labels,
-                                         num_containers)
+                                         num_containers):
+            return False
+
+        time.sleep(1)
+        if not self._link_model_to_app_and_check_success(name, name):
+            return False
+
+        return True
 
     def get_all_models(self, verbose=False):
         """Gets information about all models registered with Clipper.

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -393,6 +393,7 @@ class Clipper:
         })
         headers = {'Content-type': 'application/json'}
         r = requests.post(url, headers=headers, data=req_json)
+        print(r.text)
         return r.status_code == requests.codes.ok
 
     def get_linked_models(self, app_name):

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -378,8 +378,8 @@ class Clipper:
         model_name : str
             The name of the model to link to the application
         """
-        url = "http://%s:%d/admin/add_app_links" % (self.host,
-                                                    CLIPPER_MANAGEMENT_PORT)
+        url = "http://%s:%d/admin/add_model_links" % (self.host,
+                                                      CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({
             "app_name": app_name,
             "model_names": [model_name]
@@ -401,8 +401,8 @@ class Clipper:
         list
             Returns a list of the names of models linked to the app
         """
-        url = "http://%s:%d/admin/get_app_links" % (self.host,
-                                                    CLIPPER_MANAGEMENT_PORT)
+        url = "http://%s:%d/admin/get_linked_models" % (
+            self.host, CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({"app_name": app_name})
         headers = {'Content-type': 'application/json'}
         r = requests.post(url, headers=headers, data=req_json)

--- a/containers/R/README.md
+++ b/containers/R/README.md
@@ -37,11 +37,18 @@ Clipper.deploy_R_model(
 
 - Register Application :
 
-```
+```py
 Clipper.register_application(
-    "example_app", "example_model", "strings", default_output, slo_micros=2000
+    "example_app", "strings", default_output, slo_micros=2000
     )
  ```
+- Link model to application :
+
+```py
+Clipper.link_model_to_app(
+		"example_app", "example_model"
+		)
+```
 
 - Requesting predictions
 

--- a/examples/basic_query/example_client.py
+++ b/examples/basic_query/example_client.py
@@ -23,9 +23,10 @@ def predict(host, uid, x):
 if __name__ == '__main__':
     host = "localhost"
     clipper = Clipper(host, check_for_docker=False)
-    clipper.register_application("example_app", "example_model", "doubles",
-                                 "-1.0", 40000)
+    clipper.register_application("example_app", "doubles", "-1.0", 40000)
     clipper.register_external_model("example_model", 1, "doubles")
+    time.sleep(1.0)
+    clipper.link_model_to_app("example_app", "example_model")
     time.sleep(1.0)
     uid = 0
     while True:

--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -3,8 +3,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "notes"
     }
@@ -28,9 +26,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -40,20 +36,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Extract the images"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now, we must extract the data into a format we can load. This will make use of the provided [`extract_cifar.py`](extract_cifar.py)\n",
     "\n",
@@ -66,9 +56,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -79,10 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Load Cifar\n",
     "\n",
@@ -93,9 +78,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -108,10 +91,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Take a look at the data you've loaded. The size and blurriness of these photos should give you a better understanding of the difficulty of the task you will ask of your machine learning models! If you'd like to see more images, increase the number of rows of images displayed -- the last argument to the function -- to a number greater than 2."
    ]
@@ -121,8 +101,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -136,8 +114,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -170,8 +146,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -194,10 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Congratulations! You now have a running Clipper instance that you can start to interact with. Think of your `clipper` Python object as a vehicle for that interaction. Try using it to see the applications deployed to this Clipper instance:"
    ]
@@ -207,8 +178,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -221,8 +190,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -246,8 +213,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -268,10 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now when you list the applications registered with Clipper, you should see the newly registered \"cifar_demo\" application show up!"
    ]
@@ -280,9 +242,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -292,8 +252,6 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "deletable": true,
-    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -318,8 +276,6 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
-    "deletable": true,
-    "editable": true,
     "scrolled": false,
     "slideshow": {
      "slide_type": "slide"
@@ -337,10 +293,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Because you haven't deployed any models nor linked them to your application yet, Clipper will essentially be randomly guessing to respond to the predictions. Because you have deployed a binary classification model, random guessing should result in 50% accuracy, which is what the plot should be showing.\n",
     "\n",
@@ -351,7 +304,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
    "name": "python2"
   },

--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -197,7 +197,7 @@
    "source": [
     "# Create an application\n",
     "\n",
-    "In order to query Clipper for predictions, you need to create an application. Each application specifies a name, the query input datatype, the selection policy, and a latency service level objective. Once you register an application with Clipper, the system will create two REST endpoints: one for requesting predictions and for providing feedback.\n",
+    "In order to query Clipper for predictions, you need to create an application. Each application specifies a name, the query input datatype, the selection policy, and a latency service level objective. Once you register an application with Clipper, the system will create a REST endpoint for handling prediction requests.\n",
     "\n",
     "By associating the query interface with a specific application, Clipper allows frontend developers the flexibility to have multiple applications running in the same Clipper instance. Applications can request predictions from any model in Clipper. This allows a single Clipper instance to serve multiple machine-learning applications. It also provides a convenient mechanism for beta-testing or incremental rollout by creating experimental and stable applications for the same set of queries.\n",
     "\n",
@@ -220,7 +220,7 @@
    "outputs": [],
    "source": [
     "app_name = \"cifar_demo\"\n",
-    "# If the model (which we will later link to our apo) doesn't\n",
+    "# If the model (which we will later link to our application) doesn't\n",
     "# return a prediction in time, predict label 0 (bird) by default\n",
     "default_output = \"0\"\n",
     "\n",
@@ -260,7 +260,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Clipper applications don't generate predictions themselves; models do. Let Clipper know that your `\"cifar_demo\"` app should use the `\"birds_vs_planes_classifier\"` model to serve predictions once it is deployed.\n",
+    "In order to generate predictions, a Clipper application needs to be linked to a model. Let Clipper know that your `\"cifar_demo\"` app should use the `\"birds_vs_planes_classifier\"` model to serve predictions once it is deployed.\n",
     "\n",
     "That model hasn't been created or deployed yet, but don't worry – we'll take care of that in part two of the tutorial."
    ]
@@ -281,7 +281,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can view which models your app is linked to by running the below code."
+    "You can view which models your app is linked to by running the code below."
    ]
   },
   {

--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -220,17 +220,34 @@
    "outputs": [],
    "source": [
     "app_name = \"cifar_demo\"\n",
-    "model_name = \"birds_vs_planes_classifier\"\n",
-    "# If the model doesn't return a prediction in time, predict\n",
-    "# label 0 (bird) by default\n",
+    "# If the model (which we will later link to our apo) doesn't\n",
+    "# return a prediction in time, predict label 0 (bird) by default\n",
     "default_output = \"0\"\n",
     "\n",
     "clipper.register_application(\n",
     "    app_name,\n",
-    "    model_name,\n",
     "    \"doubles\",\n",
     "    default_output,\n",
     "    slo_micros=20000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we let Clipper know that our `\"cifar_demo\"` app can use the `\"birds_vs_planes_classifier\"` model to serve predictions once it is deployed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "model_name = \"birds_vs_planes_classifier\"\n",
+    "clipper.link_model_to_app(app_name, model_name)"
    ]
   },
   {

--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -3,6 +3,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "notes"
     }
@@ -26,7 +28,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -36,14 +40,20 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Extract the images"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Now, we must extract the data into a format we can load. This will make use of the provided [`extract_cifar.py`](extract_cifar.py)\n",
     "\n",
@@ -56,7 +66,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -67,7 +79,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Load Cifar\n",
     "\n",
@@ -78,7 +93,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -91,7 +108,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Take a look at the data you've loaded. The size and blurriness of these photos should give you a better understanding of the difficulty of the task you will ask of your machine learning models! If you'd like to see more images, increase the number of rows of images displayed -- the last argument to the function -- to a number greater than 2."
    ]
@@ -101,6 +121,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -114,6 +136,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -146,6 +170,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -168,7 +194,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Congratulations! You now have a running Clipper instance that you can start to interact with. Think of your `clipper` Python object as a vehicle for that interaction. Try using it to see the applications deployed to this Clipper instance:"
    ]
@@ -178,6 +207,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "fragment"
     }
@@ -190,6 +221,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -213,6 +246,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -233,7 +268,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Now when you list the applications registered with Clipper, you should see the newly registered \"cifar_demo\" application show up!"
    ]
@@ -242,7 +280,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -251,53 +291,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Link your app to a model"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In order to generate predictions, a Clipper application needs to be linked to a model. Let Clipper know that your `\"cifar_demo\"` app should use the `\"birds_vs_planes_classifier\"` model to serve predictions once it is deployed.\n",
-    "\n",
-    "That model hasn't been created or deployed yet, but don't worry – we'll take care of that in part two of the tutorial."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "model_name = \"birds_vs_planes_classifier\"\n",
-    "clipper.link_model_to_app(app_name, model_name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can view which models your app is linked to by running the code below."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "clipper.get_linked_models(app_name)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
+    "deletable": true,
+    "editable": true,
     "slideshow": {
      "slide_type": "slide"
     }
@@ -322,6 +318,8 @@
    "execution_count": null,
    "metadata": {
     "collapsed": true,
+    "deletable": true,
+    "editable": true,
     "scrolled": false,
     "slideshow": {
      "slide_type": "slide"
@@ -339,9 +337,12 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "Because you haven't deployed any models yet, Clipper will essentially be randomly guessing to respond to the predictions. Because you have deployed a binary classification model, random guessing should result in 50% accuracy, which is what the plot should be showing.\n",
+    "Because you haven't deployed any models nor linked them to your application yet, Clipper will essentially be randomly guessing to respond to the predictions. Because you have deployed a binary classification model, random guessing should result in 50% accuracy, which is what the plot should be showing.\n",
     "\n",
     "*Now that you've created an application, it's time to move on to [part 2](tutorial_part_two.ipynb) of the tutorial, where you\n",
     "will train and deploy some models to Clipper.*"
@@ -350,7 +351,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },

--- a/examples/tutorial/tutorial_part_one.ipynb
+++ b/examples/tutorial/tutorial_part_one.ipynb
@@ -197,11 +197,11 @@
    "source": [
     "# Create an application\n",
     "\n",
-    "In order to query Clipper for predictions, you need to create an application. Each application specifies a name, a set of models it can query, the query input datatype, the selection policy, and a latency service level objective. Once you register an application with Clipper, the system will create two REST endpoints: one for requesting predictions and for providing feedback.\n",
+    "In order to query Clipper for predictions, you need to create an application. Each application specifies a name, the query input datatype, the selection policy, and a latency service level objective. Once you register an application with Clipper, the system will create two REST endpoints: one for requesting predictions and for providing feedback.\n",
     "\n",
     "By associating the query interface with a specific application, Clipper allows frontend developers the flexibility to have multiple applications running in the same Clipper instance. Applications can request predictions from any model in Clipper. This allows a single Clipper instance to serve multiple machine-learning applications. It also provides a convenient mechanism for beta-testing or incremental rollout by creating experimental and stable applications for the same set of queries.\n",
     "\n",
-    "For this tutorial, you will create an application named \"cifar_demo\" and register a candidate model. Note that Clipper allows you to create the application before deploying the models. Clipper will be moving to a label-based model specification mechanism soon, so that in the future you won't have to explicitly enumerate all the models you want to query up front.\n",
+    "For this tutorial, you will create an application named \"cifar_demo\". Note that Clipper allows you to create the application before deploying the models. Clipper will be moving to a label-based model specification mechanism soon, so that in the future you won't have to explicitly enumerate all the models you want to query up front.\n",
     "\n",
     "Registering the `cifar_demo` application with Clipper will have the following effect on your setup: <img src=\"img/register_app.png\" style=\"width: 500px;\"/>\n",
     "\n",
@@ -235,7 +235,34 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we let Clipper know that our `\"cifar_demo\"` app can use the `\"birds_vs_planes_classifier\"` model to serve predictions once it is deployed."
+    "Now when you list the applications registered with Clipper, you should see the newly registered \"cifar_demo\" application show up!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "clipper.get_all_apps(verbose=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Link your app to a model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Clipper applications don't generate predictions themselves; models do. Let Clipper know that your `\"cifar_demo\"` app should use the `\"birds_vs_planes_classifier\"` model to serve predictions once it is deployed.\n",
+    "\n",
+    "That model hasn't been created or deployed yet, but don't worry – we'll take care of that in part two of the tutorial."
    ]
   },
   {
@@ -254,7 +281,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now when you list the applications registered with Clipper, you should see the newly registered \"cifar_demo\" application show up!"
+    "You can view which models your app is linked to by running the below code."
    ]
   },
   {
@@ -265,7 +292,7 @@
    },
    "outputs": [],
    "source": [
-    "clipper.get_all_apps(verbose=True)"
+    "clipper.get_linked_models(app_name)"
    ]
   },
   {

--- a/examples/tutorial/tutorial_part_two.ipynb
+++ b/examples/tutorial/tutorial_part_two.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Clipper Tutorial: Part 2\n",
     "\n",
@@ -18,7 +21,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -36,7 +41,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Load Cifar\n",
     "\n",
@@ -49,7 +57,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -63,7 +73,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Train Logistic Regression Model\n",
     "\n",
@@ -74,7 +87,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -88,7 +103,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Deploy Logistic Regression Model\n",
     "\n",
@@ -108,7 +126,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -129,12 +149,63 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that you've deployed your model, go ahead and check back on your running frontend application from part 1. You should see the accuracy rise from around 50% to the accuracy of your SKLearn model (68-74%), without having to stop or modify your application at all!"
+    "## Link your app to your model"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "To use your newly deployed model to generate predictions, it needs to be linked to your Clipper application. Let Clipper know that your `\"cifar_demo\"` app should use the `\"birds_vs_planes_classifier\"` model to serve predictions.\n",
+    "\n",
+    "In the future, when you deploy new versions of the `\"birds_vs_planes_classifier\"` model, queries to your Clipper application will route to them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "clipper.link_model_to_app(app_name, model_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can view which models your app is linked to by running the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "clipper.get_linked_models(app_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
+    "Now that you've deployed and linked your model to your app, go ahead and check back on your running frontend application from part 1. You should see the accuracy rise from around 50% to the accuracy of your SKLearn model (68-74%), without having to stop or modify your application at all!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Load TensorFlow Model\n",
     "\n",
@@ -147,7 +218,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -174,7 +247,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Deploy TensorFlow Model\n",
     "\n",
@@ -190,7 +266,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -207,7 +285,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Inspect Clipper Metrics\n",
     "\n",
@@ -218,7 +299,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -227,7 +310,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "__Congratulations! You've now successfully completed the tutorial. You started Clipper, created an application and queried it from a frontend client, and deployed two models trained in two different machine learning frameworks (Scikit-Learn and TensorFlow) to the running system.__\n",
     "\n",
@@ -236,7 +322,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "<img src=\"img/warning.jpg\" style=\"width: 400px;\"/>\n",
     "\n",
@@ -251,7 +340,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "If you check the accuracy of your frontend application a final time, you should see accuracy around 88%. If the accuracy is below that, you can try sending more feedback to increase the weight on the TensorFlow model even more."
    ]
@@ -260,7 +352,9 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -270,7 +364,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python2"
   },

--- a/examples/tutorial/tutorial_part_two.ipynb
+++ b/examples/tutorial/tutorial_part_two.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Clipper Tutorial: Part 2\n",
     "\n",
@@ -21,9 +18,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -41,10 +36,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Load Cifar\n",
     "\n",
@@ -57,9 +49,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -73,10 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Train Logistic Regression Model\n",
     "\n",
@@ -87,9 +74,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -103,10 +88,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Deploy Logistic Regression Model\n",
     "\n",
@@ -126,9 +108,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -192,20 +172,14 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "Now that you've deployed and linked your model to your app, go ahead and check back on your running frontend application from part 1. You should see the accuracy rise from around 50% to the accuracy of your SKLearn model (68-74%), without having to stop or modify your application at all!"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Load TensorFlow Model\n",
     "\n",
@@ -218,9 +192,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -247,10 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Deploy TensorFlow Model\n",
     "\n",
@@ -266,9 +235,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -285,10 +252,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Inspect Clipper Metrics\n",
     "\n",
@@ -299,9 +263,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -310,10 +272,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "__Congratulations! You've now successfully completed the tutorial. You started Clipper, created an application and queried it from a frontend client, and deployed two models trained in two different machine learning frameworks (Scikit-Learn and TensorFlow) to the running system.__\n",
     "\n",
@@ -322,10 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "<img src=\"img/warning.jpg\" style=\"width: 400px;\"/>\n",
     "\n",
@@ -340,10 +296,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "If you check the accuracy of your frontend application a final time, you should see accuracy around 88%. If the accuracy is below that, you can try sending more feedback to increase the weight on the TensorFlow model even more."
    ]
@@ -352,9 +305,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -364,7 +315,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 2",
    "language": "python",
    "name": "python2"
   },

--- a/integration-tests/clipper_manager_tests.py
+++ b/integration-tests/clipper_manager_tests.py
@@ -326,7 +326,8 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
 
 SHORT_TEST_ORDERING = [
     'test_external_models_register_correctly',
-    'test_application_registers_correctly', 'test_model_links_to_app',
+    'test_application_registers_correctly',
+    'test_model_links_to_app',
     'get_app_info_for_registered_app_returns_info_dictionary',
     'get_app_info_for_nonexistent_app_returns_none',
     'test_add_container_for_external_model_fails',

--- a/integration-tests/clipper_manager_tests.py
+++ b/integration-tests/clipper_manager_tests.py
@@ -78,12 +78,17 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         input_type = "doubles"
         default_output = "DEFAULT"
         slo_micros = 30000
-        self.clipper_inst.register_application(self.app_name, self.model_name,
-                                               input_type, default_output,
-                                               slo_micros)
+        self.clipper_inst.register_application(self.app_name, input_type,
+                                               default_output, slo_micros)
         registered_applications = self.clipper_inst.get_all_apps()
         self.assertGreaterEqual(len(registered_applications), 1)
         self.assertTrue(self.app_name in registered_applications)
+
+    def test_model_links_to_app(self):
+        not_deployed_model = "test_model"
+        self.clipper_inst.link_model_to_app(self.app_name, not_deployed_model)
+        result = self.clipper_inst.get_linked_models(self.app_name)
+        self.assertEqual([not_deployed_model], result)
 
     def get_app_info_for_registered_app_returns_info_dictionary(self):
         result = self.clipper_inst.get_app_info(self.app_name)
@@ -250,11 +255,11 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         self.default_output = "DEFAULT"
         self.latency_slo_micros = 30000
         self.clipper_inst.register_application(
-            self.app_name_1, self.model_name_1, self.input_type,
-            self.default_output, self.latency_slo_micros)
+            self.app_name_1, self.input_type, self.default_output,
+            self.latency_slo_micros)
         self.clipper_inst.register_application(
-            self.app_name_2, self.model_name_2, self.input_type,
-            self.default_output, self.latency_slo_micros)
+            self.app_name_2, self.input_type, self.default_output,
+            self.latency_slo_micros)
 
     @classmethod
     def tearDownClass(self):
@@ -270,6 +275,9 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
             self.model_name_2, model_version, model_data, container_name,
             self.input_type)
         self.assertTrue(result)
+
+        ### Link model and app
+        self.clipper_inst.link_model_to_app(self.app_name_2, self.model_name_2)
 
         time.sleep(30)
 
@@ -290,6 +298,9 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         result = self.clipper_inst.deploy_predict_function(
             self.model_name_1, model_version, predict_func, input_type)
         self.assertTrue(result)
+
+        ### Link model and app
+        self.clipper_inst.link_model_to_app(self.app_name_1, self.model_name_1)
 
         time.sleep(60)
 
@@ -315,7 +326,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
 
 SHORT_TEST_ORDERING = [
     'test_external_models_register_correctly',
-    'test_application_registers_correctly',
+    'test_application_registers_correctly', 'test_model_links_to_app',
     'get_app_info_for_registered_app_returns_info_dictionary',
     'get_app_info_for_nonexistent_app_returns_none',
     'test_add_container_for_external_model_fails',

--- a/integration-tests/clipper_manager_tests.py
+++ b/integration-tests/clipper_manager_tests.py
@@ -90,7 +90,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
 
     def test_get_model_links_when_none_exist_returns_empty_list(self):
         result = self.clipper_inst.get_linked_models(self.app_name)
-        self.assertIsNone(result)
+        self.assertEqual([], result)
 
     def test_link_registered_model_to_app_succeeds(self):
         result = self.clipper_inst.link_model_to_app(self.app_name,
@@ -226,6 +226,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         model_info = self.clipper_inst.get_model_info(model_name,
                                                       model_version)
         self.assertIsNotNone(model_info)
+
         running_containers_output = self.clipper_inst._execute_standard(
             "docker ps -q --filter \"ancestor=clipper/python-container\"")
         self.assertIsNotNone(running_containers_output)
@@ -245,6 +246,10 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             app_and_model_name,
             clipper_admin.clipper_manager.DEFAULT_MODEL_VERSION)
         self.assertIsNotNone(model_info)
+
+        linked_models = self.clipper_inst.get_linked_models(app_and_model_name)
+        self.assertIsNotNone(linked_models)
+
         running_containers_output = self.clipper_inst._execute_standard(
             "docker ps -q --filter \"ancestor=clipper/python-container\"")
         self.assertIsNotNone(running_containers_output)

--- a/integration-tests/deploy_R_models.py
+++ b/integration-tests/deploy_R_models.py
@@ -113,6 +113,10 @@ def deploy_and_test_model(clipper, model, version, test_data_collection):
     """
     clipper.deploy_R_model(model_name, version, model)
     time.sleep(25)
+
+    clipper.link_model_to_app(app_name, model_name)
+    time.sleep(5)
+
     num_preds = 0
     num_defaults = 0
     for i in range(0, len(test_data_collection)):
@@ -163,10 +167,6 @@ if __name__ == "__main__":
         try:
             clipper.register_application(app_name, "string", "default_pred",
                                          100000)
-            time.sleep(1)
-
-            # Link model and app
-            clipper.link_model_to_app(app_name, model_name)
             time.sleep(1)
 
             response = requests.post(

--- a/integration-tests/deploy_R_models.py
+++ b/integration-tests/deploy_R_models.py
@@ -161,9 +161,14 @@ if __name__ == "__main__":
             'test_data2=tail(test_data,0.5*nrow(test_data))')
 
         try:
-            clipper.register_application(app_name, model_name, "string",
-                                         "default_pred", 100000)
+            clipper.register_application(app_name, "string", "default_pred",
+                                         100000)
             time.sleep(1)
+
+            # Link model and app
+            clipper.link_model_to_app(app_name, model_name)
+            time.sleep(1)
+
             response = requests.post(
                 "http://localhost:1337/%s/predict" % app_name,
                 headers=headers,

--- a/integration-tests/deploy_pyspark_models.py
+++ b/integration-tests/deploy_pyspark_models.py
@@ -84,9 +84,9 @@ def predict(spark, model, xs):
     return [str(model.predict(normalize(x))) for x in xs]
 
 
-def deploy_and_test_model(sc, clipper, model, version):
+def deploy_and_test_model(sc, clipper, model, version, input_type):
     clipper.deploy_pyspark_model(model_name, version, predict, model, sc,
-                                 "ints")
+                                 input_type)
     _test_deployed_model(app_name, version)
 
 
@@ -149,8 +149,8 @@ if __name__ == "__main__":
 
         try:
             input_type = "ints"
-            clipper.register_application(app_name, model_name, input_type,
-                                         "default_pred", 100000)
+            clipper.register_application(app_name, input_type, "default_pred",
+                                         100000)
             time.sleep(1)
 
             # Link model and app
@@ -170,15 +170,15 @@ if __name__ == "__main__":
 
             version = 1
             lr_model = train_logistic_regression(trainRDD)
-            deploy_and_test_model(sc, clipper, lr_model, version)
+            deploy_and_test_model(sc, clipper, lr_model, version, input_type)
 
             version += 1
             svm_model = train_svm(trainRDD)
-            deploy_and_test_model(sc, clipper, svm_model, version)
+            deploy_and_test_model(sc, clipper, svm_model, version, input_type)
 
             version += 1
             rf_model = train_random_forest(trainRDD, 20, 16)
-            deploy_and_test_model(sc, clipper, svm_model, version)
+            deploy_and_test_model(sc, clipper, svm_model, version, input_type)
 
             version += 1
             app_and_model_name = "easy_register_app_model"

--- a/integration-tests/deploy_pyspark_models.py
+++ b/integration-tests/deploy_pyspark_models.py
@@ -152,6 +152,11 @@ if __name__ == "__main__":
             clipper.register_application(app_name, model_name, input_type,
                                          "default_pred", 100000)
             time.sleep(1)
+
+            # Link model and app
+            clipper.link_model_to_app(app_name, model_name)
+            time.sleep(1)
+
             response = requests.post(
                 "http://localhost:1337/%s/predict" % app_name,
                 headers=headers,

--- a/integration-tests/deploy_pyspark_pipeline_models.py
+++ b/integration-tests/deploy_pyspark_pipeline_models.py
@@ -128,10 +128,6 @@ if __name__ == "__main__":
                                          10000000)
             time.sleep(1)
 
-            # Link model and app
-            clipper.link_model_to_app(app_name, model_name)
-            time.sleep(1)
-
             response = requests.post(
                 "http://localhost:1337/%s/predict" % app_name,
                 headers=headers,
@@ -148,6 +144,11 @@ if __name__ == "__main__":
             clipper.deploy_pyspark_model(model_name, version, predict, model,
                                          spark.sparkContext, "strings")
             time.sleep(10)
+
+            # Link model and app
+            clipper.link_model_to_app(app_name, model_name)
+            time.sleep(5)
+
             num_preds = 25
             num_defaults = 0
             for i in range(num_preds):

--- a/integration-tests/deploy_pyspark_pipeline_models.py
+++ b/integration-tests/deploy_pyspark_pipeline_models.py
@@ -124,8 +124,8 @@ if __name__ == "__main__":
         clipper = init_clipper()
 
         try:
-            clipper.register_application(app_name, model_name, "strings",
-                                         "default_pred", 10000000)
+            clipper.register_application(app_name, "strings", "default_pred",
+                                         10000000)
             time.sleep(1)
 
             # Link model and app

--- a/integration-tests/deploy_pyspark_pipeline_models.py
+++ b/integration-tests/deploy_pyspark_pipeline_models.py
@@ -127,6 +127,11 @@ if __name__ == "__main__":
             clipper.register_application(app_name, model_name, "strings",
                                          "default_pred", 10000000)
             time.sleep(1)
+
+            # Link model and app
+            clipper.link_model_to_app(app_name, model_name)
+            time.sleep(1)
+
             response = requests.post(
                 "http://localhost:1337/%s/predict" % app_name,
                 headers=headers,

--- a/integration-tests/many_apps_many_models.py
+++ b/integration-tests/many_apps_many_models.py
@@ -98,8 +98,7 @@ def deploy_model(clipper, name, version):
 def create_and_test_app(clipper, name, num_models):
     app_name = "%s_app" % name
     model_name = "%s_model" % name
-    clipper.register_application(app_name, model_name, "doubles",
-                                 "default_pred", 100000)
+    clipper.register_application(app_name, "doubles", "default_pred", 100000)
     time.sleep(1)
 
     # Link model and app

--- a/integration-tests/many_apps_many_models.py
+++ b/integration-tests/many_apps_many_models.py
@@ -101,6 +101,11 @@ def create_and_test_app(clipper, name, num_models):
     clipper.register_application(app_name, model_name, "doubles",
                                  "default_pred", 100000)
     time.sleep(1)
+
+    # Link model and app
+    clipper.link_model_to_app(app_name, model_name)
+    time.sleep(1)
+
     response = requests.post(
         "http://localhost:1337/%s/predict" % app_name,
         headers=headers,

--- a/integration-tests/many_apps_many_models.py
+++ b/integration-tests/many_apps_many_models.py
@@ -75,6 +75,10 @@ def deploy_model(clipper, name, version):
         "doubles",
         num_containers=1)
     time.sleep(10)
+
+    clipper.link_model_to_app(app_name, model_name)
+    time.sleep(5)
+
     num_preds = 25
     num_defaults = 0
     for i in range(num_preds):
@@ -99,10 +103,6 @@ def create_and_test_app(clipper, name, num_models):
     app_name = "%s_app" % name
     model_name = "%s_model" % name
     clipper.register_application(app_name, "doubles", "default_pred", 100000)
-    time.sleep(1)
-
-    # Link model and app
-    clipper.link_model_to_app(app_name, model_name)
     time.sleep(1)
 
     response = requests.post(

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -233,7 +233,6 @@ class RequestHandler {
 
       add_application(app_name, input_type, policy, default_output,
                       latency_slo_micros);
-
     }
     if (app_names.size() > 0) {
       clipper::log_info_formatted(
@@ -277,13 +276,17 @@ class RequestHandler {
                                     std::vector<std::string> models) {
     std::unique_lock<std::mutex> l(candidate_models_for_apps_mutex_);
 
-    if (candidate_models_for_apps_.find(name) == candidate_models_for_apps_.end()) {
+    if (candidate_models_for_apps_.find(name) ==
+        candidate_models_for_apps_.end()) {
       candidate_models_for_apps_[name] = models;
     } else {
-      std::vector<std::string> existing_models = candidate_models_for_apps_[name];
+      std::vector<std::string> existing_models =
+          candidate_models_for_apps_[name];
 
-      existing_models.reserve(existing_models.size() + distance(models.begin(), models.end()));
-      existing_models.insert(existing_models.end(), models.begin(), models.end());
+      existing_models.reserve(existing_models.size() +
+                              distance(models.begin(), models.end()));
+      existing_models.insert(existing_models.end(), models.begin(),
+                             models.end());
     }
   }
 

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -176,8 +176,8 @@ class RequestHandler {
           std::string app_name = key;
           clipper::log_info_formatted(
               LOGGING_TAG_QUERY_FRONTEND,
-              "APP LINKS EVENT DETECTED. App name: {}, event_type: {}", app_name,
-              event_type);
+              "APP LINKS EVENT DETECTED. App name: {}, event_type: {}",
+              app_name, event_type);
           if (event_type == "sadd") {
             clipper::log_info_formatted(LOGGING_TAG_QUERY_FRONTEND,
                                         "New model link detected for app: {}",

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -182,12 +182,9 @@ class RequestHandler {
             clipper::log_info_formatted(LOGGING_TAG_QUERY_FRONTEND,
                                         "New model link detected for app: {}",
                                         app_name);
-
-            boost::optional<std::vector<std::string>> linked_model_names =
+            auto linked_model_names =
                 clipper::redis::get_linked_models(redis_connection_, app_name);
-            if (linked_model_names) {
-              set_linked_models_for_app(app_name, *linked_model_names);
-            }
+            set_linked_models_for_app(app_name, linked_model_names);
           }
         });
 

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -173,20 +173,20 @@ class RequestHandler {
     clipper::redis::subscribe_to_app_links_changes(
         redis_subscriber_,
         [this](const std::string& key, const std::string& event_type) {
+          std::string app_name = key;
           clipper::log_info_formatted(
               LOGGING_TAG_QUERY_FRONTEND,
-              "APP LINKS EVENT DETECTED. Key: {}, event_type: {}", key,
+              "APP LINKS EVENT DETECTED. App name: {}, event_type: {}", app_name,
               event_type);
-          if (event_type == "hset") {
-            std::string app_name = key;
+          if (event_type == "sadd") {
             clipper::log_info_formatted(LOGGING_TAG_QUERY_FRONTEND,
                                         "New model link detected for app: {}",
                                         app_name);
 
-            boost::optional<std::vector<std::string>> new_candidate_models =
-                clipper::redis::get_app_links(redis_connection_, key);
-            if (new_candidate_models) {
-              add_candidate_models_for_app(app_name, *new_candidate_models);
+            boost::optional<std::vector<std::string>> candidate_models =
+                clipper::redis::get_app_links(redis_connection_, app_name);
+            if (candidate_models) {
+              set_candidate_models_for_app(app_name, *candidate_models);
             }
           }
         });
@@ -224,7 +224,7 @@ class RequestHandler {
 
       auto candidate_model_names =
           clipper::redis::get_app_links(redis_connection_, app_name);
-      add_candidate_models_for_app(app_name, candidate_model_names);
+      set_candidate_models_for_app(app_name, candidate_model_names);
 
       InputType input_type = clipper::parse_input_type(app_info["input_type"]);
       std::string policy = app_info["policy"];
@@ -272,22 +272,10 @@ class RequestHandler {
     redis_subscriber_.disconnect();
   }
 
-  void add_candidate_models_for_app(std::string name,
+  void set_candidate_models_for_app(std::string name,
                                     std::vector<std::string> models) {
     std::unique_lock<std::mutex> l(candidate_models_for_apps_mutex_);
-
-    if (candidate_models_for_apps_.find(name) ==
-        candidate_models_for_apps_.end()) {
-      candidate_models_for_apps_[name] = models;
-    } else {
-      std::vector<std::string> existing_models =
-          candidate_models_for_apps_[name];
-
-      existing_models.reserve(existing_models.size() +
-                              distance(models.begin(), models.end()));
-      existing_models.insert(existing_models.end(), models.begin(),
-                             models.end());
-    }
+    candidate_models_for_apps_[name] = models;
   }
 
   std::vector<std::string> get_candidate_models_for_app(std::string name) {

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -303,6 +303,36 @@ TEST_F(QueryFrontendTest, TestReadModelsAtStartup) {
   EXPECT_EQ(rh2_.get_current_model_versions(), expected_models);
 }
 
+TEST_F(QueryFrontendTest, TestReadAppLinksAtStartup) {
+  // Add a few applications
+  std::string app_name_1 = "my_app_name";
+  std::string app_name_2 = "my_app_name_2";
+  InputType input_type = InputType::Doubles;
+  std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  ASSERT_TRUE(add_application(*redis_, app_name_1, input_type, policy, default_output,
+                              latency_slo_micros));
+  ASSERT_TRUE(add_application(*redis_, app_name_2, input_type, policy, default_output,
+                              latency_slo_micros));
+
+  // Give some candidate model names to app with `app_name_1`
+  add_app_links(*redis_, app_name_1, {"m1"});
+  add_app_links(*redis_, app_name_1, {"m2", "m3"});
+
+  std::vector<std::string> expected_app1_candidate_models = {"m1", "m2", "m3"};
+
+  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
+
+  std::vector<std::string> app1_candidate_models = rh2_.get_candidate_models_for_app(app_name_1);
+  std::sort(app1_candidate_models.begin(), app1_candidate_models.end());
+  std::sort(expected_app1_candidate_models.begin(), expected_app1_candidate_models.end());
+  EXPECT_EQ(expected_app1_candidate_models, app1_candidate_models);
+
+  // App with name `app_name_2` shouldn't have any linked models
+  EXPECT_EQ(rh2_.get_candidate_models_for_app(app_name_2), std::vector<std::string>{});
+}
+
 TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {
   std::vector<std::string> labels{"ads", "images", "experimental", "other",
                                   "labels"};

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -311,10 +311,10 @@ TEST_F(QueryFrontendTest, TestReadAppLinksAtStartup) {
   std::string policy = "exp3_policy";
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
-  ASSERT_TRUE(add_application(*redis_, app_name_1, input_type, policy, default_output,
-                              latency_slo_micros));
-  ASSERT_TRUE(add_application(*redis_, app_name_2, input_type, policy, default_output,
-                              latency_slo_micros));
+  ASSERT_TRUE(add_application(*redis_, app_name_1, input_type, policy,
+                              default_output, latency_slo_micros));
+  ASSERT_TRUE(add_application(*redis_, app_name_2, input_type, policy,
+                              default_output, latency_slo_micros));
 
   // Give some candidate model names to app with `app_name_1`
   add_app_links(*redis_, app_name_1, {"m1"});
@@ -324,13 +324,16 @@ TEST_F(QueryFrontendTest, TestReadAppLinksAtStartup) {
 
   RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
 
-  std::vector<std::string> app1_candidate_models = rh2_.get_candidate_models_for_app(app_name_1);
+  std::vector<std::string> app1_candidate_models =
+      rh2_.get_candidate_models_for_app(app_name_1);
   std::sort(app1_candidate_models.begin(), app1_candidate_models.end());
-  std::sort(expected_app1_candidate_models.begin(), expected_app1_candidate_models.end());
+  std::sort(expected_app1_candidate_models.begin(),
+            expected_app1_candidate_models.end());
   EXPECT_EQ(expected_app1_candidate_models, app1_candidate_models);
 
   // App with name `app_name_2` shouldn't have any linked models
-  EXPECT_EQ(rh2_.get_candidate_models_for_app(app_name_2), std::vector<std::string>{});
+  EXPECT_EQ(rh2_.get_candidate_models_for_app(app_name_2),
+            std::vector<std::string>{});
 }
 
 TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -250,12 +250,9 @@ TEST_F(QueryFrontendTest,
   }
 }
 
-// add a read links on startup?
-
 TEST_F(QueryFrontendTest, TestReadApplicationsAtStartup) {
   // Add a few applications
   std::string name = "my_app_name";
-  ;
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
   std::string default_output = "1.0";
@@ -303,7 +300,7 @@ TEST_F(QueryFrontendTest, TestReadModelsAtStartup) {
   EXPECT_EQ(rh2_.get_current_model_versions(), expected_models);
 }
 
-TEST_F(QueryFrontendTest, TestReadAppLinksAtStartup) {
+TEST_F(QueryFrontendTest, TestReadModelLinksAtStartup) {
   // Add a few applications
   std::string app_name_1 = "my_app_name";
   std::string app_name_2 = "my_app_name_2";
@@ -317,22 +314,22 @@ TEST_F(QueryFrontendTest, TestReadAppLinksAtStartup) {
                               default_output, latency_slo_micros));
 
   // Give some candidate model names to app with `app_name_1`
-  add_app_links(*redis_, app_name_1, {"m1"});
-  add_app_links(*redis_, app_name_1, {"m2", "m3"});
+  add_model_links(*redis_, app_name_1, {"m1"});
+  add_model_links(*redis_, app_name_1, {"m2", "m3"});
 
-  std::vector<std::string> expected_app1_candidate_models = {"m1", "m2", "m3"};
+  std::vector<std::string> expected_app1_linked_models = {"m1", "m2", "m3"};
 
   RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
 
-  std::vector<std::string> app1_candidate_models =
-      rh2_.get_candidate_models_for_app(app_name_1);
-  std::sort(app1_candidate_models.begin(), app1_candidate_models.end());
-  std::sort(expected_app1_candidate_models.begin(),
-            expected_app1_candidate_models.end());
-  EXPECT_EQ(expected_app1_candidate_models, app1_candidate_models);
+  std::vector<std::string> app1_linked_models =
+      rh2_.get_linked_models_for_app(app_name_1);
+  std::sort(app1_linked_models.begin(), app1_linked_models.end());
+  std::sort(expected_app1_linked_models.begin(),
+            expected_app1_linked_models.end());
+  EXPECT_EQ(expected_app1_linked_models, app1_linked_models);
 
   // App with name `app_name_2` shouldn't have any linked models
-  EXPECT_EQ(rh2_.get_candidate_models_for_app(app_name_2),
+  EXPECT_EQ(rh2_.get_linked_models_for_app(app_name_2),
             std::vector<std::string>{});
 }
 

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -175,8 +175,8 @@ TEST_F(QueryFrontendTest, TestDecodeUpdateMissingField) {
 TEST_F(QueryFrontendTest, TestAddOneApplication) {
   size_t no_apps = rh_.num_applications();
   EXPECT_EQ(no_apps, (size_t)0);
-  rh_.add_application("test_app_1", InputType::Doubles, "test_policy",
-                      "0.4", 30000);
+  rh_.add_application("test_app_1", InputType::Doubles, "test_policy", "0.4",
+                      30000);
   size_t one_app = rh_.num_applications();
   EXPECT_EQ(one_app, (size_t)1);
 }
@@ -250,26 +250,25 @@ TEST_F(QueryFrontendTest,
   }
 }
 
+// add a read links on startup?
+
 TEST_F(QueryFrontendTest, TestReadApplicationsAtStartup) {
   // Add a few applications
   std::string name = "my_app_name";
-  std::vector<std::string> model_names{"music_random_features", "simple_svm",
-                                       "music_cnn"};
+  ;
   InputType input_type = InputType::Doubles;
   std::string policy = "exp3_policy";
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
-  ASSERT_TRUE(add_application(*redis_, name, model_names, input_type, policy,
-                              default_output, latency_slo_micros));
+  ASSERT_TRUE(add_application(*redis_, name, input_type, policy, default_output,
+                              latency_slo_micros));
   std::string name2 = "my_app_name_2";
-  std::vector<std::string> model_names2{"img_random_features", "simple_svm",
-                                        "img_cnn"};
   InputType input_type2 = InputType::Doubles;
   std::string policy2 = "exp4_policy";
   int latency_slo_micros2 = 50000;
   std::string default_output2 = "1.0";
-  ASSERT_TRUE(add_application(*redis_, name2, model_names2, input_type2,
-                              policy2, default_output2, latency_slo_micros2));
+  ASSERT_TRUE(add_application(*redis_, name2, input_type2, policy2,
+                              default_output2, latency_slo_micros2));
 
   RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
   size_t two_apps = rh2_.num_applications();

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -175,7 +175,7 @@ TEST_F(QueryFrontendTest, TestDecodeUpdateMissingField) {
 TEST_F(QueryFrontendTest, TestAddOneApplication) {
   size_t no_apps = rh_.num_applications();
   EXPECT_EQ(no_apps, (size_t)0);
-  rh_.add_application("test_app_1", {}, InputType::Doubles, "test_policy",
+  rh_.add_application("test_app_1", InputType::Doubles, "test_policy",
                       "0.4", 30000);
   size_t one_app = rh_.num_applications();
   EXPECT_EQ(one_app, (size_t)1);
@@ -187,7 +187,7 @@ TEST_F(QueryFrontendTest, TestAddManyApplications) {
 
   for (int i = 0; i < 500; ++i) {
     std::string cur_name = "test_app_" + std::to_string(i);
-    rh_.add_application(cur_name, {}, InputType::Doubles, "test_policy", "0.4",
+    rh_.add_application(cur_name, InputType::Doubles, "test_policy", "0.4",
                         30000);
   }
 

--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -38,7 +38,6 @@ export(TARGETS clipper FILE ClipperConfig.cmake)
 # be last in the list
 add_executable(libclippertests EXCLUDE_FROM_ALL
     test/test_main.cpp
-    test/redis_test.cpp
     test/threadpool_test.cpp
     test/container_test.cpp
     test/metrics_test.cpp
@@ -46,6 +45,7 @@ add_executable(libclippertests EXCLUDE_FROM_ALL
     test/timers_test.cpp
     test/data_serialization_tests.cpp
     test/persistent_state_test.cpp
+    test/redis_test.cpp
     test/selection_policies_test.cpp
     test/json_util_test.cpp
     test/logging_test.cpp

--- a/src/libclipper/CMakeLists.txt
+++ b/src/libclipper/CMakeLists.txt
@@ -38,6 +38,7 @@ export(TARGETS clipper FILE ClipperConfig.cmake)
 # be last in the list
 add_executable(libclippertests EXCLUDE_FROM_ALL
     test/test_main.cpp
+    test/redis_test.cpp
     test/threadpool_test.cpp
     test/container_test.cpp
     test/metrics_test.cpp
@@ -45,7 +46,6 @@ add_executable(libclippertests EXCLUDE_FROM_ALL
     test/timers_test.cpp
     test/data_serialization_tests.cpp
     test/persistent_state_test.cpp
-    test/redis_test.cpp
     test/selection_policies_test.cpp
     test/json_util_test.cpp
     test/logging_test.cpp

--- a/src/libclipper/include/clipper/constants.hpp
+++ b/src/libclipper/include/clipper/constants.hpp
@@ -13,7 +13,7 @@ enum RedisDBTable {
   REDIS_RESOURCE_DB_NUM = 4,
   REDIS_APPLICATION_DB_NUM = 5,
   REDIS_METADATA_DB_NUM = 6,  // used to store Clipper configuration metadata
-  REDIS_APP_LINKS_DB_NUM = 7,
+  REDIS_APP_MODEL_LINKS_DB_NUM = 7,
 };
 
 constexpr int RPC_SERVICE_PORT = 7000;

--- a/src/libclipper/include/clipper/constants.hpp
+++ b/src/libclipper/include/clipper/constants.hpp
@@ -13,6 +13,7 @@ enum RedisDBTable {
   REDIS_RESOURCE_DB_NUM = 4,
   REDIS_APPLICATION_DB_NUM = 5,
   REDIS_METADATA_DB_NUM = 6,  // used to store Clipper configuration metadata
+  REDIS_APP_LINKS_DB_NUM = 7,
 };
 
 constexpr int RPC_SERVICE_PORT = 7000;

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -127,9 +127,9 @@ void add_object(rapidjson::Document& d, const char* key_name,
 
 std::string to_json_string(rapidjson::Document& d);
 
-void set_string_array(rapidjson::Document &d,
-                      const std::vector<std::string> &str_array);
-std::vector<std::string> to_string_array(rapidjson::Document &d);
+void set_string_array(rapidjson::Document& d,
+                      const std::vector<std::string>& str_array);
+std::vector<std::string> to_string_array(rapidjson::Document& d);
 
 /**
  * Sets `d` to the publicly-facing representation of a given Clipper app.

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -127,8 +127,16 @@ void add_object(rapidjson::Document& d, const char* key_name,
 
 std::string to_json_string(rapidjson::Document& d);
 
+/**
+ * Sets `d` to an Array type document containing the elements
+ * in `string_array`.
+ */
 void set_string_array(rapidjson::Document& d,
                       const std::vector<std::string>& str_array);
+/**
+ * Extracts the string vector from the document `d`. Requires
+ * that `d` represents an array with only string elements.
+ */
 std::vector<std::string> to_string_array(rapidjson::Document& d);
 
 /**

--- a/src/libclipper/include/clipper/json_util.hpp
+++ b/src/libclipper/include/clipper/json_util.hpp
@@ -127,6 +127,10 @@ void add_object(rapidjson::Document& d, const char* key_name,
 
 std::string to_json_string(rapidjson::Document& d);
 
+void set_string_array(rapidjson::Document &d,
+                      const std::vector<std::string> &str_array);
+std::vector<std::string> to_string_array(rapidjson::Document &d);
+
 /**
  * Sets `d` to the publicly-facing representation of a given Clipper app.
  * App data, provided in `app_metadata`, is assumed to be pulled from redis

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -181,7 +181,7 @@ std::vector<std::string> get_all_model_names(redox::Redox& redis);
  */
 std::vector<VersionedModelId> get_all_models(redox::Redox& redis);
 
-boost::optional<std::vector<std::string>> get_candidate_models(
+std::vector<std::string> get_app_links(
         redox::Redox& redis, const std::string& app_name);
 
 /**
@@ -341,6 +341,10 @@ void subscribe_to_container_changes(
  * to differentiate between adds, updates, and deletes if necessary.
 */
 void subscribe_to_application_changes(
+    redox::Subscriber& subscriber,
+    std::function<void(const std::string&, const std::string&)> callback);
+
+void subscribe_to_app_links_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
 

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -101,8 +101,6 @@ std::vector<std::string> str_to_labels(const std::string& label_str);
 
 std::string model_names_to_str(const std::vector<std::string>& names);
 
-std::vector<std::string> str_to_model_names(const std::string& names_str);
-
 std::string models_to_str(const std::vector<VersionedModelId>& models);
 
 std::vector<VersionedModelId> str_to_models(const std::string& model_str);
@@ -258,7 +256,7 @@ bool add_application(redox::Redox& redis, const std::string& appname,
                      const std::string& default_output,
                      const long latency_slo_micros);
 
-bool add_app_link(redox::Redox& redis, const std::string& appname,
+bool add_app_links(redox::Redox& redis, const std::string& appname,
                   const std::vector<std::string>& model_names);
 
 /**

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -182,7 +182,7 @@ std::vector<VersionedModelId> get_all_models(redox::Redox& redis);
 /**
  * Looks up which models are linked to app with name `app_name`
  * \return Returns a vector of model names. If no models are linked
- * to the specified app, then am empty vector will be returned.
+ * to the specified app, then an empty vector will be returned.
  */
 std::vector<std::string> get_linked_models(redox::Redox& redis,
                                            const std::string& app_name);
@@ -256,7 +256,7 @@ std::vector<std::pair<VersionedModelId, int>> get_all_containers(
  *
  * \return Returns true of the add was successful.
  */
-bool add_application(redox::Redox& redis, const std::string& appname,
+bool add_application(redox::Redox& redis, const std::string& app_name,
                      const InputType& input_type, const std::string& policy,
                      const std::string& default_output,
                      const long latency_slo_micros);
@@ -267,7 +267,7 @@ bool add_application(redox::Redox& redis, const std::string& appname,
  *
  * \return Returns true if the add was successful.
  */
-bool add_model_links(redox::Redox& redis, const std::string& appname,
+bool add_model_links(redox::Redox& redis, const std::string& app_name,
                      const std::vector<std::string>& model_names);
 
 /**
@@ -277,7 +277,7 @@ bool add_model_links(redox::Redox& redis, const std::string& appname,
  * and was successfully deleted. Returns false if there was a problem
  * or if the application was not in the table.
  */
-bool delete_application(redox::Redox& redis, const std::string& appname);
+bool delete_application(redox::Redox& redis, const std::string& app_name);
 
 /**
  * Looks up an application based on its name.
@@ -290,7 +290,7 @@ bool delete_application(redox::Redox& redis, const std::string& appname);
  * application was not found, an empty map will be returned.
  */
 std::unordered_map<std::string, std::string> get_application(
-    redox::Redox& redis, const std::string& appname);
+    redox::Redox& redis, const std::string& app_name);
 
 /**
  * Looks up an entry in the application table by the fully

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -181,6 +181,9 @@ std::vector<std::string> get_all_model_names(redox::Redox& redis);
  */
 std::vector<VersionedModelId> get_all_models(redox::Redox& redis);
 
+boost::optional<std::vector<std::string>> get_candidate_models(
+        redox::Redox& redis, const std::string& app_name);
+
 /**
  * Adds a container into the container table. This will
  * overwrite any existing entry with the same key.
@@ -251,10 +254,12 @@ std::vector<std::pair<VersionedModelId, int>> get_all_containers(
  * \return Returns true of the add was successful.
  */
 bool add_application(redox::Redox& redis, const std::string& appname,
-                     const std::vector<std::string>& models,
                      const InputType& input_type, const std::string& policy,
                      const std::string& default_output,
                      const long latency_slo_micros);
+
+bool add_app_link(redox::Redox& redis, const std::string& appname,
+                  const std::vector<std::string>& model_names);
 
 /**
  * Deletes a container from the container table if it exists.

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -179,8 +179,13 @@ std::vector<std::string> get_all_model_names(redox::Redox& redis);
  */
 std::vector<VersionedModelId> get_all_models(redox::Redox& redis);
 
-std::vector<std::string> get_app_links(redox::Redox& redis,
-                                       const std::string& app_name);
+/**
+ * Looks up which models are linked to app with name `app_name`
+ * \return Returns a vector of model names. If no models are linked
+ * to the specified app, then am empty vector will be returned.
+ */
+std::vector<std::string> get_linked_models(redox::Redox& redis,
+                                           const std::string& app_name);
 
 /**
  * Adds a container into the container table. This will
@@ -256,8 +261,14 @@ bool add_application(redox::Redox& redis, const std::string& appname,
                      const std::string& default_output,
                      const long latency_slo_micros);
 
-bool add_app_links(redox::Redox& redis, const std::string& appname,
-                   const std::vector<std::string>& model_names);
+/**
+ * Adds links between the specified app and models. This will not
+ * overwrite existing links.
+ *
+ * \return Returns true if the add was successful.
+ */
+bool add_model_links(redox::Redox& redis, const std::string& appname,
+                     const std::vector<std::string>& model_names);
 
 /**
  * Deletes a container from the container table if it exists.
@@ -342,7 +353,15 @@ void subscribe_to_application_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
 
-void subscribe_to_app_links_changes(
+/**
+ * Subscribes to changes in the app model link table. The
+ * callback is called with the string key of the application
+ * that changed and the Redis event type. The key can
+ * be used to look up the new value. The message type identifies
+ * what type of change was detected. This allows subscribers
+ * to differentiate between adds and deletes if necessary.
+*/
+void subscribe_to_model_link_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback);
 

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -181,8 +181,8 @@ std::vector<std::string> get_all_model_names(redox::Redox& redis);
  */
 std::vector<VersionedModelId> get_all_models(redox::Redox& redis);
 
-std::vector<std::string> get_app_links(
-        redox::Redox& redis, const std::string& app_name);
+std::vector<std::string> get_app_links(redox::Redox& redis,
+                                       const std::string& app_name);
 
 /**
  * Adds a container into the container table. This will

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -257,7 +257,7 @@ bool add_application(redox::Redox& redis, const std::string& appname,
                      const long latency_slo_micros);
 
 bool add_app_links(redox::Redox& redis, const std::string& appname,
-                  const std::vector<std::string>& model_names);
+                   const std::vector<std::string>& model_names);
 
 /**
  * Deletes a container from the container table if it exists.

--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -384,19 +384,17 @@ std::string to_json_string(rapidjson::Document& d) {
   return buffer.GetString();
 }
 
-
-void set_string_array(rapidjson::Document &d,
-                      const std::vector<std::string> &str_array) {
+void set_string_array(rapidjson::Document& d,
+                      const std::vector<std::string>& str_array) {
   d.SetArray();
   for (auto str : str_array) {
-    rapidjson::Value string_val(
-            rapidjson::StringRef(str.c_str(), str.length()),
-            d.GetAllocator());
+    rapidjson::Value string_val(rapidjson::StringRef(str.c_str(), str.length()),
+                                d.GetAllocator());
     d.PushBack(string_val, d.GetAllocator());
   }
 }
 
-std::vector<std::string> to_string_array(rapidjson::Document &d) {
+std::vector<std::string> to_string_array(rapidjson::Document& d) {
   if (!d.IsArray()) {
     throw json_semantic_error("Document must be of array type");
   }

--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -387,7 +387,7 @@ std::string to_json_string(rapidjson::Document& d) {
 void set_string_array(rapidjson::Document& d,
                       const std::vector<std::string>& str_array) {
   d.SetArray();
-  for (auto str : str_array) {
+  for (auto const& str : str_array) {
     rapidjson::Value string_val(rapidjson::StringRef(str.c_str(), str.length()),
                                 d.GetAllocator());
     d.PushBack(string_val, d.GetAllocator());

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -128,10 +128,6 @@ vector<string> str_to_labels(const string& label_str) {
   return labels;
 }
 
-std::vector<std::string> str_to_model_names(const std::string& names_str) {
-  return str_to_labels(names_str);
-}
-
 std::string models_to_str(const std::vector<VersionedModelId>& models) {
   if (models.empty()) return "";
 
@@ -453,15 +449,16 @@ bool add_application(redox::Redox& redis, const std::string& appname,
   }
 }
 
-bool add_app_link(redox::Redox& redis, const std::string& appname,
+bool add_app_links(redox::Redox& redis, const std::string& appname,
                   const std::vector<std::string>& model_names) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APP_LINKS_DB_NUM)})) {
-    //    const vector<string> cmd_vec{"SET", appname,
-    //    model_names_to_str(model_names)};
-    const vector<string> cmd_vec{"SADD", appname,
-                                 model_names_to_str(model_names)};
-    return send_cmd_no_reply<int>(redis, cmd_vec);
+    for (auto model_name : model_names) {
+      if (!send_cmd_no_reply<int>(redis, vector<string>{"SADD", appname, model_name})) {
+        return false;
+      }
+    }
+    return true;
   } else {
     return false;
   }

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -450,11 +450,12 @@ bool add_application(redox::Redox& redis, const std::string& appname,
 }
 
 bool add_app_links(redox::Redox& redis, const std::string& appname,
-                  const std::vector<std::string>& model_names) {
+                   const std::vector<std::string>& model_names) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APP_LINKS_DB_NUM)})) {
     for (auto model_name : model_names) {
-      if (!send_cmd_no_reply<int>(redis, vector<string>{"SADD", appname, model_name})) {
+      if (!send_cmd_no_reply<int>(
+              redis, vector<string>{"SADD", appname, model_name})) {
         return false;
       }
     }

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -212,7 +212,12 @@ std::vector<std::string> get_linked_models(redox::Redox& redis,
           redis, {"SELECT", std::to_string(REDIS_APP_MODEL_LINKS_DB_NUM)})) {
     auto result =
         send_cmd_with_reply<std::vector<string>>(redis, {"SMEMBERS", app_name});
-    linked_models = *result;
+    if (result) {
+      linked_models = *result;
+    } else {
+      log_error_formatted(LOGGING_TAG_REDIS,
+                          "Found no linked models for app {}", app_name);
+    }
   } else {
     log_error_formatted(
         LOGGING_TAG_REDIS,

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -209,16 +209,19 @@ boost::optional<std::string> get_current_model_version(
   return boost::none;
 }
 
-std::vector<std::string> get_app_links(
-        redox::Redox& redis, const std::string& app_name) {
+std::vector<std::string> get_app_links(redox::Redox& redis,
+                                       const std::string& app_name) {
   std::vector<std::string> app_links;
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APP_LINKS_DB_NUM)})) {
-    auto result = send_cmd_with_reply<std::vector<string>>(redis, {"SMEMBERS", app_name});
+    auto result =
+        send_cmd_with_reply<std::vector<string>>(redis, {"SMEMBERS", app_name});
     app_links = *result;
   } else {
-    log_error_formatted(LOGGING_TAG_REDIS, "Redis encountered an error in searching for app links for {}",
-                        app_name);
+    log_error_formatted(
+        LOGGING_TAG_REDIS,
+        "Redis encountered an error in searching for app links for {}",
+        app_name);
   }
 
   return app_links;
@@ -454,8 +457,10 @@ bool add_app_link(redox::Redox& redis, const std::string& appname,
                   const std::vector<std::string>& model_names) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APP_LINKS_DB_NUM)})) {
-//    const vector<string> cmd_vec{"SET", appname, model_names_to_str(model_names)};
-    const vector<string> cmd_vec{"SADD", appname, model_names_to_str(model_names)};
+    //    const vector<string> cmd_vec{"SET", appname,
+    //    model_names_to_str(model_names)};
+    const vector<string> cmd_vec{"SADD", appname,
+                                 model_names_to_str(model_names)};
     return send_cmd_no_reply<int>(redis, cmd_vec);
   } else {
     return false;
@@ -551,8 +556,8 @@ void subscribe_to_application_changes(
 }
 
 void subscribe_to_app_links_changes(
-        redox::Subscriber& subscriber,
-        std::function<void(const std::string&, const std::string&)> callback) {
+    redox::Subscriber& subscriber,
+    std::function<void(const std::string&, const std::string&)> callback) {
   std::string prefix = "";
   subscribe_to_keyspace_changes(REDIS_APP_LINKS_DB_NUM, prefix, subscriber,
                                 std::move(callback));

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -205,14 +205,14 @@ boost::optional<std::string> get_current_model_version(
   return boost::none;
 }
 
-std::vector<std::string> get_app_links(redox::Redox& redis,
-                                       const std::string& app_name) {
-  std::vector<std::string> app_links;
+std::vector<std::string> get_linked_models(redox::Redox& redis,
+                                           const std::string& app_name) {
+  std::vector<std::string> linked_models;
   if (send_cmd_no_reply<string>(
-          redis, {"SELECT", std::to_string(REDIS_APP_LINKS_DB_NUM)})) {
+          redis, {"SELECT", std::to_string(REDIS_APP_MODEL_LINKS_DB_NUM)})) {
     auto result =
         send_cmd_with_reply<std::vector<string>>(redis, {"SMEMBERS", app_name});
-    app_links = *result;
+    linked_models = *result;
   } else {
     log_error_formatted(
         LOGGING_TAG_REDIS,
@@ -220,7 +220,7 @@ std::vector<std::string> get_app_links(redox::Redox& redis,
         app_name);
   }
 
-  return app_links;
+  return linked_models;
 }
 
 bool add_model(Redox& redis, const VersionedModelId& model_id,
@@ -449,10 +449,10 @@ bool add_application(redox::Redox& redis, const std::string& appname,
   }
 }
 
-bool add_app_links(redox::Redox& redis, const std::string& appname,
-                   const std::vector<std::string>& model_names) {
+bool add_model_links(redox::Redox& redis, const std::string& appname,
+                     const std::vector<std::string>& model_names) {
   if (send_cmd_no_reply<string>(
-          redis, {"SELECT", std::to_string(REDIS_APP_LINKS_DB_NUM)})) {
+          redis, {"SELECT", std::to_string(REDIS_APP_MODEL_LINKS_DB_NUM)})) {
     for (auto model_name : model_names) {
       if (!send_cmd_no_reply<int>(
               redis, vector<string>{"SADD", appname, model_name})) {
@@ -553,12 +553,12 @@ void subscribe_to_application_changes(
                                 std::move(callback));
 }
 
-void subscribe_to_app_links_changes(
+void subscribe_to_model_link_changes(
     redox::Subscriber& subscriber,
     std::function<void(const std::string&, const std::string&)> callback) {
   std::string prefix = "";
-  subscribe_to_keyspace_changes(REDIS_APP_LINKS_DB_NUM, prefix, subscriber,
-                                std::move(callback));
+  subscribe_to_keyspace_changes(REDIS_APP_MODEL_LINKS_DB_NUM, prefix,
+                                subscriber, std::move(callback));
 }
 
 void subscribe_to_model_version_changes(

--- a/src/libclipper/test/json_util_test.cpp
+++ b/src/libclipper/test/json_util_test.cpp
@@ -278,10 +278,8 @@ TEST_F(RedisToJsonTest, TestRedisAppMetadataToJson) {
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
   std::string selection_policy = DefaultOutputSelectionPolicy::get_name();
-  std::vector<std::string> candidate_model_names =
-      std::vector<std::string>{"m", "k"};
 
-  ASSERT_TRUE(add_application(*redis_, "myappname", candidate_model_names,
+  ASSERT_TRUE(add_application(*redis_, "myappname",
                               parse_input_type(input_type), selection_policy,
                               default_output, latency_slo_micros));
   std::unordered_map<std::string, std::string> app_metadata =
@@ -293,8 +291,6 @@ TEST_F(RedisToJsonTest, TestRedisAppMetadataToJson) {
   ASSERT_EQ(get_string(d, "input_type"), input_type);
   ASSERT_EQ(get_string(d, "default_output"), default_output);
   ASSERT_EQ(get_int(d, "latency_slo_micros"), latency_slo_micros);
-  ASSERT_EQ(get_string_array(d, "candidate_model_names"),
-            candidate_model_names);
 }
 
 TEST_F(RedisToJsonTest, TestRedisModelMetadataToJson) {

--- a/src/libclipper/test/json_util_test.cpp
+++ b/src/libclipper/test/json_util_test.cpp
@@ -33,6 +33,25 @@ TEST(JsonUtilTests, TestCorrectJsonValues) {
   EXPECT_EQ(output_json, expected_json);
 }
 
+TEST(JsonUtilTests, TestSetStringArrayCorrect) {
+  const std::vector<std::string> str_array = {"a", "b"};
+  rapidjson::Document d;
+  set_string_array(d, str_array);
+  std::string expected_json = R"(["a","b"])";
+  EXPECT_EQ(to_json_string(d), expected_json);
+}
+
+TEST(JsonUtilTests, TestToStringArrayCorrect) {
+  rapidjson::Document d;
+  rapidjson::Document::AllocatorType& a = d.GetAllocator();
+  d.SetArray();
+  d.PushBack("a", a);
+  d.PushBack("b", a);
+  auto result = to_string_array(d);
+  std::vector<std::string> expected_result = {"a", "b"};
+  EXPECT_EQ(expected_result, result);
+}
+
 TEST(JsonUtilTests, TestCorrectJsonArrays) {
   std::string expected_json =
       R"({"string_array":["test1","word2","phrase3"],)"

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -108,10 +108,11 @@ TEST_F(RedisTest, AddAppLinks) {
   std::string policy = DefaultOutputSelectionPolicy::get_name();
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
-  ASSERT_TRUE(add_application(*redis_, app_name, input_type, policy, default_output,
-                              latency_slo_micros));
+  ASSERT_TRUE(add_application(*redis_, app_name, input_type, policy,
+                              default_output, latency_slo_micros));
 
-  std::vector<std::string> model_names = std::vector<std::string>{"model1", "model2"};
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"model1", "model2"};
   ASSERT_TRUE(add_app_links(*redis_, app_name, model_names));
 
   auto linked_models = get_app_links(*redis_, app_name);
@@ -555,14 +556,14 @@ TEST_F(RedisTest, SubscriptionDetectAppLinksAdd) {
   std::mutex notification_mutex;
   std::atomic<bool> recv{false};
   subscribe_to_app_links_changes(
-          *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
-                  const std::string& key, const std::string& event_type) {
-              ASSERT_EQ(event_type, "sadd");
-              std::unique_lock<std::mutex> l(notification_mutex);
-              recv = true;
-              ASSERT_EQ(key, name);
-              notification_recv.notify_all();
-          });
+      *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
+                        const std::string& key, const std::string& event_type) {
+        ASSERT_EQ(event_type, "sadd");
+        std::unique_lock<std::mutex> l(notification_mutex);
+        recv = true;
+        ASSERT_EQ(key, name);
+        notification_recv.notify_all();
+      });
   // give Redis some time to register the subscription
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -466,7 +466,8 @@ TEST_F(RedisTest, SubscriptionDetectContainerDelete) {
       [&notification_recv, &notification_mutex, &recv, replica_key](
           const std::string& key, const std::string& event_type) {
         log_info_formatted(LOGGING_TAG_REDIS_TEST,
-                           "CONTAINER DELETED CALLBACK. EVENT TYPE: ", event_type);
+                           "CONTAINER DELETED CALLBACK. EVENT TYPE: ",
+                           event_type);
         ASSERT_TRUE(event_type == "hdel" || event_type == "del");
         std::unique_lock<std::mutex> l(notification_mutex);
         recv = true;

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -591,7 +591,7 @@ TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
   int latency_slo_micros = 10000;
   ASSERT_TRUE(add_application(*redis_, name, input_type, policy, default_output,
                               latency_slo_micros));
-  log_info(LOGGING_TAG_REDIS_TEST, "Registered app");
+
   // Register the models to link
   std::vector<std::string> labels{"ads", "images", "experimental", "other",
                                   "labels"};
@@ -606,39 +606,29 @@ TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
                         model_path));
   ASSERT_TRUE(add_model(*redis_, model_2_id, input_type, labels, container_name,
                         model_path));
-  log_info(LOGGING_TAG_REDIS_TEST, "Registered models");
+
   std::condition_variable_any notification_recv;
   std::mutex notification_mutex;
-  std::atomic<bool> recv{false};
+  std::atomic<int> num_sadd_recv{0};
   subscribe_to_model_link_changes(
-      *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
-                        const std::string& key, const std::string& event_type) {
-        log_info(LOGGING_TAG_REDIS_TEST, "Detected model link change");
+      *subscriber_,
+      [&notification_recv, &notification_mutex, &num_sadd_recv, name](
+          const std::string& key, const std::string& event_type) {
         ASSERT_EQ(event_type, "sadd");
         std::unique_lock<std::mutex> l(notification_mutex);
-        log_info(LOGGING_TAG_REDIS_TEST, "Got mutex in subscription closure.");
-        recv = true;
-        log_info(LOGGING_TAG_REDIS_TEST, "Set recv = true.");
+        num_sadd_recv += 1;
         ASSERT_EQ(key, name);
-        log_info(LOGGING_TAG_REDIS_TEST, "Asserted key = name");
         notification_recv.notify_all();
-        log_info(LOGGING_TAG_REDIS_TEST, "Notified cv waiters.");
       });
   // give Redis some time to register the subscription
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  log_info(LOGGING_TAG_REDIS_TEST, "Finished sleeping");
   std::vector<std::string> model_names = {model_name_1, model_name_2};
   ASSERT_TRUE(add_model_links(*redis_, name, model_names));
-  log_info(LOGGING_TAG_REDIS_TEST, "Added model links.");
 
   std::unique_lock<std::mutex> l(notification_mutex);
-  log_info(LOGGING_TAG_REDIS_TEST, "Got mutex outside subscription closure.");
-  bool result =
-      notification_recv.wait_for(l, std::chrono::milliseconds(1000), [&recv]() {
-        log_info(LOGGING_TAG_REDIS_TEST, "Inside wait_for callback");
-        return recv == true;
-      });
-  log_info(LOGGING_TAG_REDIS_TEST, "Finished generating `result`: ", result);
+  bool result = notification_recv.wait_for(
+      l, std::chrono::milliseconds(1000),
+      [&num_sadd_recv]() { return num_sadd_recv == 2; });
   ASSERT_TRUE(result);
 }
 

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -102,7 +102,7 @@ TEST_F(RedisTest, AddModel) {
   ASSERT_EQ(result["model_data_path"], model_path);
 }
 
-TEST_F(RedisTest, AddAppLinks) {
+TEST_F(RedisTest, AddModelLinks) {
   std::string app_name = "my_app_name";
   InputType input_type = InputType::Doubles;
   std::string policy = DefaultOutputSelectionPolicy::get_name();
@@ -113,9 +113,9 @@ TEST_F(RedisTest, AddAppLinks) {
 
   std::vector<std::string> model_names =
       std::vector<std::string>{"model1", "model2"};
-  ASSERT_TRUE(add_app_links(*redis_, app_name, model_names));
+  ASSERT_TRUE(add_model_links(*redis_, app_name, model_names));
 
-  auto linked_models = get_app_links(*redis_, app_name);
+  auto linked_models = get_linked_models(*redis_, app_name);
   std::sort(linked_models.begin(), linked_models.end());
   std::sort(model_names.begin(), model_names.end());
   ASSERT_EQ(model_names, linked_models);
@@ -542,7 +542,7 @@ TEST_F(RedisTest, SubscriptionDetectApplicationDelete) {
   ASSERT_TRUE(result);
 }
 
-TEST_F(RedisTest, SubscriptionDetectAppLinksAdd) {
+TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
   // Register the application to link to
   std::string name = "my_app_name";
   InputType input_type = InputType::Doubles;
@@ -555,7 +555,7 @@ TEST_F(RedisTest, SubscriptionDetectAppLinksAdd) {
   std::condition_variable_any notification_recv;
   std::mutex notification_mutex;
   std::atomic<bool> recv{false};
-  subscribe_to_app_links_changes(
+  subscribe_to_model_link_changes(
       *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
                         const std::string& key, const std::string& event_type) {
         ASSERT_EQ(event_type, "sadd");
@@ -568,7 +568,7 @@ TEST_F(RedisTest, SubscriptionDetectAppLinksAdd) {
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   std::vector<std::string> model_names = {"model1", "model2"};
-  ASSERT_TRUE(add_app_links(*redis_, name, model_names));
+  ASSERT_TRUE(add_model_links(*redis_, name, model_names));
 
   std::unique_lock<std::mutex> l(notification_mutex);
   bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -68,19 +68,19 @@ TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
   std::mutex notification_mutex;
   std::atomic<bool> recv{false};
   subscribe_to_model_link_changes(
-          *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
-                  const std::string& key, const std::string& event_type) {
-              log_info(LOGGING_TAG_REDIS_TEST, "Received event");
-              ASSERT_EQ(event_type, "sadd");
-              log_info(LOGGING_TAG_REDIS_TEST, "Confirmed event is SADD");
-              std::unique_lock<std::mutex> l(notification_mutex);
-              log_info(LOGGING_TAG_REDIS_TEST, "Got lock in subscription callback");
-              recv = true;
-              ASSERT_EQ(key, name);
-              log_info(LOGGING_TAG_REDIS_TEST, "Before cv notify");
-              notification_recv.notify_all();
-              log_info(LOGGING_TAG_REDIS_TEST, "After cv notify");
-          });
+      *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
+                        const std::string& key, const std::string& event_type) {
+        log_info(LOGGING_TAG_REDIS_TEST, "Received event");
+        ASSERT_EQ(event_type, "sadd");
+        log_info(LOGGING_TAG_REDIS_TEST, "Confirmed event is SADD");
+        std::unique_lock<std::mutex> l(notification_mutex);
+        log_info(LOGGING_TAG_REDIS_TEST, "Got lock in subscription callback");
+        recv = true;
+        ASSERT_EQ(key, name);
+        log_info(LOGGING_TAG_REDIS_TEST, "Before cv notify");
+        notification_recv.notify_all();
+        log_info(LOGGING_TAG_REDIS_TEST, "After cv notify");
+      });
   // give Redis some time to register the subscription
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -54,48 +54,6 @@ class RedisTest : public ::testing::Test {
   }
 };
 
-TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
-  // Register the application to link to
-  std::string name = "my_app_name";
-  InputType input_type = InputType::Doubles;
-  std::string policy = "exp3_policy";
-  std::string default_output = "1.0";
-  int latency_slo_micros = 10000;
-  ASSERT_TRUE(add_application(*redis_, name, input_type, policy, default_output,
-                              latency_slo_micros));
-
-  std::condition_variable_any notification_recv;
-  std::mutex notification_mutex;
-  std::atomic<bool> recv{false};
-  subscribe_to_model_link_changes(
-      *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
-                        const std::string& key, const std::string& event_type) {
-        log_info(LOGGING_TAG_REDIS_TEST, "Received event");
-        ASSERT_EQ(event_type, "sadd");
-        log_info(LOGGING_TAG_REDIS_TEST, "Confirmed event is SADD");
-        std::unique_lock<std::mutex> l(notification_mutex);
-        log_info(LOGGING_TAG_REDIS_TEST, "Got lock in subscription callback");
-        recv = true;
-        ASSERT_EQ(key, name);
-        log_info(LOGGING_TAG_REDIS_TEST, "Before cv notify");
-        notification_recv.notify_all();
-        log_info(LOGGING_TAG_REDIS_TEST, "After cv notify");
-      });
-  // give Redis some time to register the subscription
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-  std::vector<std::string> model_names = {"model1", "model2"};
-  log_info(LOGGING_TAG_REDIS_TEST, "Before add_mode_links");
-  ASSERT_TRUE(add_model_links(*redis_, name, model_names));
-  log_info(LOGGING_TAG_REDIS_TEST, "After add_mode_links");
-  std::unique_lock<std::mutex> l(notification_mutex);
-  log_info(LOGGING_TAG_REDIS_TEST, "Got lock outside of subscription callback");
-  bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),
-                                           [&recv]() { return recv == true; });
-  log_info(LOGGING_TAG_REDIS_TEST, "After waiting on cv");
-  ASSERT_TRUE(result);
-}
-
 TEST_F(RedisTest, ParseModelReplicaKey) {
   VersionedModelId model = VersionedModelId("model1", "4");
   int replica_id = 7;
@@ -604,6 +562,40 @@ TEST_F(RedisTest, SubscriptionDetectModelVersionAdd) {
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   ASSERT_TRUE(set_current_model_version(*redis_, model_name, "1"));
+
+  std::unique_lock<std::mutex> l(notification_mutex);
+  bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),
+                                           [&recv]() { return recv == true; });
+  ASSERT_TRUE(result);
+}
+
+TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
+  // Register the application to link to
+  std::string name = "my_app_name";
+  InputType input_type = InputType::Doubles;
+  std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  ASSERT_TRUE(add_application(*redis_, name, input_type, policy, default_output,
+                              latency_slo_micros));
+
+  std::condition_variable_any notification_recv;
+  std::mutex notification_mutex;
+  std::atomic<bool> recv{false};
+  subscribe_to_model_link_changes(
+      *subscriber_, [&notification_recv, &notification_mutex, &recv, name](
+              const std::string& key, const std::string& event_type) {
+          ASSERT_EQ(event_type, "sadd");
+          std::unique_lock<std::mutex> l(notification_mutex);
+          recv = true;
+          ASSERT_EQ(key, name);
+          notification_recv.notify_all();
+      });
+  // give Redis some time to register the subscription
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  std::vector<std::string> model_names = {"model1", "model2"};
+  ASSERT_TRUE(add_model_links(*redis_, name, model_names));
 
   std::unique_lock<std::mutex> l(notification_mutex);
   bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -1059,6 +1059,13 @@ class RequestHandler {
 
     std::vector<std::string> versions =
         clipper::redis::get_model_versions(redis_connection_, model_name);
+
+    if (versions.size() == 0) {
+      std::stringstream ss;
+      ss << "Cannot set version for nonexistent model " << model_name;
+      throw std::invalid_argument(ss.str());
+    }
+
     bool version_exists = false;
     for (auto v : versions) {
       if (v == new_model_version) {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -527,7 +527,7 @@ class RequestHandler {
       validate_group_str_for_redis(model_name, "model name");
     }
 
-    if (clipper::redis::add_app_link(redis_connection_, app_name,
+    if (clipper::redis::add_app_links(redis_connection_, app_name,
                                      model_names)) {
       return "Success!";
     } else {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -528,7 +528,7 @@ class RequestHandler {
     }
 
     if (clipper::redis::add_app_links(redis_connection_, app_name,
-                                     model_names)) {
+                                      model_names)) {
       return "Success!";
     } else {
       std::stringstream ss;

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -588,6 +588,16 @@ TEST_F(ManagementFrontendTest, TestSetModelVersionCorrect) {
   ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version_2);
 }
 
+TEST_F(ManagementFrontendTest, TestSetVersionNonexistentModel) {
+  std::string model_name = "m";
+  std::string model_version = "1";
+
+  std::string set_model_version_json =
+      get_set_model_version_request_json(model_name, model_version);
+  ASSERT_THROW(rh_.set_model_version(set_model_version_json),
+               std::invalid_argument);
+}
+
 TEST_F(ManagementFrontendTest, TestSetModelInvalidVersion) {
   std::string model_name = "m";
   std::string model_version_1 = "1";

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -56,7 +56,8 @@ class ManagementFrontendTest : public ::testing::Test {
                                        std::string& default_output,
                                        int latency_slo_micros) {
     rapidjson::Document d;
-    set_add_app_request_doc(d, name, input_type, default_output, latency_slo_micros);
+    set_add_app_request_doc(d, name, input_type, default_output,
+                            latency_slo_micros);
     return to_json_string(d);
   }
 
@@ -76,17 +77,16 @@ class ManagementFrontendTest : public ::testing::Test {
     add_string(d, "model_data_path", model_data_path);
   }
 
-
-  void set_add_app_links_request_doc(rapidjson::Document &d,
-                                     std::string &app_name,
+  void set_add_app_links_request_doc(rapidjson::Document& d,
+                                     std::string& app_name,
                                      std::vector<std::string>& model_names) {
     d.SetObject();
     add_string(d, "app_name", app_name);
     add_string_array(d, "model_names", model_names);
   }
 
-  std::string get_add_app_links_request_json(std::string& name,
-                                             std::vector<std::string>& model_names) {
+  std::string get_add_app_links_request_json(
+      std::string& name, std::vector<std::string>& model_names) {
     rapidjson::Document d;
     set_add_app_links_request_doc(d, name, model_names);
     return to_json_string(d);
@@ -115,7 +115,8 @@ TEST_F(ManagementFrontendTest, TestAddApplicationCorrect) {
   std::string app_name = "myappname";
   std::string input_type = "integers";
   std::string default_output = "4.3";
-  std::string add_app_json = get_add_app_request_json(app_name, input_type, default_output, 1000);
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
 
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
   auto result = get_application(*redis_, app_name);
@@ -153,11 +154,14 @@ TEST_F(ManagementFrontendTest, TestAddAppLink) {
   std::string app_name = "myappname";
   std::string input_type = "integers";
   std::string default_output = "4.3";
-  std::string add_app_json = get_add_app_request_json(app_name, input_type, default_output, 1000);
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
 
-  std::vector<std::string> model_names = std::vector<std::string>{"mymodelname"};
-  std::string add_links_json = get_add_app_links_request_json(app_name, model_names);
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"mymodelname"};
+  std::string add_links_json =
+      get_add_app_links_request_json(app_name, model_names);
 
   ASSERT_EQ(rh_.add_app_links(add_links_json), "Success!");
   std::vector<std::string> result = get_app_links(*redis_, app_name);
@@ -173,18 +177,23 @@ TEST_F(ManagementFrontendTest, TestAddAppLinkWhenAlreadyExists) {
   std::string app_name = "myappname";
   std::string input_type = "integers";
   std::string default_output = "4.3";
-  std::string add_app_json = get_add_app_request_json(app_name, input_type, default_output, 1000);
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
 
-  std::vector<std::string> model_names = std::vector<std::string>{"mymodelname"};
-  std::string add_links_json = get_add_app_links_request_json(app_name, model_names);
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"mymodelname"};
+  std::string add_links_json =
+      get_add_app_links_request_json(app_name, model_names);
   ASSERT_EQ(rh_.add_app_links(add_links_json), "Success!");
 
   // Attempts to re-add already existing links should work
   ASSERT_EQ(rh_.add_app_links(add_links_json), "Success!");
 
-  std::vector<std::string> new_model_names = std::vector<std::string>{"mymodelname2"};
-  std::string add_new_links_json = get_add_app_links_request_json(app_name, new_model_names);
+  std::vector<std::string> new_model_names =
+      std::vector<std::string>{"mymodelname2"};
+  std::string add_new_links_json =
+      get_add_app_links_request_json(app_name, new_model_names);
 
   // When adding a new, second link, it should break
   ASSERT_THROW(rh_.add_app_links(add_new_links_json), std::invalid_argument);
@@ -192,8 +201,10 @@ TEST_F(ManagementFrontendTest, TestAddAppLinkWhenAlreadyExists) {
 
 TEST_F(ManagementFrontendTest, TestAddAppLinkToNonexistentApp) {
   std::string app_name = "myappname";
-  std::vector<std::string> model_names = std::vector<std::string>{"mymodelname"};
-  std::string add_links_json = get_add_app_links_request_json(app_name, model_names);
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"mymodelname"};
+  std::string add_links_json =
+      get_add_app_links_request_json(app_name, model_names);
 
   ASSERT_THROW(rh_.add_app_links(add_links_json), std::invalid_argument);
 }
@@ -203,7 +214,8 @@ TEST_F(ManagementFrontendTest, TestAddAppLinksProhibitedChars) {
   std::string input_type = "doubles";
   std::string default_output = "my_default_output";
   int latency_slo_micros = 10000;
-  std::string add_app_json = get_add_app_request_json(app_name, input_type, default_output, latency_slo_micros);
+  std::string add_app_json = get_add_app_request_json(
+      app_name, input_type, default_output, latency_slo_micros);
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
 
   std::stringstream ss;
@@ -212,8 +224,10 @@ TEST_F(ManagementFrontendTest, TestAddAppLinksProhibitedChars) {
   std::vector<std::string> bad_model_names = {bad_model_name};
 
   // Attempting to add an app link to a model with invalid character should fail
-  std::string add_app_bad_links_json = get_add_app_links_request_json(app_name, bad_model_names);
-  ASSERT_THROW(rh_.add_app_links(add_app_bad_links_json), std::invalid_argument);
+  std::string add_app_bad_links_json =
+      get_add_app_links_request_json(app_name, bad_model_names);
+  ASSERT_THROW(rh_.add_app_links(add_app_bad_links_json),
+               std::invalid_argument);
 }
 
 TEST_F(ManagementFrontendTest, TestAddAppLinkMalformedJson) {
@@ -232,7 +246,8 @@ TEST_F(ManagementFrontendTest, TestAddAppLinkMissingField) {
       "app_name": "myappname"
     }
   )";
-  ASSERT_THROW(rh_.add_app_links(missing_field_add_links_json), json_semantic_error);
+  ASSERT_THROW(rh_.add_app_links(missing_field_add_links_json),
+               json_semantic_error);
 }
 
 TEST_F(ManagementFrontendTest, TestGetAppLinks) {
@@ -240,7 +255,8 @@ TEST_F(ManagementFrontendTest, TestGetAppLinks) {
   std::string app_name = "myappname";
   std::string input_type = "integers";
   std::string default_output = "4.3";
-  std::string add_app_json = get_add_app_request_json(app_name, input_type, default_output, 1000);
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
 
   // Confirm that no links exist
@@ -249,8 +265,10 @@ TEST_F(ManagementFrontendTest, TestGetAppLinks) {
   ASSERT_EQ("[]", result);
 
   // Add the link
-  std::vector<std::string> model_names = std::vector<std::string>{"mymodelname"};
-  std::string add_links_json = get_add_app_links_request_json(app_name, model_names);
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"mymodelname"};
+  std::string add_links_json =
+      get_add_app_links_request_json(app_name, model_names);
   ASSERT_EQ(rh_.add_app_links(add_links_json), "Success!");
 
   result = rh_.get_app_links(get_app_links_json);
@@ -277,13 +295,15 @@ TEST_F(ManagementFrontendTest, TestGetAppLinksMalformedJson) {
       app_name : "a
     }
   )";
-  ASSERT_THROW(rh_.get_app_links(malformed_get_app_links_json), json_parse_error);
+  ASSERT_THROW(rh_.get_app_links(malformed_get_app_links_json),
+               json_parse_error);
 }
 TEST_F(ManagementFrontendTest, TestAddDuplicateApplication) {
   std::string app_name = "myappname";
   std::string input_type = "integers";
   std::string default_output = "4.3";
-  std::string add_app_json = get_add_app_request_json(app_name, input_type, default_output, 1000);
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
 
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
   auto result = get_application(*redis_, "myappname");
@@ -295,15 +315,14 @@ TEST_F(ManagementFrontendTest, TestAddDuplicateApplication) {
   ASSERT_THROW(rh_.add_application(add_app_json), std::invalid_argument);
 }
 
-
-
 TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
   // Register the application
   std::string name = "my_app_name";
   std::string input_type = "doubles";
   std::string default_output = "my_default_output";
   int latency_slo_micros = 10000;
-  std::string add_app_json = get_add_app_request_json(name, input_type, default_output, latency_slo_micros);
+  std::string add_app_json = get_add_app_request_json(
+      name, input_type, default_output, latency_slo_micros);
   ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
 
   std::string get_app_json = get_app_json_request_string(name);
@@ -315,11 +334,13 @@ TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
 
   std::string response_name = get_string(response_doc, "name");
   std::string response_input_type = get_string(response_doc, "input_type");
-  std::string response_default_output = get_string(response_doc, "default_output");
+  std::string response_default_output =
+      get_string(response_doc, "default_output");
   int response_latency_slo_micros = get_int(response_doc, "latency_slo_micros");
   auto initial_linked_models = get_string_array(response_doc, "linked_models");
 
-  // Confirm that get_application results match values submitted with registration request
+  // Confirm that get_application results match values submitted with
+  // registration request
   ASSERT_EQ(response_name, name);
   ASSERT_EQ(response_input_type, input_type);
   ASSERT_EQ(response_default_output, default_output);
@@ -327,8 +348,10 @@ TEST_F(ManagementFrontendTest, TestGetApplicationCorrect) {
   ASSERT_EQ(initial_linked_models, std::vector<std::string>{});
 
   // Link models
-  std::vector<std::string> model_names = std::vector<std::string>{"mymodelname"};
-  std::string add_links_json = get_add_app_links_request_json(name, model_names);
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"mymodelname"};
+  std::string add_links_json =
+      get_add_app_links_request_json(name, model_names);
   ASSERT_EQ(rh_.add_app_links(add_links_json), "Success!");
 
   json_response = rh_.get_application(get_app_json);
@@ -367,15 +390,19 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsVerboseCorrect) {
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
 
-  std::string add_app1_json_string = get_add_app_request_json(name1, input_type, default_output, latency_slo_micros);
-  std::string add_app2_json_string = get_add_app_request_json(name2, input_type, default_output, latency_slo_micros);
+  std::string add_app1_json_string = get_add_app_request_json(
+      name1, input_type, default_output, latency_slo_micros);
+  std::string add_app2_json_string = get_add_app_request_json(
+      name2, input_type, default_output, latency_slo_micros);
 
   ASSERT_EQ(rh_.add_application(add_app1_json_string), "Success!");
   ASSERT_EQ(rh_.add_application(add_app2_json_string), "Success!");
 
   // Link models to app with name app1
-  std::vector<std::string> model_names = std::vector<std::string>{"mymodelname"};
-  std::string add_links_json = get_add_app_links_request_json(name1, model_names);
+  std::vector<std::string> model_names =
+      std::vector<std::string>{"mymodelname"};
+  std::string add_links_json =
+      get_add_app_links_request_json(name1, model_names);
   ASSERT_EQ(rh_.add_app_links(add_links_json), "Success!");
 
   std::string get_apps_verbose_json = R"(
@@ -403,16 +430,24 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsVerboseCorrect) {
   }
 
   std::string app1_response_name = get_string(app1_response_doc, "name");
-  std::string app1_response_input_type = get_string(app1_response_doc, "input_type");
-  std::string app1_response_default_output = get_string(app1_response_doc, "default_output");
-  int app1_response_latency_slo_micros = get_int(app1_response_doc, "latency_slo_micros");
-  auto app1_linked_models = get_string_array(app1_response_doc, "linked_models");
+  std::string app1_response_input_type =
+      get_string(app1_response_doc, "input_type");
+  std::string app1_response_default_output =
+      get_string(app1_response_doc, "default_output");
+  int app1_response_latency_slo_micros =
+      get_int(app1_response_doc, "latency_slo_micros");
+  auto app1_linked_models =
+      get_string_array(app1_response_doc, "linked_models");
 
   std::string app2_response_name = get_string(app2_response_doc, "name");
-  std::string app2_response_input_type = get_string(app2_response_doc, "input_type");
-  std::string app2_response_default_output = get_string(app2_response_doc, "default_output");
-  int app2_response_latency_slo_micros = get_int(app2_response_doc, "latency_slo_micros");
-  auto app2_linked_models = get_string_array(app2_response_doc, "linked_models");
+  std::string app2_response_input_type =
+      get_string(app2_response_doc, "input_type");
+  std::string app2_response_default_output =
+      get_string(app2_response_doc, "default_output");
+  int app2_response_latency_slo_micros =
+      get_int(app2_response_doc, "latency_slo_micros");
+  auto app2_linked_models =
+      get_string_array(app2_response_doc, "linked_models");
 
   ASSERT_EQ(app1_response_name, name1);
   ASSERT_EQ(app1_response_input_type, input_type);
@@ -460,8 +495,10 @@ TEST_F(ManagementFrontendTest, TestGetAllApplicationsNotVerboseCorrect) {
   std::string default_output = "1.0";
   int latency_slo_micros = 10000;
 
-  std::string add_app1_json_string = get_add_app_request_json(name1, input_type, default_output, latency_slo_micros);
-  std::string add_app2_json_string = get_add_app_request_json(name2, input_type, default_output, latency_slo_micros);
+  std::string add_app1_json_string = get_add_app_request_json(
+      name1, input_type, default_output, latency_slo_micros);
+  std::string add_app2_json_string = get_add_app_request_json(
+      name2, input_type, default_output, latency_slo_micros);
 
   ASSERT_EQ(rh_.add_application(add_app1_json_string), "Success!");
   ASSERT_EQ(rh_.add_application(add_app2_json_string), "Success!");

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -657,6 +657,99 @@ TEST_F(ManagementFrontendTest, TestAddModelLinkCorrect) {
   ASSERT_EQ(model_names, result);
 }
 
+TEST_F(ManagementFrontendTest, TestAddModelLinkIncompatibleInputType) {
+  std::string app_name = "myappname";
+  std::string app_input_type = "integers";
+  std::string default_output = "4.3";
+  std::string add_app_json =
+      get_add_app_request_json(app_name, app_input_type, default_output, 1000);
+  ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
+
+  std::string model_name = "mymodelname";
+  std::string model_version = "4";
+  std::string model_input_type = "doubles";
+  std::string container_name = "container/name";
+  std::string model_data_path = "tmp/model";
+  std::vector<std::string> labels = {"l1", "l2"};
+  std::string add_model_json =
+      get_add_model_request_json(model_name, model_version, model_input_type,
+                                 labels, container_name, model_data_path);
+  ASSERT_EQ(rh_.add_model(add_model_json), "Success!");
+
+  std::vector<std::string> model_names = std::vector<std::string>{model_name};
+  std::string add_links_json =
+      get_add_model_links_request_json(app_name, model_names);
+
+  ASSERT_THROW(rh_.add_model_links(add_links_json), std::invalid_argument);
+}
+
+TEST_F(ManagementFrontendTest, TestAddNewLinkedModelIncompatibleInputType) {
+  std::string app_name = "myappname";
+  std::string input_type = "integers";
+  std::string default_output = "4.3";
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
+  ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
+
+  std::string model_name = "mymodelname";
+  std::string model_version = "4";
+  std::string container_name = "container/name";
+  std::string model_data_path = "tmp/model";
+  std::vector<std::string> labels = {"l1", "l2"};
+  std::string add_compatible_model_json =
+      get_add_model_request_json(model_name, model_version, input_type, labels,
+                                 container_name, model_data_path);
+  ASSERT_EQ(rh_.add_model(add_compatible_model_json), "Success!");
+
+  std::vector<std::string> model_names = std::vector<std::string>{model_name};
+  std::string add_links_json =
+      get_add_model_links_request_json(app_name, model_names);
+
+  ASSERT_EQ(rh_.add_model_links(add_links_json), "Success!");
+
+  std::string incompatible_model_input_type = "doubles";
+  std::string add_incompatible_model_json = get_add_model_request_json(
+      model_name, model_version, incompatible_model_input_type, labels,
+      container_name, model_data_path);
+  ASSERT_THROW(rh_.add_model(add_incompatible_model_json),
+               std::invalid_argument);
+}
+
+TEST_F(ManagementFrontendTest,
+       TestSetModellVersionForLinkedModelIncompatibleInputType) {
+  std::string app_name = "myappname";
+  std::string input_type = "integers";
+  std::string default_output = "4.3";
+  std::string add_app_json =
+      get_add_app_request_json(app_name, input_type, default_output, 1000);
+  ASSERT_EQ(rh_.add_application(add_app_json), "Success!");
+
+  std::string incompatible_model_input_type = "doubles";
+  std::string compatible_model_version = "2";
+  std::string model_name = "mymodelname";
+  std::string incompatible_model_version = "1";
+  std::string container_name = "container/name";
+  std::string model_data_path = "tmp/model";
+  std::vector<std::string> labels = {"l1", "l2"};
+
+  std::string add_incompatible_model_json = get_add_model_request_json(
+      model_name, incompatible_model_version, incompatible_model_input_type,
+      labels, container_name, model_data_path);
+  std::string add_compatible_model_json = get_add_model_request_json(
+      model_name, compatible_model_version, input_type, labels, container_name,
+      model_data_path);
+  ASSERT_EQ(rh_.add_model(add_incompatible_model_json), "Success!");
+  ASSERT_EQ(rh_.add_model(add_compatible_model_json), "Success!");
+
+  std::vector<std::string> model_names = std::vector<std::string>{model_name};
+  std::string add_links_json =
+      get_add_model_links_request_json(app_name, model_names);
+  ASSERT_EQ(rh_.add_model_links(add_links_json), "Success!");
+
+  ASSERT_THROW(rh_.set_model_version(model_name, incompatible_model_version),
+               std::invalid_argument);
+}
+
 TEST_F(ManagementFrontendTest, TestAddModelLinkWithNonexistentModel) {
   std::string app_name = "myappname";
   std::string input_type = "integers";


### PR DESCRIPTION
This PR addresses the third checkbox in #218. It only allows for adding links -- I'll work on a PR that allows for removing links after this gets edited and merged.

Given that users cannot yet remove links and that we limit apps to having at most 1 linked model, the only real difference this PR introduces to Clipper users is that app's candidate models (we now call them linked models) can be specified after app registration.