### PR TITLE
Fixed conda object manipulation problem

### DIFF
--- a/clipper_admin/clipper_admin/deployers/check_and_write_deps.py
+++ b/clipper_admin/clipper_admin/deployers/check_and_write_deps.py
@@ -92,7 +92,6 @@ def check_solvability_write_deps(env_path, directory, platform,
             for package in missing_packages:
                 conda_deps.remove(package[0].spec)
 
-
             # Check that the dependencies that are not missing are satisfiable
             r.install(conda_deps)
     except UnsatisfiableError as unsat_e:

--- a/clipper_admin/clipper_admin/deployers/check_and_write_deps.py
+++ b/clipper_admin/clipper_admin/deployers/check_and_write_deps.py
@@ -88,9 +88,10 @@ def check_solvability_write_deps(env_path, directory, platform,
             # This call doesn't install anything; it checks the solvability of package dependencies.
             r.install(conda_deps)
         except NoPackagesFoundError as missing_packages_error:
-            missing_packages = missing_packages_error.pkgs
+            missing_packages = missing_packages_error.bad_deps
             for package in missing_packages:
-                conda_deps.remove(package)
+                conda_deps.remove(package[0].spec)
+
 
             # Check that the dependencies that are not missing are satisfiable
             r.install(conda_deps)

--- a/clipper_admin/clipper_admin/deployers/check_and_write_deps.py
+++ b/clipper_admin/clipper_admin/deployers/check_and_write_deps.py
@@ -106,7 +106,7 @@ def check_solvability_write_deps(env_path, directory, platform,
         print(
             "The following packages in your conda environment aren't available in the linux-64 "
             "conda channel the container will use:")
-        print(", ".join(str(package) for package in missing_packages))
+        print(", ".join(str(package[0].spec) for package in missing_packages))
         print(
             "We will skip their installation when deploying your function. If your function uses "
             "these packages, the container will experience a runtime error when queried."


### PR DESCRIPTION
Should resolve #269 

As @mdagost mentioned, conda updated how they passed around internal dependency objects. This PR updates our manipulation of these dependency objects to be compatible with this update.

Before testing, make sure you're on the latest version of conda: `conda 4.3.24`. This change isn't backwards compatible so we should probably also state somewhere that conda versions should be `>= 4.3.24`

To test, run the quickstart with a conda environment that has packages not found in the `linux-64` conda platform.

If you want to test the updated script in an isolated manner, you can:
1. Navigate to `<clipper>/clipper_admin/clipper_admin/deployers`
2. Activate a conda environment and install some packages that don't exist on some target platform
- For the linux-64 platform, `appnope` doesn't exist
3. Export your environment: `PIP_FORMAT=legacy conda env export >>"env_path.txt"`
4. Deactivate your conda environment: `source deactivate`
5. Make an output directory for the script: `mkdir output_dir`
5. Run the script. Example: `python check_and_write_deps.py "env_path.txt" "output_dir" 'linux-64' "conda_dependencies.txt" "pip_dependencies.txt"`
6. Confirm that `<pwd>/output_dir/conda_dependencies.txt` and `<pwd>/output_dir/conda_dependencies.txt` don't have any of the packages that shouldn't exist on your stated platform
