### PR TITLE
Delete app + remove app-model links

### DIFF
--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -397,6 +397,22 @@ class Clipper:
         print(r.text)
         return r.status_code == requests.codes.ok
 
+    def delete_application(self, name):
+        """
+        Deletes an existing Clipper application. Also removes its associated
+        model links.
+
+        Parameters
+        ----------
+        name : str
+            The name of the application.
+        """
+        url = "http://%s:1338/admin/delete_app" % self.host
+        req_json = json.dumps({"name": name})
+        headers = {'Content-type': 'application/json'}
+        r = requests.delete(url, headers=headers, data=req_json)
+        print(r.text)
+
     def remove_model_link(self, app_name, model_name):
         """
         Prevents the model with `model_name` from being used by the app with `app_name`.

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -406,12 +406,18 @@ class Clipper:
         ----------
         name : str
             The name of the application.
+
+        Returns
+        -------
+            Returns true iff the application was successfully deleted
         """
-        url = "http://%s:1338/admin/delete_app" % self.host
+        url = "http://%s:%d/admin/delete_app" % (self.host,
+                                                 CLIPPER_MANAGEMENT_PORT)
         req_json = json.dumps({"name": name})
         headers = {'Content-type': 'application/json'}
-        r = requests.delete(url, headers=headers, data=req_json)
+        r = requests.post(url, headers=headers, data=req_json)
         print(r.text)
+        return r.status_code == requests.codes.ok
 
     def remove_model_link(self, app_name, model_name):
         """

--- a/clipper_admin/clipper_manager.py
+++ b/clipper_admin/clipper_manager.py
@@ -397,6 +397,35 @@ class Clipper:
         print(r.text)
         return r.status_code == requests.codes.ok
 
+    def remove_model_link(self, app_name, model_name):
+        """
+        Prevents the model with `model_name` from being used by the app with `app_name`.
+        The model and app should both be registered with Clipper and a link should
+        already exist between them.
+
+        Parameters
+        ----------
+        app_name : str
+            The name of the application
+        model_name : str
+            The name of the model to link to the application
+
+        Returns
+        -------
+        bool
+            Returns true iff the model link removal request was successful
+        """
+        url = "http://%s:%d/admin/remove_model_links" % (
+            self.host, CLIPPER_MANAGEMENT_PORT)
+        req_json = json.dumps({
+            "app_name": app_name,
+            "model_names": [model_name]
+        })
+        headers = {'Content-type': 'application/json'}
+        r = requests.post(url, headers=headers, data=req_json)
+        print(r.text)
+        return r.status_code == requests.codes.ok
+
     def get_linked_models(self, app_name):
         """Retrieves the models linked to the specified application
 

--- a/integration-tests/clipper_manager_tests.py
+++ b/integration-tests/clipper_manager_tests.py
@@ -85,6 +85,17 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         self.assertGreaterEqual(len(registered_applications), 1)
         self.assertTrue(self.app_name in registered_applications)
 
+    def test_delete_application_suceeds(self):
+        temp_app_name = "temp_app"
+        input_type = "doubles"
+        default_output = "DEFAULT"
+        slo_micros = 30000
+        self.clipper_inst.register_application(temp_app_name, input_type,
+                                               default_output, slo_micros)
+        self.clipper_inst.delete_application(temp_app_name)
+        registered_applications = self.clipper_inst.get_all_apps()
+        self.assertFalse(self.app_name in registered_applications)
+
     def test_link_not_registered_model_to_app_fails(self):
         not_deployed_model = "test_model"
         result = self.clipper_inst.link_model_to_app(self.app_name,
@@ -383,6 +394,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
 SHORT_TEST_ORDERING = [
     'test_external_models_register_correctly',
     'test_application_registers_correctly',
+    'test_delete_application_suceeds',
     'test_link_not_registered_model_to_app_fails',
     'test_get_model_links_when_none_exist_returns_empty_list',
     'test_link_registered_model_to_app_succeeds',

--- a/integration-tests/clipper_manager_tests.py
+++ b/integration-tests/clipper_manager_tests.py
@@ -94,7 +94,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
                                                default_output, slo_micros)
         self.clipper_inst.delete_application(temp_app_name)
         registered_applications = self.clipper_inst.get_all_apps()
-        self.assertFalse(self.app_name in registered_applications)
+        self.assertFalse(temp_app_name in registered_applications)
 
     def test_link_not_registered_model_to_app_fails(self):
         not_deployed_model = "test_model"

--- a/integration-tests/clipper_manager_tests.py
+++ b/integration-tests/clipper_manager_tests.py
@@ -104,6 +104,14 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         result = self.clipper_inst.get_linked_models(self.app_name)
         self.assertEqual([self.model_name], result)
 
+    def test_remove_model_links_succeeds(self):
+        remove_model_result = self.clipper_inst.remove_model_link(
+            self.app_name, self.model_name)
+        self.assertTrue(remove_model_result)
+        get_linked_models_result = self.clipper_inst.get_linked_models(
+            self.app_name)
+        self.assertEqual([], get_linked_models_result)
+
     def get_app_info_for_registered_app_returns_info_dictionary(self):
         result = self.clipper_inst.get_app_info(self.app_name)
         self.assertIsNotNone(result)
@@ -322,6 +330,21 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         self.assertNotEqual(parsed_response["output"], self.default_output)
         self.assertFalse(parsed_response["default"])
 
+    def test_queries_to_app_with_removed_model_links_yield_default_predictions(
+            self):
+        self.clipper_inst.remove_model_link(self.app_name_2, self.model_name_2)
+        time.sleep(1)
+
+        url = "http://localhost:1337/{}/predict".format(self.app_name_2)
+        test_input = [99.3, 18.9, 67.2, 34.2]
+        req_json = json.dumps({'input': test_input})
+        headers = {'Content-type': 'application/json'}
+        response = requests.post(url, headers=headers, data=req_json)
+        parsed_response = response.json()
+        print(parsed_response)
+        self.assertEqual(parsed_response["output"], self.default_output)
+        self.assertTrue(parsed_response["default"])
+
     def test_deployed_and_linked_predict_function_queried_successfully(self):
         model_version = 1
         predict_func = lambda inputs: [str(mm.COEFFICIENT * mmip.COEFFICIENT * len(x)) for x in inputs]
@@ -380,6 +403,7 @@ SHORT_TEST_ORDERING = [
 LONG_TEST_ORDERING = [
     'test_queries_to_app_without_linked_models_yield_default_predictions',
     'test_deployed_and_linked_model_queried_successfully',
+    'test_queries_to_app_with_removed_model_links_yield_default_predictions',
     'test_deployed_and_linked_predict_function_queried_successfully'
 ]
 

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -185,6 +185,13 @@ class RequestHandler {
             auto linked_model_names =
                 clipper::redis::get_linked_models(redis_connection_, app_name);
             set_linked_models_for_app(app_name, linked_model_names);
+          } else if (event_type == "srem") {
+            clipper::log_info_formatted(
+                LOGGING_TAG_QUERY_FRONTEND,
+                "Model link removal detected for app: {}", app_name);
+            auto linked_model_names =
+                clipper::redis::get_linked_models(redis_connection_, app_name);
+            set_linked_models_for_app(app_name, linked_model_names);
           }
         });
 

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -316,8 +316,9 @@ TEST_F(QueryFrontendTest, TestReadModelLinksAtStartup) {
   // Give some candidate model names to app with `app_name_1`
   add_model_links(*redis_, app_name_1, {"m1"});
   add_model_links(*redis_, app_name_1, {"m2", "m3"});
+  remove_model_links(*redis_, app_name_1, {"m2"});
 
-  std::vector<std::string> expected_app1_linked_models = {"m1", "m2", "m3"};
+  std::vector<std::string> expected_app1_linked_models = {"m1", "m3"};
 
   RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
 

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -279,6 +279,13 @@ bool remove_model_links(redox::Redox& redis, const std::string& app_name,
                         const std::vector<std::string>& model_names);
 
 /**
+ * Removes all links between the specified app and models.
+ *
+ * \return Returns true if the removal was successful.
+ */
+bool remove_all_model_links(redox::Redox& redis, const std::string& app_name);
+
+/**
  * Deletes a container from the container table if it exists.
  *
  * \return Returns true if the container was present in the table

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -271,6 +271,14 @@ bool add_model_links(redox::Redox& redis, const std::string& app_name,
                      const std::vector<std::string>& model_names);
 
 /**
+ * Removes links between the specified app and models.
+ *
+ * \return Returns true if the removal was successful.
+ */
+bool remove_model_links(redox::Redox& redis, const std::string& app_name,
+                        const std::vector<std::string>& model_names);
+
+/**
  * Deletes a container from the container table if it exists.
  *
  * \return Returns true if the container was present in the table

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -470,6 +470,22 @@ bool add_model_links(redox::Redox& redis, const std::string& appname,
   }
 }
 
+bool remove_model_links(redox::Redox& redis, const std::string& appname,
+                        const std::vector<std::string>& model_names) {
+  if (send_cmd_no_reply<string>(
+          redis, {"SELECT", std::to_string(REDIS_APP_MODEL_LINKS_DB_NUM)})) {
+    for (auto model_name : model_names) {
+      if (!send_cmd_no_reply<int>(
+              redis, vector<string>{"SREM", appname, model_name})) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return false;
+  }
+}
+
 bool delete_application(redox::Redox& redis, const std::string& appname) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APPLICATION_DB_NUM)})) {

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -486,6 +486,15 @@ bool remove_model_links(redox::Redox& redis, const std::string& appname,
   }
 }
 
+bool remove_all_model_links(redox::Redox& redis, const std::string& appname) {
+  if (send_cmd_no_reply<string>(
+          redis, {"SELECT", std::to_string(REDIS_APP_MODEL_LINKS_DB_NUM)})) {
+    return send_cmd_no_reply<int>(redis, vector<string>{"DEL", appname});
+  } else {
+    return false;
+  }
+}
+
 bool delete_application(redox::Redox& redis, const std::string& appname) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_APPLICATION_DB_NUM)})) {

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -134,6 +134,49 @@ TEST_F(RedisTest, AddModelLinks) {
   ASSERT_EQ(model_names, linked_models);
 }
 
+TEST_F(RedisTest, RemoveModelLinks) {
+  std::string app_name = "my_app_name";
+  InputType input_type = InputType::Doubles;
+  std::string policy = DefaultOutputSelectionPolicy::get_name();
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  ASSERT_TRUE(add_application(*redis_, app_name, input_type, policy,
+                              default_output, latency_slo_micros));
+
+  std::vector<std::string> labels{"ads", "images", "experimental", "other",
+                                  "labels"};
+  std::string model_name_1 = "model_1";
+  std::string model_name_2 = "model_2";
+  std::string model_name_3 = "model_3";
+  VersionedModelId model_1 = VersionedModelId(model_name_1, "1");
+  VersionedModelId model_2 = VersionedModelId(model_name_2, "1");
+  VersionedModelId model_3 = VersionedModelId(model_name_3, "1");
+  std::string container_name = "clipper/test_container";
+  std::string model_path = "/tmp/models/m/1";
+  ASSERT_TRUE(add_model(*redis_, model_1, input_type, labels, container_name,
+                        model_path));
+  ASSERT_TRUE(add_model(*redis_, model_2, input_type, labels, container_name,
+                        model_path));
+  ASSERT_TRUE(add_model(*redis_, model_3, input_type, labels, container_name,
+                        model_path));
+
+  std::vector<std::string> model_names_to_add =
+      std::vector<std::string>{model_name_1, model_name_2, model_name_3};
+  ASSERT_TRUE(add_model_links(*redis_, app_name, model_names_to_add));
+
+  auto linked_models = get_linked_models(*redis_, app_name);
+  std::sort(linked_models.begin(), linked_models.end());
+  std::sort(model_names_to_add.begin(), model_names_to_add.end());
+  ASSERT_EQ(model_names_to_add, linked_models);
+
+  std::vector<std::string> model_names_to_remove =
+      std::vector<std::string>{model_name_1, model_name_2};
+
+  ASSERT_TRUE(remove_model_links(*redis_, app_name, model_names_to_remove));
+  linked_models = get_linked_models(*redis_, app_name);
+  ASSERT_EQ(linked_models, std::vector<std::string>{model_name_3});
+}
+
 TEST_F(RedisTest, SetCurrentModelVersion) {
   std::string model_name = "mymodel";
   ASSERT_TRUE(set_current_model_version(*redis_, model_name, "2"));
@@ -629,6 +672,64 @@ TEST_F(RedisTest, SubscriptionDetectModelLinksAdd) {
   bool result = notification_recv.wait_for(
       l, std::chrono::milliseconds(1000),
       [&num_sadd_recv]() { return num_sadd_recv == 2; });
+  ASSERT_TRUE(result);
+}
+
+TEST_F(RedisTest, SubscriptionDetectModelLinksRemove) {
+  // Register the application to link to
+  std::string name = "my_app_name";
+  InputType input_type = InputType::Doubles;
+  std::string policy = "exp3_policy";
+  std::string default_output = "1.0";
+  int latency_slo_micros = 10000;
+  ASSERT_TRUE(add_application(*redis_, name, input_type, policy, default_output,
+                              latency_slo_micros));
+
+  // Register the models to link
+  std::vector<std::string> labels{"ads", "images", "experimental", "other",
+                                  "labels"};
+  std::string model_name_1 = "model_1";
+  std::string model_name_2 = "model_2";
+  std::string model_version = "1";
+  VersionedModelId model_1_id = VersionedModelId(model_name_1, model_version);
+  VersionedModelId model_2_id = VersionedModelId(model_name_2, model_version);
+  std::string container_name = "clipper/test_container";
+  std::string model_path = "/tmp/models/m/1";
+  ASSERT_TRUE(add_model(*redis_, model_1_id, input_type, labels, container_name,
+                        model_path));
+  ASSERT_TRUE(add_model(*redis_, model_2_id, input_type, labels, container_name,
+                        model_path));
+  std::vector<std::string> model_names = {model_name_1, model_name_2};
+  ASSERT_TRUE(add_model_links(*redis_, name, model_names));
+
+  std::condition_variable_any notification_recv;
+  std::mutex notification_mutex;
+  std::atomic<int> num_srem_recv{0};
+  subscribe_to_model_link_changes(
+      *subscriber_,
+      [&notification_recv, &notification_mutex, &num_srem_recv, name](
+          const std::string& key, const std::string& event_type) {
+        // 'del' events are emitted when a redis set goes empty
+        // In this case, we remove all the elements from the
+        // set of models linked to a specific app.
+        ASSERT_TRUE(event_type == "del" || event_type == "srem");
+        if (event_type == "srem") {
+          ASSERT_EQ(event_type, "srem");
+          std::unique_lock<std::mutex> l(notification_mutex);
+          num_srem_recv += 1;
+          ASSERT_EQ(key, name);
+          notification_recv.notify_all();
+        }
+      });
+  // give Redis some time to register the subscription
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+  ASSERT_TRUE(remove_model_links(*redis_, name, model_names));
+
+  std::unique_lock<std::mutex> l(notification_mutex);
+  bool result = notification_recv.wait_for(
+      l, std::chrono::milliseconds(1000),
+      [&num_srem_recv]() { return num_srem_recv == 2; });
   ASSERT_TRUE(result);
 }
 

--- a/src/libs/httpserver/server_http.hpp
+++ b/src/libs/httpserver/server_http.hpp
@@ -293,34 +293,34 @@ class ServerBase {
   }
 
 
-    /// Use this function to delete existing endpoints while the service is running
-    void delete_endpoint(
-            std::string res_name, std::string res_method) {
-      std::unique_lock<std::mutex> l(mu);
-      auto app_res = resource[res_name];
-      app_res.erase(res_method);
-      if (app_res.size() == 0) {
-        resource.erase(res_name);
-      }
-      for (size_t i = 0; i < opt_resource.size(); i ++) {
-        auto opt_it = opt_resource[i];
-        if (res_method == opt_it.first) {
-          auto endpoint_pairs(opt_it.second);
-          for (size_t j = 0; j < endpoint_pairs.size(); j ++) {
-            auto pair = endpoint_pairs[j];
-            if (REGEX_NS::regex_match(res_name, pair.first)) {
-              (opt_resource[i].second).erase((opt_resource[i].second).begin() + j);
-              if (endpoint_pairs.size() == 0) {
-                opt_resource.erase(opt_resource.begin() + i);
-              }
-              return;
+  /// Use this function to delete existing endpoints while the service is running
+  void delete_endpoint(
+          std::string res_name, std::string res_method) {
+    std::unique_lock<std::mutex> l(mu);
+    auto app_res = resource[res_name];
+    app_res.erase(res_method);
+    if (app_res.size() == 0) {
+      resource.erase(res_name);
+    }
+    for (size_t i = 0; i < opt_resource.size(); i ++) {
+      auto opt_it = opt_resource[i];
+      if (res_method == opt_it.first) {
+        auto endpoint_pairs(opt_it.second);
+        for (size_t j = 0; j < endpoint_pairs.size(); j ++) {
+          auto pair = endpoint_pairs[j];
+          if (REGEX_NS::regex_match(res_name, pair.first)) {
+            (opt_resource[i].second).erase((opt_resource[i].second).begin() + j);
+            if (endpoint_pairs.size() == 0) {
+              opt_resource.erase(opt_resource.begin() + i);
             }
+            return;
           }
         }
       }
     }
+  }
 
-    size_t num_endpoints() {
+  size_t num_endpoints() {
     size_t count = 0;
     std::unique_lock<std::mutex> l(mu);
     for (auto e : opt_resource) {

--- a/src/libs/httpserver/server_http.hpp
+++ b/src/libs/httpserver/server_http.hpp
@@ -292,7 +292,35 @@ class ServerBase {
     it->second.emplace_back(REGEX_NS::regex(res_name), res_fn);
   }
 
-  size_t num_endpoints() {
+
+    /// Use this function to delete existing endpoints while the service is running
+    void delete_endpoint(
+            std::string res_name, std::string res_method) {
+      std::unique_lock<std::mutex> l(mu);
+      auto app_res = resource[res_name];
+      app_res.erase(res_method);
+      if (app_res.size() == 0) {
+        resource.erase(res_name);
+      }
+      for (size_t i = 0; i < opt_resource.size(); i ++) {
+        auto opt_it = opt_resource[i];
+        if (res_method == opt_it.first) {
+          auto endpoint_pairs(opt_it.second);
+          for (size_t j = 0; j < endpoint_pairs.size(); j ++) {
+            auto pair = endpoint_pairs[j];
+            if (REGEX_NS::regex_match(res_name, pair.first)) {
+              (opt_resource[i].second).erase((opt_resource[i].second).begin() + j);
+              if (endpoint_pairs.size() == 0) {
+                opt_resource.erase(opt_resource.begin() + i);
+              }
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    size_t num_endpoints() {
     size_t count = 0;
     std::unique_lock<std::mutex> l(mu);
     for (auto e : opt_resource) {


### PR DESCRIPTION
I'm gone on Monday but can do revisions on this until then. Don't feel obligated to review before then (or at all if since these features aren't high priority) -- I won't be offended at all if you close the PR and just choose to use this as a reference for whenever you later want to introduce these deletion features.

This PR allows you to delete applications (self explanatory), which in the process deletes all of the app's associated linked models.

This PR also allows you to remove specified linked models.

There's a slight problem introduced here: if we link a model, send a query, and then unlink a model soon after, we run the risk of that query being served by the model we just unlinked (because its associated prediction task might have been placed it in be in its model queue). In a discussion with @dcrankshaw a while ago we thought that this would be fine. I imagine the same applies to the similar case where you send a query to a registered app and then soon after delete the app.