### PR TITLE
Updated README to clarify quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,16 @@ Clipper is a prediction serving system that sits between user-facing application
 
 ## Quickstart
 
+**Note: This quickstart works for the latest version of code. For a quickstart that works with the released version of Clipper available on PyPi, go to our [website](http://clipper.ai/overview/quickstart/)**
 
-**Note: This quickstart requires [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).**
+> Note: This quickstart requires [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
 
 
 #### Start a Clipper Instance and Deploy a Model
 
 ```
-$ pip install clipper_admin
+# From the root of the Clipper repo
+$ pip install -e .
 $ python
 >>> from clipper_admin import Clipper
 >>> import numpy as np

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Clipper is a prediction serving system that sits between user-facing application
 
 **Note: This quickstart works for the latest version of code. For a quickstart that works with the released version of Clipper available on PyPi, go to our [website](http://clipper.ai/overview/quickstart/)**
 
-> Note: This quickstart requires [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
+> This quickstart requires [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/).
 
 
 #### Start a Clipper Instance and Deploy a Model


### PR DESCRIPTION
The README contains a quickstart. I clarified that this quickstart corresponds to the latest commit on `develop`, not the released version.