### PR TITLE
Build new docker images in build_model with in-memory Dockerfile

### DIFF
--- a/clipper_admin/clipper_admin/deployers/deployer_utils.py
+++ b/clipper_admin/clipper_admin/deployers/deployer_utils.py
@@ -3,10 +3,12 @@ from __future__ import print_function, with_statement, absolute_import
 import logging
 from .cloudpickle import CloudPickler
 from .module_dependency import ModuleDependencyAnalyzer
+from ..clipper_admin import CLIPPER_TEMP_DIR
 import six
 import os
 import sys
 import shutil
+import tempfile
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 if sys.version < '3':
     import subprocess32 as subprocess
@@ -21,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 
 def save_python_function(name, func):
-    relative_base_serializations_dir = "python_func_serializations"
     predict_fname = "func.pkl"
     environment_fname = "environment.yml"
     conda_dep_fname = "conda_dependencies.txt"
@@ -35,10 +36,10 @@ def save_python_function(name, func):
     serialized_prediction_function = s.getvalue()
 
     # Set up serialization directory
-    serialization_dir = os.path.join('/tmp', relative_base_serializations_dir,
-                                     name)
-    if not os.path.exists(serialization_dir):
-        os.makedirs(serialization_dir)
+    if not os.path.exists(CLIPPER_TEMP_DIR):
+        os.makedirs(CLIPPER_TEMP_DIR)
+    serialization_dir = tempfile.mkdtemp(dir=CLIPPER_TEMP_DIR)
+    logger.info("Saving function to {}".format(serialization_dir))
 
     # Export Anaconda environment
     environment_file_abs_path = os.path.join(serialization_dir,

--- a/clipper_admin/clipper_admin/deployers/pyspark.py
+++ b/clipper_admin/clipper_admin/deployers/pyspark.py
@@ -210,16 +210,9 @@ def deploy_pyspark_model(
     logger.info("Spark model saved")
 
     # Deploy model
-    clipper_conn.build_and_deploy_model(
-        name,
-        version,
-        input_type,
-        serialization_dir,
-        base_image,
-        labels,
-        registry,
-        num_replicas,
-        force=True)
+    clipper_conn.build_and_deploy_model(name, version, input_type,
+                                        serialization_dir, base_image, labels,
+                                        registry, num_replicas)
 
     # Remove temp files
     shutil.rmtree(serialization_dir)

--- a/clipper_admin/clipper_admin/deployers/python.py
+++ b/clipper_admin/clipper_admin/deployers/python.py
@@ -165,15 +165,8 @@ def deploy_python_closure(
     serialization_dir = save_python_function(name, func)
     logger.info("Python closure saved")
     # Deploy function
-    clipper_conn.build_and_deploy_model(
-        name,
-        version,
-        input_type,
-        serialization_dir,
-        base_image,
-        labels,
-        registry,
-        num_replicas,
-        force=True)
+    clipper_conn.build_and_deploy_model(name, version, input_type,
+                                        serialization_dir, base_image, labels,
+                                        registry, num_replicas)
     # Remove temp files
     shutil.rmtree(serialization_dir)

--- a/examples/tutorial/tutorial_part_two.ipynb
+++ b/examples/tutorial/tutorial_part_two.ipynb
@@ -268,8 +268,7 @@
     "    input_type=\"doubles\",\n",
     "    model_data_path=os.path.abspath(\"tf_cifar_model\"),\n",
     "    base_image=\"clipper/tf_cifar_container:latest\",\n",
-    "    num_replicas=1,\n",
-    "    force=True\n",
+    "    num_replicas=1\n",
     ")"
    ]
   },

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -173,12 +173,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         container_name = "clipper/noop-container:{}".format(clipper_version)
         input_type = "doubles"
         self.clipper_conn.build_and_deploy_model(
-            model_name,
-            version,
-            input_type,
-            fake_model_data,
-            container_name,
-            force=True)
+            model_name, version, input_type, fake_model_data, container_name)
         model_info = self.clipper_conn.get_model_info(model_name, version)
         self.assertIsNotNone(model_info)
         self.assertEqual(type(model_info), dict)
@@ -187,21 +182,6 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             filters={"ancestor": container_name})
         self.assertEqual(len(containers), 1)
 
-    def test_dont_overwrite_docker_file(self):
-        model_name = "m"
-        version = "v1"
-        container_name = "clipper/noop-container:{}".format(clipper_version)
-        input_type = "doubles"
-        # Force this one to make sure there's a docker file in the directory
-        self.clipper_conn.build_model(
-            model_name, version, fake_model_data, container_name, force=True)
-
-        # This call to build_model should cause an error
-        with self.assertRaises(cl.ClipperException) as context:
-            self.clipper_conn.build_model(model_name, version, fake_model_data,
-                                          container_name)
-        self.assertTrue("Found existing Dockerfile" in str(context.exception))
-
     def test_set_num_replicas_for_deployed_model_succeeds(self):
         model_name = "set-num-reps-model"
         input_type = "doubles"
@@ -209,12 +189,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         container_name = "clipper/noop-container:{}".format(clipper_version)
         input_type = "doubles"
         self.clipper_conn.build_and_deploy_model(
-            model_name,
-            version,
-            input_type,
-            fake_model_data,
-            container_name,
-            force=True)
+            model_name, version, input_type, fake_model_data, container_name)
 
         # Version defaults to current version
         self.clipper_conn.set_num_replicas(model_name, 4)
@@ -237,8 +212,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             input_type,
             fake_model_data,
             container_name,
-            num_replicas=2,
-            force=True)
+            num_replicas=2)
         docker_client = get_docker_client()
         containers = docker_client.containers.list(
             filters={"ancestor": container_name})
@@ -250,8 +224,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             input_type,
             fake_model_data,
             container_name,
-            num_replicas=3,
-            force=True)
+            num_replicas=3)
         containers = docker_client.containers.list(
             filters={"ancestor": container_name})
         self.assertEqual(len(containers), 5)
@@ -395,12 +368,8 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         model_version = 1
         container_name = "clipper/noop-container:{}".format(clipper_version)
         self.clipper_conn.build_and_deploy_model(
-            self.model_name_2,
-            model_version,
-            self.input_type,
-            fake_model_data,
-            container_name,
-            force=True)
+            self.model_name_2, model_version, self.input_type, fake_model_data,
+            container_name)
 
         self.clipper_conn.link_model_to_app(self.app_name_2, self.model_name_2)
         time.sleep(30)
@@ -463,7 +432,6 @@ SHORT_TEST_ORDERING = [
     'test_link_registered_model_to_app_succeeds',
     'get_app_info_for_registered_app_returns_info_dictionary',
     'get_app_info_for_nonexistent_app_returns_none',
-    'test_dont_overwrite_docker_file',
     'test_set_num_replicas_for_external_model_fails',
     'test_model_version_sets_correctly',
     'test_get_logs_creates_log_files',

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -161,7 +161,8 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         if not os.path.exists(cl.CLIPPER_TEMP_DIR):
             os.makedirs(cl.CLIPPER_TEMP_DIR)
         tmp_log_dir = tempfile.mkdtemp(dir=cl.CLIPPER_TEMP_DIR)
-        log_file_names = self.clipper_conn.get_clipper_logs(logging_dir=tmp_log_dir)
+        log_file_names = self.clipper_conn.get_clipper_logs(
+            logging_dir=tmp_log_dir)
         self.assertIsNotNone(log_file_names)
         self.assertGreaterEqual(len(log_file_names), 1)
         for file_name in log_file_names:

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -12,6 +12,8 @@ import os
 import json
 import time
 import requests
+import tempfile
+import shutil
 from argparse import ArgumentParser
 import logging
 from test_utils import get_docker_client, create_docker_connection, fake_model_data
@@ -156,11 +158,17 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         self.assertTrue(models_list_contains_correct_version)
 
     def test_get_logs_creates_log_files(self):
-        log_file_names = self.clipper_conn.get_clipper_logs()
+        if not os.path.exists(cl.CLIPPER_TEMP_DIR):
+            os.makedirs(cl.CLIPPER_TEMP_DIR)
+        tmp_log_dir = tempfile.mkdtemp(dir=cl.CLIPPER_TEMP_DIR)
+        log_file_names = self.clipper_conn.get_clipper_logs(logging_dir=tmp_log_dir)
         self.assertIsNotNone(log_file_names)
         self.assertGreaterEqual(len(log_file_names), 1)
         for file_name in log_file_names:
             self.assertTrue(os.path.isfile(file_name))
+
+        # Remove temp files
+        shutil.rmtree(tmp_log_dir)
 
     def test_inspect_instance_returns_json_dict(self):
         metrics = self.clipper_conn.inspect_instance()

--- a/integration-tests/kubernetes_integration_test.py
+++ b/integration-tests/kubernetes_integration_test.py
@@ -33,8 +33,7 @@ def deploy_model(clipper_conn, name, version):
         "clipper/noop-container:{}".format(clipper_version),
         num_replicas=1,
         container_registry=
-        "568959175238.dkr.ecr.us-west-1.amazonaws.com/clipper",
-        force=True)
+        "568959175238.dkr.ecr.us-west-1.amazonaws.com/clipper")
     time.sleep(10)
 
     clipper_conn.link_model_to_app(app_name, model_name)

--- a/integration-tests/kubernetes_integration_test.py
+++ b/integration-tests/kubernetes_integration_test.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 import requests
+import tempfile
+import shutil
 import json
 import numpy as np
 import time
@@ -10,7 +12,7 @@ from test_utils import (create_kubernetes_connection, BenchmarkException,
                         fake_model_data, headers, log_clipper_state)
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.abspath("%s/../clipper_admin" % cur_dir))
-from clipper_admin import __version__ as clipper_version
+from clipper_admin import __version__ as clipper_version, CLIPPER_TEMP_DIR
 
 logging.basicConfig(
     format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
@@ -115,7 +117,13 @@ if __name__ == "__main__":
                         (num_apps, num_models))
             for a in range(num_apps):
                 create_and_test_app(clipper_conn, "testapp%s" % a, num_models)
-            logger.info(clipper_conn.get_clipper_logs())
+
+            if not os.path.exists(CLIPPER_TEMP_DIR):
+                os.makedirs(CLIPPER_TEMP_DIR)
+            tmp_log_dir = tempfile.mkdtemp(dir=CLIPPER_TEMP_DIR)
+            logger.info(clipper_conn.get_clipper_logs(tmp_log_dir))
+            # Remove temp files
+            shutil.rmtree(tmp_log_dir)
             log_clipper_state(clipper_conn)
             logger.info("SUCCESS")
             clipper_conn.stop_all()

--- a/integration-tests/many_apps_many_models.py
+++ b/integration-tests/many_apps_many_models.py
@@ -29,8 +29,7 @@ def deploy_model(clipper_conn, name, version, link=False):
         "doubles",
         fake_model_data,
         "clipper/noop-container:{}".format(clipper_version),
-        num_replicas=1,
-        force=True)
+        num_replicas=1)
     time.sleep(10)
 
     if link:

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -7,20 +7,17 @@ import socket
 import docker
 import logging
 import time
+import tempfile
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.abspath("%s/../clipper_admin" % cur_dir))
-from clipper_admin import ClipperConnection, DockerContainerManager, KubernetesContainerManager
+from clipper_admin import ClipperConnection, DockerContainerManager, KubernetesContainerManager, CLIPPER_TEMP_DIR
 from clipper_admin.container_manager import CLIPPER_DOCKER_LABEL
 from clipper_admin import __version__ as clipper_version
 
 logger = logging.getLogger(__name__)
 
 headers = {'Content-type': 'application/json'}
-fake_model_data = "/tmp/test123456"
-try:
-    os.mkdir(fake_model_data)
-except OSError:
-    pass
+fake_model_data = tempfile.mkdtemp(dir=CLIPPER_TEMP_DIR)
 
 
 class BenchmarkException(Exception):

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -17,6 +17,9 @@ from clipper_admin import __version__ as clipper_version
 logger = logging.getLogger(__name__)
 
 headers = {'Content-type': 'application/json'}
+if not os.path.exists(CLIPPER_TEMP_DIR):
+    os.makedirs(CLIPPER_TEMP_DIR)
+
 fake_model_data = tempfile.mkdtemp(dir=CLIPPER_TEMP_DIR)
 
 


### PR DESCRIPTION
Removes the need to write a Dockerfile to disk in the user's file system by creating an in-memory Dockefile with StringIO then adding it directly to a temporary tar file to be used as the Docker build context.

The end result is that we don't write (and potentially overwrite) Dockerfile's in the user's system.