### PR TITLE
Update Python container to correctly run "pip install cryptography"

### DIFF
--- a/PythonContainerDockerfile
+++ b/PythonContainerDockerfile
@@ -2,6 +2,8 @@ FROM clipper/py-rpc:latest
 
 MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>
 
+RUN apt-get install -yqq build-essential libssl-dev libffi-dev python-dev
+
 COPY containers/python/python_container_conda_deps.txt /lib/
 RUN conda install -y --file /lib/python_container_conda_deps.txt
 

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -678,7 +678,6 @@ class Clipper:
                                 version,
                                 predict_function,
                                 input_type,
-                                container_name="clipper/python-container"
                                 labels=DEFAULT_LABEL,
                                 num_containers=1):
         """Deploy an arbitrary Python function to Clipper.
@@ -699,16 +698,6 @@ class Clipper:
             captured via closure capture.
         input_type : str
             One of "integers", "floats", "doubles", "bytes", or "strings".
-        container_name : str, optional
-            The Docker container image to use to run this model container.
-            By default this will use the clipper/python-container Docker image distributed
-            by Clipper. This container has several common Python packages already installed
-            and will attempt to install any missing dependencies at runtime.
-            If your predict function requires additional dependencies that the default container
-            fails to install automatically, you can create a custom Docker image that contains
-            those dependencies and specify the custom container in the ``container_name``
-            argument. This custom container must be compatible with clipper/python-container
-            container.
         labels : list of str, optional
             A list of strings annotating the model.
         num_containers : int, optional
@@ -744,11 +733,12 @@ class Clipper:
                 num_containers=1)
         """
 
+        default_python_container = "clipper/python-container"
         serialization_dir = self._save_python_function(name, predict_function)
 
         # Deploy function
         deploy_result = self.deploy_model(name, version, serialization_dir,
-                                          container_name, input_type,
+                                          default_python_container, input_type,
                                           labels, num_containers)
         # Remove temp files
         shutil.rmtree(serialization_dir)

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -678,6 +678,7 @@ class Clipper:
                                 version,
                                 predict_function,
                                 input_type,
+                                container_name="clipper/python-container"
                                 labels=DEFAULT_LABEL,
                                 num_containers=1):
         """Deploy an arbitrary Python function to Clipper.
@@ -698,6 +699,16 @@ class Clipper:
             captured via closure capture.
         input_type : str
             One of "integers", "floats", "doubles", "bytes", or "strings".
+        container_name : str, optional
+            The Docker container image to use to run this model container.
+            By default this will use the clipper/python-container Docker image distributed
+            by Clipper. This container has several common Python packages already installed
+            and will attempt to install any missing dependencies at runtime.
+            If your predict function requires additional dependencies that the default container
+            fails to install automatically, you can create a custom Docker image that contains
+            those dependencies and specify the custom container in the ``container_name``
+            argument. This custom container must be compatible with clipper/python-container
+            container.
         labels : list of str, optional
             A list of strings annotating the model.
         num_containers : int, optional
@@ -733,12 +744,11 @@ class Clipper:
                 num_containers=1)
         """
 
-        default_python_container = "clipper/python-container"
         serialization_dir = self._save_python_function(name, predict_function)
 
         # Deploy function
         deploy_result = self.deploy_model(name, version, serialization_dir,
-                                          default_python_container, input_type,
+                                          container_name, input_type,
                                           labels, num_containers)
         # Remove temp files
         shutil.rmtree(serialization_dir)

--- a/containers/python/python_container_conda_deps.txt
+++ b/containers/python/python_container_conda_deps.txt
@@ -3,6 +3,7 @@ backports_abc
 bleach
 certifi
 configparser
+cryptography
 decorator
 entrypoints
 enum34


### PR DESCRIPTION
If the user has a version of the cryptography library installed with pip, this change allows the model container to build it from source as the pip package requires. The cryptography library has C extensions, so it requires a compiler to build it.

In particular, this case is important to support because the `clipper_admin` pip package installs the cryptography as a dependency (by way of the fabric dependency).