### PR TITLE
[Do not merge] Script for tracking thread behavior

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,16 @@
+{
+  "cifar_data_path":"/Users/nishadsingh/Documents/clip/dataset/cifar-100-binary/test.bin",
+  "num_threads":"1",
+  "num_batches":"10000",
+  "request_batch_size":"1",
+  "request_batch_delay_micros":"10",
+  "poisson_delay":"false",
+  "prevent_cache_hits":"true",
+  "latency_objective":"25000",
+  "report_delay_seconds":"-1",
+  "model_name":"bench_noop",
+  "model_version":"1",
+  "benchmark_report_path":"/Users/nishadsingh/Documents/clip/thread_reports/r_sendrate_10_numbatch_250000.txt",
+  "thread_counts_report_path":"/Users/nishadsingh/Documents/clip/thread_reports/t_sendrate_10_numbatch_250000_test.txt",
+  "sleep_afer_send_time_sec":"5"
+}

--- a/configure
+++ b/configure
@@ -268,7 +268,7 @@ cd $RELEASE_DIR
 rm -f CMakeCache.txt
 build_cmd="$CMAKE \
     $GENERATOR \
-    -D CMAKE_BUILD_TYPE=Release \
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo \
     $CFLAGS \
     ../"
 echo $build_cmd | tee -a "../$LOG_FILE"

--- a/src/benchmarks/src/end_to_end_bench.cpp
+++ b/src/benchmarks/src/end_to_end_bench.cpp
@@ -89,19 +89,19 @@ void send_predictions(std::unordered_map<std::string, std::string> &config,
                  query_num};
       bench_metrics.request_throughput_->mark(1);
 
-//      set_q_path_bench_script(query_num, std::this_thread::get_id());
-//      update_bench_script_count(std::this_thread::get_id());
-//      log_info("qid", query_num, "send request", std::this_thread::get_id());
+      set_q_path_bench_script(query_num, std::this_thread::get_id());
+      update_bench_script_count(std::this_thread::get_id());
+      log_info("qid", query_num, "send request", std::this_thread::get_id());
 
       if (SEND_REQUESTS) {
         boost::future<Response> prediction = qp.predict(q);
         prediction.then([bench_metrics](boost::future<Response> f) {
           Response r = f.get();
 
-//          set_q_path_bench_cont(r.query_.test_qid_,
-//                                              std::this_thread::get_id());
-//          update_bench_cont_count(std::this_thread::get_id());
-//          log_info("qid", r.query_.test_qid_, "bench continuation", std::this_thread::get_id());
+          set_q_path_bench_cont(r.query_.test_qid_,
+                                              std::this_thread::get_id());
+          update_bench_cont_count(std::this_thread::get_id());
+          log_info("qid", r.query_.test_qid_, "bench continuation", std::this_thread::get_id());
 
           // Update metrics
           if (r.output_is_default_) {
@@ -358,9 +358,9 @@ void run_benchmark(std::unordered_map<std::string, std::string> &config) {
           .count();
 
   for (int j = 0; j < num_threads; j++) {
-    std::vector<std::vector<double>> thread_datapoints(datapoints);
+//    std::vector<std::vector<double>> thread_datapoints(datapoints);
     std::thread thread([&]() {
-      send_predictions(config, qp, thread_datapoints, bench_metrics, j);
+      send_predictions(config, qp, datapoints, bench_metrics, j);
     });
     threads.push_back(std::move(thread));
   }
@@ -393,9 +393,9 @@ void run_benchmark(std::unordered_map<std::string, std::string> &config) {
     std::this_thread::sleep_for(std::chrono::seconds(sleep_amt));
   }
 
-//  std::thread report_t_counts_metrics_thread(
-//      [&]() { report_t_counts_metrics(config); });
-//  report_t_counts_metrics_thread.join();
+  std::thread report_t_counts_metrics_thread(
+      [&]() { report_t_counts_metrics(config); });
+  report_t_counts_metrics_thread.join();
 
   log_info("BENCH", "Terminating benchmarking script");
   std::terminate();

--- a/src/benchmarks/src/end_to_end_bench.cpp
+++ b/src/benchmarks/src/end_to_end_bench.cpp
@@ -359,7 +359,7 @@ void run_benchmark(std::unordered_map<std::string, std::string> &config) {
 
   for (int j = 0; j < num_threads; j++) {
 //    std::vector<std::vector<double>> thread_datapoints(datapoints);
-    std::thread thread([&]() {
+    std::thread thread([&config, &qp, datapoints, &bench_metrics, j]() {
       send_predictions(config, qp, datapoints, bench_metrics, j);
     });
     threads.push_back(std::move(thread));

--- a/src/benchmarks/src/end_to_end_bench.cpp
+++ b/src/benchmarks/src/end_to_end_bench.cpp
@@ -248,14 +248,28 @@ void report_t_counts_metrics(
 
   auto t_counts_table = get_t_counts_table();
   std::stringstream t_ss;
+  std::vector<int> num_threads_executing_event = {0, 0, 0, 0, 0};
   t_ss << std::endl;
   for (auto it = begin(t_counts_table); it != end(t_counts_table); ++it) {
     t_ss << it->first << ": ";
+    int i = 0;
     for (auto el : it->second) {
       t_ss << el << ", ";
+      if (el > 0) {
+        num_threads_executing_event[i] += 1;
+      }
+      i += 1;
     }
     t_ss << std::endl;
   }
+
+  std::stringstream num_threads_executing_event_ss;
+  for (auto el : num_threads_executing_event) {
+    num_threads_executing_event_ss << el << " : ";
+  }
+  report_file << "num_threads_executing_event_ss:    " << num_threads_executing_event_ss.str() << std::endl;
+
+
   std::string table = t_ss.str();
   log_info("TABLE", table);
   report_file << table << "--------------" << std::endl;
@@ -394,7 +408,7 @@ void run_benchmark(std::unordered_map<std::string, std::string> &config) {
   }
 
   std::thread report_t_counts_metrics_thread(
-      [&]() { report_t_counts_metrics(config); });
+      [&config]() { report_t_counts_metrics(config); });
   report_t_counts_metrics_thread.join();
 
   log_info("BENCH", "Terminating benchmarking script");

--- a/src/benchmarks/src/thread_info_logger.hpp
+++ b/src/benchmarks/src/thread_info_logger.hpp
@@ -1,0 +1,147 @@
+namespace thread_info_logger {
+
+class ThreadInfoLogger {
+
+public:
+  static constexpr int BENCH_SCRIPT_INDEX = 0;
+  static constexpr int TASKS_COMPLETED_INDEX = 1;
+  static constexpr int TIMER_EXPIRE_INDEX = 2;
+  static constexpr int RESPONSE_READY_INDEX = 3;
+  static constexpr int BENCH_CONT_INDEX = 4;
+
+  /**
+   * Obtains an instance of the Logger singleton
+   * that can be used to log messages at specified levels
+   */
+  static ThreadInfoLogger &get() {
+    static ThreadInfoLogger instance;
+    return instance;
+  }
+
+  static void update_bench_script_count(std::__thread_id tid) {
+    get().update_count(tid, ThreadInfoLogger::BENCH_SCRIPT_INDEX);
+  }
+
+  static void update_tasks_completed_count(std::__thread_id tid) {
+    get().update_count(tid, ThreadInfoLogger::TASKS_COMPLETED_INDEX);
+  }
+
+  static void update_response_ready_count(std::__thread_id tid) {
+    get().update_count(tid, ThreadInfoLogger::RESPONSE_READY_INDEX);
+  }
+
+  static void update_bench_cont_count(std::__thread_id tid) {
+    get().update_count(tid, ThreadInfoLogger::BENCH_CONT_INDEX);
+  }
+
+  static void update_timer_expire_count(std::__thread_id tid) {
+    get().update_count(tid, ThreadInfoLogger::TIMER_EXPIRE_INDEX);
+  }
+
+  static std::unordered_map <std::__thread_id, std::vector<int>> get_t_counts_table() {
+    return get().t_counts_table;
+  };
+
+  static void create_q_path_entry(int qid) {
+    get().add_q_path_entry(qid);
+  }
+
+  static void set_q_path_bench_script(int qid, std::__thread_id tid) {
+    get().update_q_path(qid, tid, ThreadInfoLogger::BENCH_SCRIPT_INDEX);
+  }
+
+  static void set_q_path_tasks_completed(int qid, std::__thread_id tid) {
+    get().update_q_path_task(qid, tid);
+  }
+
+  static void set_q_path_timer_expire(int qid, std::__thread_id tid) {
+    get().update_q_path_timer(qid, tid);
+  }
+
+  static void set_q_path_response_ready(int qid, std::__thread_id tid) {
+    get().update_q_path(qid, tid, ThreadInfoLogger::RESPONSE_READY_INDEX);
+  }
+
+  static void set_q_path_bench_cont(int qid, std::__thread_id tid) {
+    get().update_q_path_response_received(qid, tid);
+  }
+
+//static std::unordered_map<int, std::pair<std::vector<std::__thread_id>, std::pair<std::atomic<int>, std::atomic<bool>>>> get_q_path_table() {
+  static std::unordered_map<int, std::pair<std::vector<std::__thread_id>, std::pair<std::pair<double, double>, bool>>> get_q_path_table() {
+    return ThreadInfoLogger::get().q_path_table;
+  }
+
+private:
+
+  /**
+   * Maps from TID ->
+   *    vector(
+   *        (int) count in benchmark script,
+   *        (int) count in when_any,
+   *        (int) count in timer expire,
+   *        (int) count in response ready,
+   *        (int) count in bench continuation
+   *    )
+   */
+  std::unordered_map <std::__thread_id, std::vector<int>> t_counts_table;
+
+  void update_count(std::__thread_id tid, int index) {
+    if (t_counts_table.find(tid) == t_counts_table.end()) {
+      t_counts_table[tid] = std::vector<int> {0, 0, 0, 0, 0};
+    }
+
+    auto vec = t_counts_table[tid];
+    vec[index] += 1;
+    t_counts_table[tid] = vec;
+  }
+
+//  std::unordered_map<int, std::pair<std::vector<std::__thread_id>, std::pair<std::atomic<int>, std::atomic<bool>>>> q_path_table;
+  /**
+   * Maps from Query ID ->
+   *    pair(
+   *        vector(
+   *            (tid) id of thread that executed benchmark script,
+   *            (tid) id for when_any,
+   *            (tid) id for timer_expire,
+   *            (tid) id for response_ready,
+   *            (tid) id for bench continuation
+   *        ),
+   *        pair(
+   *            pair(
+   *                time (microseconds since epoch) at which tasks completed,
+   *                time (microseconds since epoch) at which timer expired
+   *            ),
+   *            (bool) if the response for this query was received in the benchmark continuation
+   *        )
+   *   )
+   */
+  std::unordered_map<int, std::pair<std::vector<std::__thread_id>, std::pair<std::pair<double, double>, bool>>> q_path_table;
+
+  void add_q_path_entry(int qid) {
+    std::__thread_id tid = std::__thread_id();
+    auto vec = std::vector<std::__thread_id>{tid, tid, tid, tid, tid};
+    q_path_table.emplace(qid, std::make_pair(vec, std::make_pair(std::make_pair(0, 0), false)));
+  }
+
+  void update_q_path(int qid, std::__thread_id tid, int index) {
+    q_path_table[qid].first[index] = tid;
+  }
+
+  void update_q_path_task(int qid, std::__thread_id tid) {
+    update_q_path(qid, tid, ThreadInfoLogger::TASKS_COMPLETED_INDEX);
+    q_path_table[qid].second.first.first = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  }
+
+  void update_q_path_timer(int qid, std::__thread_id tid) {
+    update_q_path(qid, tid, ThreadInfoLogger::TIMER_EXPIRE_INDEX);
+    q_path_table[qid].second.first.second = std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  }
+
+  void update_q_path_response_received(int qid, std::__thread_id tid) {
+    update_q_path(qid, tid, ThreadInfoLogger::BENCH_CONT_INDEX);
+    q_path_table[qid].second.second = true;
+  }
+};
+
+
+} // namespace thread_info_logger

--- a/src/libclipper/include/clipper/datatypes.hpp
+++ b/src/libclipper/include/clipper/datatypes.hpp
@@ -225,6 +225,9 @@ class Query {
   Query(std::string label, long user_id, std::shared_ptr<Input> input,
         long latency_budget_micros, std::string selection_policy,
         std::vector<VersionedModelId> candidate_models);
+  Query(std::string label, long user_id, std::shared_ptr<Input> input,
+        long latency_budget_micros, std::string selection_policy,
+        std::vector<VersionedModelId> candidate_models, int test_qid);
 
   // Note that it should be relatively cheap to copy queries because
   // the actual input won't be copied
@@ -240,6 +243,7 @@ class Query {
   // use is to distinguish queries coming from different
   // REST endpoints.
   std::string label_;
+  int test_qid_;
   long user_id_;
   std::shared_ptr<Input> input_;
   // TODO change this to a deadline instead of a duration

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -9,6 +9,7 @@
 
 #include <clipper/logging.hpp>
 #include "boost/thread.hpp"
+#include "../../benchmarks/src/thread_info_logger.hpp"
 
 namespace clipper {
 
@@ -53,7 +54,7 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all(
 }
 
 template <class T>
-std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_test(
+std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_log_thread_info(
     std::vector<boost::future<T>> futures,
     std::shared_ptr<std::atomic<int>> num_completed, Query query) {
   if (futures.size() == 0) {
@@ -69,9 +70,8 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_test(
                                        query](auto result) mutable {
       if (num_completed->fetch_add(1) + 1 == num_futures) {
         completion_promise->set_value();
-        log_info("qid", query.test_qid_, "in when_all", std::this_thread::get_id());
-        set_q_path_when_any(query.test_qid_, std::this_thread::get_id());
-        update_when_any_count(std::this_thread::get_id());
+//        thread_info_logger::ThreadInfoLogger::set_q_path_tasks_completed(query.test_qid_, std::this_thread::get_id());
+        thread_info_logger::ThreadInfoLogger::update_tasks_completed_count(std::this_thread::get_id());
         assert(*num_completed == num_futures);
       }
       return result.get();

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -69,9 +69,8 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_test(
                                        query](auto result) mutable {
       if (num_completed->fetch_add(1) + 1 == num_futures) {
         completion_promise->set_value();
-        //        log_info("TID", "Completed task futures", query.test_qid_,
-        //                 std::this_thread::get_id());
-        set_task_completion_tid(query.test_qid_, std::this_thread::get_id());
+        log_info("qid", query.test_qid_, "in when_all", std::this_thread::get_id());
+        set_q_path_when_any(query.test_qid_, std::this_thread::get_id());
         update_when_any_count(std::this_thread::get_id());
         assert(*num_completed == num_futures);
       }

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -69,9 +69,9 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_test(
                                        query](auto result) mutable {
       if (num_completed->fetch_add(1) + 1 == num_futures) {
         completion_promise->set_value();
-//        log_info("qid", query.test_qid_, "in when_all", std::this_thread::get_id());
-//        set_q_path_when_any(query.test_qid_, std::this_thread::get_id());
-//        update_when_any_count(std::this_thread::get_id());
+        log_info("qid", query.test_qid_, "in when_all", std::this_thread::get_id());
+        set_q_path_when_any(query.test_qid_, std::this_thread::get_id());
+        update_when_any_count(std::this_thread::get_id());
         assert(*num_completed == num_futures);
       }
       return result.get();

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -69,9 +69,9 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_test(
                                        query](auto result) mutable {
       if (num_completed->fetch_add(1) + 1 == num_futures) {
         completion_promise->set_value();
-        log_info("qid", query.test_qid_, "in when_all", std::this_thread::get_id());
-        set_q_path_when_any(query.test_qid_, std::this_thread::get_id());
-        update_when_any_count(std::this_thread::get_id());
+//        log_info("qid", query.test_qid_, "in when_all", std::this_thread::get_id());
+//        set_q_path_when_any(query.test_qid_, std::this_thread::get_id());
+//        update_when_any_count(std::this_thread::get_id());
         assert(*num_completed == num_futures);
       }
       return result.get();

--- a/src/libclipper/include/clipper/future.hpp
+++ b/src/libclipper/include/clipper/future.hpp
@@ -69,9 +69,10 @@ std::pair<boost::future<void>, std::vector<boost::future<T>>> when_all_test(
                                        query](auto result) mutable {
       if (num_completed->fetch_add(1) + 1 == num_futures) {
         completion_promise->set_value();
-        log_info("TID", "Completed task futures", query.test_qid_,
-                 std::this_thread::get_id());
+        //        log_info("TID", "Completed task futures", query.test_qid_,
+        //                 std::this_thread::get_id());
         set_task_completion_tid(query.test_qid_, std::this_thread::get_id());
+        update_when_any_count(std::this_thread::get_id());
         assert(*num_completed == num_futures);
       }
       return result.get();

--- a/src/libclipper/include/clipper/logging.hpp
+++ b/src/libclipper/include/clipper/logging.hpp
@@ -134,13 +134,7 @@ class Logger {
   }
 
   void _update_q_path_tasks_completed_before_timer(int qid, bool tasks_completed_first) {
-    int completed_by;
-    if (tasks_completed_first) {
-      completed_by = COMPLETED_BY_TASK;
-    } else {
-      completed_by = COMPLETED_BY_TIMER;
-    }
-    q_path_table[qid].second.first = completed_by;
+    q_path_table[qid].second.first = tasks_completed_first ? COMPLETED_BY_TASK : COMPLETED_BY_TIMER;
   }
 
   void _update_q_path_response_received(int qid) {

--- a/src/libclipper/include/clipper/logging.hpp
+++ b/src/libclipper/include/clipper/logging.hpp
@@ -14,6 +14,20 @@ static constexpr uint LOGGING_LEVEL_FORMAT_ERROR_LENGTH = 5;
 static constexpr uint LOGGING_LEVEL_FORMAT_DEBUG_LENGTH = 5;
 static constexpr uint MAX_LOGGING_LEVEL_FORMAT_LENGTH = 5;
 static constexpr uint MAX_TAG_LENGTH = 10;
+
+static constexpr int if_task_completed_reserve_value = -1;
+static constexpr int task_completed_value = 1;
+static constexpr int timer_completed_value = 0;
+//  int tid_vec_size = 6;
+static constexpr int benchmark_script_tid_index = 0;
+static constexpr int if_task_completed_index = 1;
+static constexpr int task_or_timer_completion_tid_index = 2;
+static constexpr int response_ready_continuation_tid_index = 3;
+static constexpr int benchmark_script_continuation_tid_index = 4;
+static constexpr int complete_account_index = 5;
+static constexpr int incomplete_account_value = 0;
+static constexpr int complete_account_value = 1;
+
 // Defines the logging format as [HH:MM:SS.mmm][<LOG_LEVEL>] <Message>
 // Note: <Message> includes a formatted, user-defined tag (see
 // get_formatted_tag())
@@ -81,6 +95,46 @@ class Logger {
   template <class... Args>
   void log_error_formatted(const std::string tag, const char *message,
                            Args... args) const;
+
+  // QID -> [benchmark script TID, if tasks completed, task futures completion
+  // TID if tasks completed, else timer system future completion TID, response
+  // ready future continuation TID, benchmark script continuation TID]
+  std::unordered_map<int, std::vector<int>> tid_table;
+
+  void set_benchmark_script_tid(int test_qid, int tid) {
+    auto tid_vec = std::vector<int>{0, 0, 0, 0, 0, 0};
+    tid_vec[benchmark_script_tid_index] = tid;
+    tid_vec[if_task_completed_index] = if_task_completed_reserve_value;
+    tid_vec[complete_account_index] = incomplete_account_value;
+    tid_table[test_qid] = tid_vec;
+  }
+
+  void set_timer_completion_tid(int test_qid, int tid) {
+    auto tid_vec = tid_table[test_qid];
+    if (tid_vec[if_task_completed_index] == if_task_completed_reserve_value) {
+      tid_vec[if_task_completed_index] = timer_completed_value;
+      tid_vec[task_or_timer_completion_tid_index] = tid;
+    }
+  }
+
+  void set_task_completion_tid(int test_qid, int tid) {
+    auto tid_vec = tid_table[test_qid];
+    if (tid_vec[if_task_completed_index] == if_task_completed_reserve_value) {
+      tid_vec[if_task_completed_index] = task_completed_value;
+      tid_vec[task_or_timer_completion_tid_index] = tid;
+    }
+  }
+
+  void set_response_ready_continuation_tid(int test_qid, int tid) {
+    auto tid_vec = tid_table[test_qid];
+    tid_vec[response_ready_continuation_tid_index] = tid;
+  }
+
+  void set_benchmark_script_continuation_tid(int test_qid, int tid) {
+    auto tid_vec = tid_table[test_qid];
+    tid_vec[benchmark_script_continuation_tid_index] = tid;
+    tid_vec[complete_account_index] = complete_account_value;
+  }
 
  private:
   Logger();
@@ -189,6 +243,37 @@ void Logger::concatenate_messages(std::stringstream &ss, LogLevel log_level,
     pad_logging_stream_for_alignment(ss, log_level, tag_length);
   }
   ss << message;
+}
+
+static void set_benchmark_script_tid(int test_qid, std::__thread_id tid) {
+  Logger::get().set_benchmark_script_tid(test_qid,
+                                         std::hash<std::thread::id>()(tid));
+}
+
+static void set_timer_completion_tid(int test_qid, std::__thread_id tid) {
+  Logger::get().set_timer_completion_tid(test_qid,
+                                         std::hash<std::thread::id>()(tid));
+}
+
+static void set_task_completion_tid(int test_qid, std::__thread_id tid) {
+  Logger::get().set_task_completion_tid(test_qid,
+                                        std::hash<std::thread::id>()(tid));
+}
+
+static void set_response_ready_continuation_tid(int test_qid,
+                                                std::__thread_id tid) {
+  Logger::get().set_response_ready_continuation_tid(
+      test_qid, std::hash<std::thread::id>()(tid));
+}
+
+static void set_benchmark_script_continuation_tid(int test_qid,
+                                                  std::__thread_id tid) {
+  Logger::get().set_benchmark_script_continuation_tid(
+      test_qid, std::hash<std::thread::id>()(tid));
+}
+
+static std::unordered_map<int, std::vector<int>> get_tid_table() {
+  return Logger::get().tid_table;
 }
 
 template <class... Strings>

--- a/src/libclipper/include/clipper/logging.hpp
+++ b/src/libclipper/include/clipper/logging.hpp
@@ -34,6 +34,14 @@ static constexpr int TIMER_EXPIRE_INDEX = 2;
 static constexpr int RESPONSE_READY_INDEX = 3;
 static constexpr int BENCH_CONT_INDEX = 4;
 
+static constexpr int Q_PATH_BENCH_SCRIPT_INDEX = 0;
+static constexpr int Q_PATH_TASK_OR_TIMER_INDEX = 1;
+static constexpr int Q_PATH_RESPONSE_READY_INDEX = 2;
+static constexpr int Q_PATH_BENCH_CONT_INDEX = 3;
+
+//    [count in benchmark, count in when any, count in timer expire,
+    // count in response ready, count in bench continuation]
+
 
 // Defines the logging format as [HH:MM:SS.mmm][<LOG_LEVEL>] <Message>
 // Note: <Message> includes a formatted, user-defined tag (see
@@ -103,14 +111,44 @@ class Logger {
   void log_error_formatted(const std::string tag, const char *message,
                            Args... args) const;
 
-  // QID -> [benchmark script TID, if tasks completed, task futures completion
-  // TID if tasks completed, else timer system future completion TID, response
-  // ready future continuation TID, benchmark script continuation TID]
-  std::unordered_map<int, std::vector<int>> tid_table;
+  // QID -> <[benchmark script TID, timer or when_any expire TID, response
+  // ready future continuation TID, benchmark script continuation TID],
+  // <true if tasks completed before timer expired, true if response was received>>
+  std::unordered_map<int, std::pair<std::vector<std::__thread_id>, std::pair<bool, bool>>> q_path_table;
 
   // TID -> [count in benchmark, count in when any, count in timer expire,
   // count in response ready, count in bench continuation]
   std::unordered_map<std::__thread_id, std::vector<int>> t_counts_table;
+
+  void _make_qid_entry_if_doesnt_exist(int qid) {
+    if (q_path_table.find(qid) == q_path_table.end()) {
+      std::__thread_id tid = std::__thread_id();
+      std::vector<std::__thread_id> vec = std::vector<std::__thread_id>{tid, tid, tid, tid};
+      q_path_table[qid] = std::make_pair(vec, std::make_pair(false, false));
+    }
+  }
+
+  void _update_q_path(int qid, std::__thread_id tid, int index) {
+    _make_qid_entry_if_doesnt_exist(qid);
+    std::vector<std::__thread_id> vec = q_path_table[qid].first;
+    std::pair<bool, bool> state_flags = q_path_table[qid].second;
+    vec[index] = tid;
+    q_path_table[qid] = std::make_pair(vec, state_flags);
+  }
+
+  void _update_q_path_tasks_completed_before_timer(int qid, bool tasks_completed_first) {
+    _make_qid_entry_if_doesnt_exist(qid);
+    std::vector<std::__thread_id> vec = q_path_table[qid].first;
+    bool response_received = q_path_table[qid].second.second;
+    q_path_table[qid] = std::make_pair(vec, std::make_pair(tasks_completed_first, response_received));
+  }
+
+  void _update_q_path_response_received(int qid, bool response_received) {
+    _make_qid_entry_if_doesnt_exist(qid);
+    std::vector<std::__thread_id> vec = q_path_table[qid].first;
+    bool tasks_completed_first = q_path_table[qid].second.first;
+    q_path_table[qid] = std::make_pair(vec, std::make_pair(tasks_completed_first, response_received));
+  }
 
   void _update_count(std::__thread_id tid, int index) {
     if (t_counts_table.find(tid) == t_counts_table.end()) {
@@ -120,45 +158,6 @@ class Logger {
     auto vec = t_counts_table[tid];
     vec[index] += 1;
     t_counts_table[tid] = vec;
-  }
-
-  void set_benchmark_script_tid(int test_qid, int tid) {
-    auto tid_vec = std::vector<int>{-1, -1, -1, -1, -1, -1};
-    tid_vec[benchmark_script_tid_index] = tid;
-    tid_vec[if_task_completed_index] = if_task_completed_reserve_value;
-    tid_vec[complete_account_index] = incomplete_account_value;
-    tid_table[test_qid] = tid_vec;
-  }
-
-  void set_timer_completion_tid(int test_qid, int tid) {
-    auto tid_vec = tid_table[test_qid];
-    if (tid_vec[if_task_completed_index] == if_task_completed_reserve_value) {
-      tid_vec[if_task_completed_index] = timer_completed_value;
-      tid_vec[task_or_timer_completion_tid_index] = tid;
-      tid_table[test_qid] = tid_vec;
-    }
-  }
-
-  void set_task_completion_tid(int test_qid, int tid) {
-    auto tid_vec = tid_table[test_qid];
-    if (tid_vec[if_task_completed_index] == if_task_completed_reserve_value) {
-      tid_vec[if_task_completed_index] = task_completed_value;
-      tid_vec[task_or_timer_completion_tid_index] = tid;
-      tid_table[test_qid] = tid_vec;
-    }
-  }
-
-  void set_response_ready_continuation_tid(int test_qid, int tid) {
-    auto tid_vec = tid_table[test_qid];
-    tid_vec[response_ready_continuation_tid_index] = tid;
-    tid_table[test_qid] = tid_vec;
-  }
-
-  void set_benchmark_script_continuation_tid(int test_qid, int tid) {
-    auto tid_vec = tid_table[test_qid];
-    tid_vec[benchmark_script_continuation_tid_index] = tid;
-    tid_vec[complete_account_index] = complete_account_value;
-    tid_table[test_qid] = tid_vec;
   }
 
  private:
@@ -270,35 +269,31 @@ void Logger::concatenate_messages(std::stringstream &ss, LogLevel log_level,
   ss << message;
 }
 
-static void set_benchmark_script_tid(int test_qid, std::__thread_id tid) {
-  Logger::get().set_benchmark_script_tid(test_qid,
-                                         std::hash<std::thread::id>()(tid));
+static void set_q_path_bench_script(int qid, std::__thread_id tid) {
+  Logger::get()._update_q_path(qid, tid, Q_PATH_BENCH_SCRIPT_INDEX);
 }
 
-static void set_timer_completion_tid(int test_qid, std::__thread_id tid) {
-  Logger::get().set_timer_completion_tid(test_qid,
-                                         std::hash<std::thread::id>()(tid));
+static void set_q_path_when_any(int qid, std::__thread_id tid) {
+  Logger::get()._update_q_path(qid, tid, Q_PATH_TASK_OR_TIMER_INDEX);
+  Logger::get()._update_q_path_tasks_completed_before_timer(qid, true);
 }
 
-static void set_task_completion_tid(int test_qid, std::__thread_id tid) {
-  Logger::get().set_task_completion_tid(test_qid,
-                                        std::hash<std::thread::id>()(tid));
+static void set_q_path_timer_expire(int qid, std::__thread_id tid) {
+  Logger::get()._update_q_path(qid, tid, Q_PATH_TASK_OR_TIMER_INDEX);
+  Logger::get()._update_q_path_tasks_completed_before_timer(qid, false);
 }
 
-static void set_response_ready_continuation_tid(int test_qid,
-                                                std::__thread_id tid) {
-  Logger::get().set_response_ready_continuation_tid(
-      test_qid, std::hash<std::thread::id>()(tid));
+static void set_q_path_response_ready(int qid, std::__thread_id tid) {
+  Logger::get()._update_q_path(qid, tid, Q_PATH_RESPONSE_READY_INDEX);
 }
 
-static void set_benchmark_script_continuation_tid(int test_qid,
-                                                  std::__thread_id tid) {
-  Logger::get().set_benchmark_script_continuation_tid(
-      test_qid, std::hash<std::thread::id>()(tid));
+static void set_q_path_bench_cont(int qid, std::__thread_id tid) {
+  Logger::get()._update_q_path(qid, tid, Q_PATH_BENCH_CONT_INDEX);
+  Logger::get()._update_q_path_response_received(qid, true);
 }
 
-static std::unordered_map<int, std::vector<int>> get_tid_table() {
-  return Logger::get().tid_table;
+static std::unordered_map<int, std::pair<std::vector<std::__thread_id>, std::pair<bool, bool>>> get_q_path_table() {
+  return Logger::get().q_path_table;
 }
 
 static void update_bench_script_count(std::__thread_id tid) {

--- a/src/libclipper/include/clipper/logging.hpp
+++ b/src/libclipper/include/clipper/logging.hpp
@@ -124,20 +124,29 @@ class Logger {
   // count in response ready, count in bench continuation]
   std::unordered_map<std::__thread_id, std::vector<int>> t_counts_table;
 
-  void _update_q_path(int qid, std::__thread_id tid, int index) {
+  void _make_q_path_entry_if_doesnt_exist(int qid) {
+    std::vector<std::__thread_id> vec;
     if (q_path_table.find(qid) == q_path_table.end()) {
       std::__thread_id tid = std::__thread_id();
-      std::vector<std::__thread_id> vec = std::vector<std::__thread_id>{tid, tid, tid, tid};
+       vec = std::vector<std::__thread_id>{tid, tid, tid, tid};
       q_path_table[qid] = std::make_pair(vec, std::make_pair(COMPLETED_BY_NEITHER, false));
     }
+  }
+
+  void _update_q_path(int qid, std::__thread_id tid, int index) {
+    _make_q_path_entry_if_doesnt_exist(qid);
     q_path_table[qid].first[index] = tid;
   }
 
   void _update_q_path_tasks_completed_before_timer(int qid, bool tasks_completed_first) {
-    q_path_table[qid].second.first = tasks_completed_first ? COMPLETED_BY_TASK : COMPLETED_BY_TIMER;
+    _make_q_path_entry_if_doesnt_exist(qid);
+    if (q_path_table[qid].second.first == COMPLETED_BY_NEITHER) {
+      q_path_table[qid].second.first = tasks_completed_first ? COMPLETED_BY_TASK : COMPLETED_BY_TIMER;
+    }
   }
 
   void _update_q_path_response_received(int qid) {
+    _make_q_path_entry_if_doesnt_exist(qid);
     q_path_table[qid].second.second = true;
   }
 

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -311,6 +311,18 @@ rpc::PredictionResponse::deserialize_prediction_response(ByteBuffer bytes) {
 
 Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
              long latency_budget_micros, std::string selection_policy,
+             std::vector<VersionedModelId> candidate_models, int test_qid)
+    : label_(label),
+      user_id_(user_id),
+      input_(input),
+      latency_budget_micros_(latency_budget_micros),
+      selection_policy_(selection_policy),
+      candidate_models_(candidate_models),
+      test_qid_(test_qid),
+      create_time_(std::chrono::high_resolution_clock::now()) {}
+
+Query::Query(std::string label, long user_id, std::shared_ptr<Input> input,
+             long latency_budget_micros, std::string selection_policy,
              std::vector<VersionedModelId> candidate_models)
     : label_(label),
       user_id_(user_id),

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -159,9 +159,9 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                       final_output.second,
                       default_explanation};
 
-//    log_info("qid", query.test_qid_, "response_ready_future continuation", std::this_thread::get_id());
-//    set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
-//    update_response_ready_count(std::this_thread::get_id());
+    log_info("qid", query.test_qid_, "response_ready_future continuation", std::this_thread::get_id());
+    set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
+    update_response_ready_count(std::this_thread::get_id());
     response_promise.set_value(response);
   });
   return response_future;

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -158,10 +158,9 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                       final_output.first,
                       final_output.second,
                       default_explanation};
-    //    log_info("TID", "Response ready future continuation", query.test_qid_,
-    //             std::this_thread::get_id());
-    set_response_ready_continuation_tid(query.test_qid_,
-                                        std::this_thread::get_id());
+
+    log_info("qid", query.test_qid_, "Response ready continuation", std::this_thread::get_id());
+    set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
     update_response_ready_count(std::this_thread::get_id());
     response_promise.set_value(response);
   });

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -88,8 +88,6 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                         query_id);
   }
 
-  log_info("TID", "Create timer future", query.test_qid_,
-           std::this_thread::get_id());
   boost::future<void> timer_future =
       timer_system_.set_timer(query.latency_budget_micros_, query);
 
@@ -160,10 +158,11 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                       final_output.first,
                       final_output.second,
                       default_explanation};
-    log_info("TID", "Response ready future continuation", query.test_qid_,
-             std::this_thread::get_id());
+    //    log_info("TID", "Response ready future continuation", query.test_qid_,
+    //             std::this_thread::get_id());
     set_response_ready_continuation_tid(query.test_qid_,
                                         std::this_thread::get_id());
+    update_response_ready_count(std::this_thread::get_id());
     response_promise.set_value(response);
   });
   return response_future;

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -94,7 +94,7 @@ boost::future<Response> QueryProcessor::predict(Query query) {
   boost::future<void> all_tasks_completed;
   auto num_completed = std::make_shared<std::atomic<int>>(0);
   std::tie(all_tasks_completed, task_futures) =
-      future::when_all_test(std::move(task_futures), num_completed, query);
+      future::when_all_log_thread_info(std::move(task_futures), num_completed, query);
 
   auto completed_flag = std::make_shared<std::atomic_flag>();
   // Due to some complexities of initializing the atomic_flag in a shared_ptr,
@@ -159,9 +159,8 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                       final_output.second,
                       default_explanation};
 
-    log_info("qid", query.test_qid_, "response_ready_future continuation", std::this_thread::get_id());
-    set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
-    update_response_ready_count(std::this_thread::get_id());
+//    thread_info_logger::ThreadInfoLogger::set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
+    thread_info_logger::ThreadInfoLogger::update_response_ready_count(std::this_thread::get_id());
     response_promise.set_value(response);
   });
   return response_future;

--- a/src/libclipper/src/query_processor.cpp
+++ b/src/libclipper/src/query_processor.cpp
@@ -159,9 +159,9 @@ boost::future<Response> QueryProcessor::predict(Query query) {
                       final_output.second,
                       default_explanation};
 
-    log_info("qid", query.test_qid_, "Response ready continuation", std::this_thread::get_id());
-    set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
-    update_response_ready_count(std::this_thread::get_id());
+//    log_info("qid", query.test_qid_, "response_ready_future continuation", std::this_thread::get_id());
+//    set_q_path_response_ready(query.test_qid_, std::this_thread::get_id());
+//    update_response_ready_count(std::this_thread::get_id());
     response_promise.set_value(response);
   });
   return response_future;

--- a/src/libclipper/src/timers.cpp
+++ b/src/libclipper/src/timers.cpp
@@ -35,9 +35,10 @@ bool Timer::operator>=(const Timer &rhs) const {
 }
 
 void Timer::expire(Query query) {
-  log_info("TID", "Complete timer", query.test_qid_,
-           std::this_thread::get_id());
+  //  log_info("TID", "Complete timer", query.test_qid_,
+  //           std::this_thread::get_id());
   set_timer_completion_tid(query.test_qid_, std::this_thread::get_id());
+  update_timer_expire_count(std::this_thread::get_id());
   completion_promise_.set_value();
 }
 

--- a/src/libclipper/src/timers.cpp
+++ b/src/libclipper/src/timers.cpp
@@ -35,10 +35,9 @@ bool Timer::operator>=(const Timer &rhs) const {
 }
 
 void Timer::expire(Query query) {
-  //  log_info("TID", "Complete timer", query.test_qid_,
-  //           std::this_thread::get_id());
-  set_timer_completion_tid(query.test_qid_, std::this_thread::get_id());
+  set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
   update_timer_expire_count(std::this_thread::get_id());
+  log_info("qid", query.test_qid_, "in timer expire", std::this_thread::get_id());
   completion_promise_.set_value();
 }
 

--- a/src/libclipper/src/timers.cpp
+++ b/src/libclipper/src/timers.cpp
@@ -7,6 +7,7 @@
 #include <boost/thread.hpp>
 #include <clipper/timers.hpp>
 #include <clipper/util.hpp>
+#include "../../benchmarks/src/thread_info_logger.hpp"
 
 using std::pair;
 // using std::chrono::high_resolution_clock;
@@ -35,9 +36,8 @@ bool Timer::operator>=(const Timer &rhs) const {
 }
 
 void Timer::expire(Query query) {
-  set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
-  update_timer_expire_count(std::this_thread::get_id());
-  log_info("qid", query.test_qid_, "in timer expire", std::this_thread::get_id());
+//  thread_info_logger::ThreadInfoLogger::set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
+  thread_info_logger::ThreadInfoLogger::update_timer_expire_count(std::this_thread::get_id());
   completion_promise_.set_value();
 }
 

--- a/src/libclipper/src/timers.cpp
+++ b/src/libclipper/src/timers.cpp
@@ -35,9 +35,9 @@ bool Timer::operator>=(const Timer &rhs) const {
 }
 
 void Timer::expire(Query query) {
-//  set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
-//  update_timer_expire_count(std::this_thread::get_id());
-//  log_info("qid", query.test_qid_, "in timer expire", std::this_thread::get_id());
+  set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
+  update_timer_expire_count(std::this_thread::get_id());
+  log_info("qid", query.test_qid_, "in timer expire", std::this_thread::get_id());
   completion_promise_.set_value();
 }
 

--- a/src/libclipper/src/timers.cpp
+++ b/src/libclipper/src/timers.cpp
@@ -34,6 +34,11 @@ bool Timer::operator>=(const Timer &rhs) const {
   return deadline_ >= rhs.deadline_;
 }
 
-void Timer::expire() { completion_promise_.set_value(); }
+void Timer::expire(Query query) {
+  log_info("TID", "Complete timer", query.test_qid_,
+           std::this_thread::get_id());
+  set_timer_completion_tid(query.test_qid_, std::this_thread::get_id());
+  completion_promise_.set_value();
+}
 
 }  // namespace clipper

--- a/src/libclipper/src/timers.cpp
+++ b/src/libclipper/src/timers.cpp
@@ -35,9 +35,9 @@ bool Timer::operator>=(const Timer &rhs) const {
 }
 
 void Timer::expire(Query query) {
-  set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
-  update_timer_expire_count(std::this_thread::get_id());
-  log_info("qid", query.test_qid_, "in timer expire", std::this_thread::get_id());
+//  set_q_path_timer_expire(query.test_qid_, std::this_thread::get_id());
+//  update_timer_expire_count(std::this_thread::get_id());
+//  log_info("qid", query.test_qid_, "in timer expire", std::this_thread::get_id());
   completion_promise_.set_value();
 }
 

--- a/src/logging_constants.hpp
+++ b/src/logging_constants.hpp
@@ -1,0 +1,7 @@
+#include <utility>
+
+const size_t FIXED_BATCH_SIZE = 5;
+const bool IGNORE_OVERDUE_TASKS = false;
+const bool USE_FIXED_BATCH_SIZE = false;
+const bool SEND_REQUESTS = true;
+const bool SHORT_CIRCUIT_TASK_EXECUTOR = false;


### PR DESCRIPTION
Note: This PR shouldn't be merged. 

This PR has a script that runs the `end_to_end_benchmark` script and measures + reports out some other information about thread usage.

To run:
- pull from this branch
- feel free to adjust the variables in `src/logging_constants.hpp`
   - `USE_FIXED_BATCH_SIZE` and `FIXED_BATCH_SIZE` together control whether or not to override the current adaptive batching techniques and use fixed (maximum) batch sizes
   - set `SHORT_CIRCUIT_TASK_EXECUTOR` to `true` if you want the query processor to return results from its `.predict` immediately after receiving requests
   - set `SEND_REQUESTS` to `false` if you only want to create Query objects in the benchmarking script but not actually send them as requests
    - set `IGNORE_OVERDUE_TASKS` to `true` if you want `task_executor.remove_tasks_with_elapsed_deadlines` to not do anything, resulting in us not removing overdue tasks from model queues
- get redis running
- deploy a model-container (for instance, run `./bench/setup_noop_bench.sh`)
- change the `cifar_data_path`, `benchmark_report_path`, and `thread_counts_report_path` variables in `config.json`. If you're not using the `set_noop_bench.sh` script, change the `model_version` and `model_name` fields to match that of the model-container you just deployed
- `./configure --release && cd release && make`
- `./src/benchmarks/end_to_end_bench -f ../config.json`

The script ends with a `std::terminate()` so don't be surprised if you see `libc++abi.dylib: terminating \n Abort trap: 6` at the end.

The output thread info report  exist in the location specified by `thread_counts_report_path`. Go ahead and open it. You should see something like:

```
---Configuration---
num_batches: 10000
poisson_delay: false
request_batch_delay_micros: 10
num_threads: 1
sleep_afer_send_time_sec: 5
latency_objective: 25000
benchmark_report_path: /Users/nishadsingh/Documents/clip/thread_reports/r_sendrate_10_numbatch_250000.txt
model_version: 1
cifar_data_path: /Users/nishadsingh/Documents/clip/dataset/cifar-100-binary/test.bin
report_delay_seconds: -1
model_name: bench_noop
prevent_cache_hits: true
request_batch_size: 1
thread_counts_report_path: /Users/nishadsingh/Documents/clip/thread_reports/t_sendrate_10_numbatch_250000_test.txt
-------------------
SHORT_CIRCUIT_TASK_EXECUTOR: 0, SEND_REQUESTS: 1, IGNORE_OVERDUE_TASKS: 0, USE_FIXED_BATCH_SIZE: 0, FIXED_BATCH_SIZE: 5


-----------------------------------Number of times each thread executed each event------------------------------------

thread id       bench script        tasks completed     timer expired       response ready      bench continuation
----------------------------------------------------------------------------------------------------------------------
                1 unique threads    13 unique threads   1 unique threads    17 unique threads   18 unique threads   

0x70000f0dc000: 0                   7                   0                   101                 238                 
0x70000eed0000: 0                   880                 0                   319                 1144                
0x70000f2e8000: 0                   1                   0                   3                   18                  
0x70000f471000: 0                   0                   0                   0                   4                   
0x70000ef53000: 0                   125                 0                   9055                283                 
0x70000ee4d000: 10000               12                  0                   1                   11                  
0x70000f889000: 0                   0                   0                   1                   0                   
0x70000f265000: 0                   0                   0                   25                  11                  
0x70000ecc4000: 0                   0                   10000               0                   0                   
0x70000f4f4000: 0                   0                   0                   1                   0                   
0x70000f059000: 0                   121                 0                   290                 162                 
0x70000f15f000: 0                   7                   0                   5                   74                  
0x70000f98f000: 0                   0                   0                   0                   1                   
0x70000f36b000: 0                   3                   0                   7                   3                   
0x70000efd6000: 0                   172                 0                   166                 8026                
0x70000f1e2000: 0                   2                   0                   16                  15                  
0x70000f3ee000: 0                   1                   0                   5                   5                   
0x70000f577000: 0                   0                   0                   2                   1                   
0x70000f5fa000: 0                   0                   0                   0                   2                   
0x70000f783000: 0                   0                   0                   1                   1                   
0x70000f700000: 0                   1                   0                   2                   0                   
0x70000f806000: 0                   0                   0                   0                   1                   
0x70000f90c000: 0                   1                   0                   0                   0                   
```

We report out a table that shows the number of times each thread executed a certain part of code. Each row corresponds to a unique thread, and each column to a part of code.

Some results of running the script with different parameters have been documented in "Thread creation results" under the Performance Benchmarking folder on our Google Drive.


There's a second thing this script could record (it's commented out because it occasionally seg faults for reasons I can't figure out): aggregate stats about the number of queries for which specific threads execute different parts of code. If you're brave enough to uncomment those sections, you'll see output like: 

```
Number of queries whose response_ready_future was completed by all_tasks_completed: 4028
Number completed by timer_future: 5972
Number of queries that didn't receive a response: 0


For the following two matrices, Matrix[i, j] corresponds to the number of queries for which the thread that executed event i also executed thread j

----------------Stats for queries where response_ready_future future completed by all_tasks_completed------------------
                    bench script        tasks completed     timer expired        response ready      bench continuation
-----------------------------------------------------------------------------------------------------------------------
bench script        4028                0                   0                   0                   0                   
tasks completed                         4028                0                   0                   9                   
timer expired                                               4028                0                   0                   
response ready                                                                  4028                0                   
bench continuation                                                                                  4028                

-------------------Stats for queries where response_ready_future future completed by timer_future----------------------
                    bench script        tasks completed     timer expired        response ready      bench continuation
-----------------------------------------------------------------------------------------------------------------------
bench script        5972                2                   0                   3                   0                   
tasks completed                         5972                0                   135                 604                 
timer expired                                               5972                0                   0                   
response ready                                                                  5972                12                  
bench continuation                                                                                  5972               
```