### PR TITLE
Handling for internal server errors

### DIFF
--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -289,13 +289,15 @@ class RequestHandler {
             request->content.string(), name, versioned_models, policy,
             latency_slo_micros, input_type);
         prediction.then([response, app_metrics](boost::future<Response> f) {
-          if(f.has_exception()) {
+          if (f.has_exception()) {
             try {
               boost::rethrow_exception(f.get_exception_ptr());
-            } catch(std::exception& e) {
-              clipper::log_error_formatted(clipper::LOGGING_TAG_CLIPPER, "Unexpected error: {}", e.what());
+            } catch (std::exception& e) {
+              clipper::log_error_formatted(clipper::LOGGING_TAG_CLIPPER,
+                                           "Unexpected error: {}", e.what());
             }
-            respond_http("An unexpected error occurred!", "500 Internal Server Error", response);
+            respond_http("An unexpected error occurred!",
+                         "500 Internal Server Error", response);
             return;
           }
 

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -1,6 +1,5 @@
 #include <cassert>
 #include <iostream>
-#include <sstream>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -7,10 +7,10 @@
 #include <unordered_map>
 
 #define PROVIDES_EXECUTORS
+#include <boost/exception_ptr.hpp>
 #include <boost/optional.hpp>
 #include <boost/thread.hpp>
 #include <boost/thread/executors/basic_thread_pool.hpp>
-#include <boost/exception_ptr.hpp>
 
 #include <clipper/containers.hpp>
 #include <clipper/datatypes.hpp>
@@ -120,7 +120,8 @@ boost::future<Response> QueryProcessor::predict(Query query) {
         } catch (std::exception& e) {
           log_error_formatted(
               LOGGING_TAG_QUERY_PROCESSOR,
-              "Unexpected error while executing prediction tasks: {}", e.what());
+              "Unexpected error while executing prediction tasks: {}",
+              e.what());
         }
       } else if ((*r).is_ready()) {
         outputs.push_back((*r).get());


### PR DESCRIPTION
If the thread of execution responsible for delivering an HTTP prediction response encounters an unexpected error, this PR ensures that we respond with error code 500 instead of timing out.