### PR TITLE
Add CLIPPER_INPUT_TYPE to k8s environment

### DIFF
--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -189,6 +189,9 @@ class KubernetesContainerManager(ContainerManager):
                                 }, {
                                     'name': 'CLIPPER_IP',
                                     'value': 'query-frontend'
+                                }, {
+                                    'name': 'CLIPPER_INPUT_TYPE',
+                                    'value': input_type
                                 }]
                             }]
                         }


### PR DESCRIPTION
It was always using the default "doubles" input_type

p.s. we are now able to successfully serve predictions using clipper on AWS using kops k8s!