### PR TITLE
Add version specification in setup.py; Making Clipper_admin python 2-3 compatible.

### DIFF
--- a/clipper_admin/setup.cfg
+++ b/clipper_admin/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. Such that `python setup.py bdist_wheel` will create py2 and py3 compatible
+# verion in one wheel
+universal=1

--- a/clipper_admin/setup.py
+++ b/clipper_admin/setup.py
@@ -27,7 +27,7 @@ setup(
     keywords=['clipper', 'prediction', 'model', 'management'],
     install_requires=[
         'requests',
-        'subprocess32',
+        'subprocess32;python_version<"3.0"',
         'pyyaml',
         'docker',
         'kubernetes',


### PR DESCRIPTION
This PR can contribute to 0.3.0 release of clipper such that it will
be py2 and py3 compatible. Issue #138 can be closed once this 
PR is merged.

The fix is simple: just add version specification for `subprocess32`.

The file `setup.cfg` is added for easier wheel generation. If we don't
have this file, you have to manually add `--universal` flag to generate
the wheel such that the wheel is `py2.py3` compatible. 

# Modify version in setup.py; add setup.cfg

This can be last step towards python2 and python3 compatibility.
The issue with running clipper_admin on python3 is not the code
itself, but the installation process. This change fixes the
pip install process.

<Simon Mo>