### PR TITLE
change CODE_VERSION build arg to develop

### DIFF
--- a/ManagementFrontendDockerfile
+++ b/ManagementFrontendDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/lib_base:${CODE_VERSION}
 
 COPY ./ /clipper

--- a/NoopBenchDockerfile
+++ b/NoopBenchDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 COPY containers/python/noop_container.py /container/

--- a/NoopDockerfile
+++ b/NoopDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>

--- a/PySparkContainerDockerfile
+++ b/PySparkContainerDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>

--- a/PythonContainerDockerfile
+++ b/PythonContainerDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>

--- a/QueryFrontendDockerfile
+++ b/QueryFrontendDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/lib_base:${CODE_VERSION}
 
 # Build Clipper

--- a/RPythonDockerfile
+++ b/RPythonDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 ## Use Debian unstable via pinning -- new style via APT::Default-Release

--- a/SklearnCifarDockerfile
+++ b/SklearnCifarDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>

--- a/SumBenchDockerfile
+++ b/SumBenchDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 COPY containers/python/sum_container.py /container/

--- a/SumDockerfile
+++ b/SumDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 COPY containers/python/sum_container.py /container/

--- a/TensorFlowCifarDockerfile
+++ b/TensorFlowCifarDockerfile
@@ -1,4 +1,4 @@
-ARG CODE_VERSION=0.2-rc1
+ARG CODE_VERSION=develop
 FROM clipper/py-rpc:${CODE_VERSION}
 
 MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>


### PR DESCRIPTION
I had set the default values of these build args improperly. They should match the version in VERSION.txt. This will fix our failing docker hub builds.