### PR TITLE
Fixes readthedocs documentation

### DIFF
--- a/bin/check_format.sh
+++ b/bin/check_format.sh
@@ -58,6 +58,8 @@ if [ $num_py_violations -eq 0 ]; then
     echo "Passed Python PEP8 check"
 else
     echo "Found $num_py_violations Python PEP8 format violations"
+    find . -name '*.py' -print | egrep -v "yapf|ycm|googletest" \
+        | xargs python $CLIPPER_ROOT/bin/yapf/yapf -d
     exit 1
 fi
 

--- a/clipper_admin/clipper_admin/deployers/pyspark.py
+++ b/clipper_admin/clipper_admin/deployers/pyspark.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, with_statement, absolute_import
 import shutil
+import pyspark
 import logging
 import re
 import os
@@ -10,11 +11,6 @@ from ..clipper_admin import ClipperException
 from .deployer_utils import save_python_function
 
 logger = logging.getLogger(__name__)
-
-try:
-    import pyspark
-except ImportError:
-    logger.warning("Could not import PySpark")
 
 
 def create_endpoint(

--- a/clipper_admin/clipper_admin/deployers/pyspark.py
+++ b/clipper_admin/clipper_admin/deployers/pyspark.py
@@ -1,6 +1,5 @@
 from __future__ import print_function, with_statement, absolute_import
 import shutil
-import pyspark
 import logging
 import re
 import os
@@ -11,6 +10,11 @@ from ..clipper_admin import ClipperException
 from .deployer_utils import save_python_function
 
 logger = logging.getLogger(__name__)
+
+try:
+    import pyspark
+except ImportError:
+    logger.warning("Could not import PySpark")
 
 
 def create_endpoint(

--- a/clipper_admin/docs/conf.py
+++ b/clipper_admin/docs/conf.py
@@ -34,7 +34,7 @@ templates_path = ['_templates']
 
 import sys
 import os
-import shlex
+# import shlex
 
 import sphinx_rtd_theme
 

--- a/clipper_admin/docs/conf.py
+++ b/clipper_admin/docs/conf.py
@@ -38,6 +38,16 @@ import shlex
 
 import sphinx_rtd_theme
 
+from mock import Mock as MagicMock
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return MagicMock()
+
+MOCK_MODULES = ['pyspark']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/clipper_admin/docs/conf.py
+++ b/clipper_admin/docs/conf.py
@@ -115,7 +115,7 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/clipper_admin/docs/conf.py
+++ b/clipper_admin/docs/conf.py
@@ -40,10 +40,12 @@ import sphinx_rtd_theme
 
 from mock import Mock as MagicMock
 
+
 class Mock(MagicMock):
     @classmethod
     def __getattr__(cls, name):
-            return MagicMock()
+        return MagicMock()
+
 
 MOCK_MODULES = ['pyspark']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -4,3 +4,4 @@ pyyaml==3.12
 docker==2.5.1
 kubernetes==3.0.0
 six==1.10.0
+mock

--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -4,4 +4,4 @@ pyyaml==3.12
 docker==2.5.1
 kubernetes==3.0.0
 six==1.10.0
-pyspark==2.2.0
+pyspark>=2.1.0

--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -4,4 +4,3 @@ pyyaml==3.12
 docker==2.5.1
 kubernetes==3.0.0
 six==1.10.0
-pyspark>=2.1.0

--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -1,0 +1,7 @@
+requests==2.18.4
+subprocess32==3.2.7
+pyyaml==3.12
+docker==2.5.1
+kubernetes==3.0.0
+six==1.10.0
+pyspark==2.2.0


### PR DESCRIPTION
Fixes #277. Readthedocs was having issues installing all the Clipper dependencies. Solved by adding a requirements.txt file and mocking out PySpark (based on [this FAQ answer](http://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules)).

The rebuilt documentation is here: http://docs.clipper.ai/en/check-rtd-build/ (compare to http://docs.clipper.ai/en/develop/).