### PR TITLE
Support for Generic Tensorflow Models

### DIFF
--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -257,6 +257,7 @@ build_images () {
     create_image python-closure-container PyClosureContainerDockerfile $public
     create_image pyspark-container PySparkContainerDockerfile $public
     create_image tf_cifar_container TensorFlowCifarDockerfile $public
+    create_image tf-container TensorFlowDockerfile $public
 }
 
 

--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -140,6 +140,7 @@ function run_integration_tests {
   python ../integration-tests/deploy_pyspark_models.py
   python ../integration-tests/deploy_pyspark_pipeline_models.py
   python ../integration-tests/kubernetes_integration_test.py
+  python ../integration-tests/deploy_tensorflow_models.py
   ../integration-tests/r_integration_test/rclipper_test.sh
 }
 

--- a/clipper_admin/clipper_admin/deployers/tensorflow.py
+++ b/clipper_admin/clipper_admin/deployers/tensorflow.py
@@ -1,0 +1,176 @@
+from __future__ import print_function, with_statement, absolute_import
+import shutil
+import tensorflow as tf
+import logging
+import re
+import os
+import json
+
+from ..version import __version__
+from ..clipper_admin import ClipperException
+from .deployer_utils import save_python_function
+
+logger = logging.getLogger(__name__)
+
+
+def create_endpoint(clipper_conn,
+                    name,
+                    input_type,
+                    func,
+                    tf_sess,
+                    default_output="None",
+                    version=1,
+                    slo_micros=3000000,
+                    labels=None,
+                    registry=None,
+                    base_image="clipper/tf-container:{}".format(__version__),
+                    num_replicas=1):
+    """Registers an app and deploys the provided predict function with TensorFlow  model as
+    a Clipper model.
+
+    Parameters
+    ----------
+    clipper_conn : :py:meth:`clipper_admin.ClipperConnection`
+        A ``ClipperConnection`` object connected to a running Clipper cluster.
+    name : str
+        The name to be assigned to both the registered application and deployed model.
+    input_type : str
+        The input_type to be associated with the registered app and deployed model.
+        One of "integers", "floats", "doubles", "bytes", or "strings".
+    func : function
+        The prediction function. Any state associated with the function will be
+        captured via closure capture and pickled with Cloudpickle.
+    tf_sess : The Tensorflow Session to save.
+    default_output : str, optional
+        The default output for the application. The default output will be returned whenever
+        an application is unable to receive a response from a model within the specified
+        query latency SLO (service level objective). The reason the default output was returned
+        is always provided as part of the prediction response object. Defaults to "None".
+    version : str, optional
+        The version to assign this model. Versions must be unique on a per-model
+        basis, but may be re-used across different models.
+    slo_micros : int, optional
+        The query latency objective for the application in microseconds.
+        This is the processing latency between Clipper receiving a request
+        and sending a response. It does not account for network latencies
+        before a request is received or after a response is sent.
+        If Clipper cannot process a query within the latency objective,
+        the default output is returned. Therefore, it is recommended that
+        the SLO not be set aggressively low unless absolutely necessary.
+        100000 (100ms) is a good starting value, but the optimal latency objective
+        will vary depending on the application.
+    labels : list(str), optional
+        A list of strings annotating the model. These are ignored by Clipper
+        and used purely for user annotations.
+    registry : str, optional
+        The Docker container registry to push the freshly built model to. Note
+        that if you are running Clipper on Kubernetes, this registry must be accesible
+        to the Kubernetes cluster in order to fetch the container from the registry.
+    base_image : str, optional
+        The base Docker image to build the new model image from. This
+        image should contain all code necessary to run a Clipper model
+        container RPC client.
+    num_replicas : int, optional
+        The number of replicas of the model to create. The number of replicas
+        for a model can be changed at any time with
+        :py:meth:`clipper.ClipperConnection.set_num_replicas`.
+    """
+
+    clipper_conn.register_application(name, input_type, default_output,
+                                      slo_micros)
+    deploy_tensorflow_model(clipper_conn, name, version, input_type, func,
+                            tf_sess, base_image, labels, registry,
+                            num_replicas)
+
+    clipper_conn.link_model_to_app(name, name)
+
+
+def deploy_tensorflow_model(
+        clipper_conn,
+        name,
+        version,
+        input_type,
+        func,
+        tf_sess,
+        base_image="clipper/tf-container:{}".format(__version__),
+        labels=None,
+        registry=None,
+        num_replicas=1):
+    """Deploy a Python prediction function with a Tensorflow model.
+    Parameters
+    ----------
+    clipper_conn : :py:meth:`clipper_admin.ClipperConnection`
+        A ``ClipperConnection`` object connected to a running Clipper cluster.
+    name : str
+        The name to be assigned to both the registered application and deployed model.
+    version : str
+        The version to assign this model. Versions must be unique on a per-model
+        basis, but may be re-used across different models.
+    input_type : str
+        The input_type to be associated with the registered app and deployed model.
+        One of "integers", "floats", "doubles", "bytes", or "strings".
+    func : function
+        The prediction function. Any state associated with the function will be
+        captured via closure capture and pickled with Cloudpickle.
+    tf_sess : tensorflow.python.client.session.Session
+        The tensor flow session to save.
+    base_image : str, optional
+        The base Docker image to build the new model image from. This
+        image should contain all code necessary to run a Clipper model
+        container RPC client.
+    labels : list(str), optional
+        A list of strings annotating the model. These are ignored by Clipper
+        and used purely for user annotations.
+    registry : str, optional
+        The Docker container registry to push the freshly built model to. Note
+        that if you are running Clipper on Kubernetes, this registry must be accesible
+        to the Kubernetes cluster in order to fetch the container from the registry.
+    num_replicas : int, optional
+        The number of replicas of the model to create. The number of replicas
+        for a model can be changed at any time with
+        :py:meth:`clipper.ClipperConnection.set_num_replicas`.
+
+
+    Example
+    -------
+        from clipper_admin import ClipperConnection, DockerContainerManager
+        from clipper_admin.deployers.tensorflow import deploy_tensorflow_model
+
+        clipper_conn = ClipperConnection(DockerContainerManager())
+
+        # Connect to an already-running Clipper cluster
+        clipper_conn.connect()
+
+        def predict(sess, inputs):
+            preds = sess.run('predict_class:0', feed_dict={'pixels:0': inputs})
+            return [str(p) for p in preds]
+
+        deploy_tensorflow_model(
+        clipper_conn,
+        model_name,
+        version,
+        input_type,
+        predict_fn,
+        sess)
+
+    """
+    # save predict function
+    serialization_dir = save_python_function(name, func)
+    # save Tensorflow session
+    tf_sess_save_loc = os.path.join(serialization_dir, "tfmodel/model.ckpt")
+    try:
+        saver = tf.train.Saver()
+        save_path = saver.save(tf_sess, tf_sess_save_loc)
+    except Exception as e:
+        logger.warn("Error saving Tensorflow model: %s" % e)
+        raise e
+
+    logger.info("TensorFlow model saved at: %s " % save_path)
+
+    # Deploy model
+    clipper_conn.build_and_deploy_model(name, version, input_type,
+                                        serialization_dir, base_image, labels,
+                                        registry, num_replicas)
+
+    # Remove temp files
+    shutil.rmtree(serialization_dir)

--- a/clipper_admin/setup.py
+++ b/clipper_admin/setup.py
@@ -35,4 +35,5 @@ setup(
     ],
     extras_require={
         'PySpark': ['pyspark'],
+        'TensorFlow': ['tensorflow'],
     })

--- a/containers/python/tf_container.py
+++ b/containers/python/tf_container.py
@@ -1,0 +1,100 @@
+from __future__ import print_function
+import rpc
+import os
+import sys
+import tensorflow as tf
+
+from clipper_admin.deployers import cloudpickle
+
+
+def load_predict_func(file_path):
+    with open(file_path, 'r') as serialized_func_file:
+        return cloudpickle.load(serialized_func_file)
+
+
+class TfContainer(rpc.ModelContainerBase):
+    def __init__(self, path, input_type):
+        self.input_type = rpc.string_to_input_type(input_type)
+        modules_folder_path = "{dir}/modules/".format(dir=path)
+        sys.path.append(os.path.abspath(modules_folder_path))
+        predict_fname = "func.pkl"
+        predict_path = "{dir}/{predict_fname}".format(
+            dir=path, predict_fname=predict_fname)
+        self.predict_func = load_predict_func(predict_path)
+        self.sess = tf.Session(
+            '',
+            tf.Graph(),
+            config=tf.ConfigProto(
+                allow_soft_placement=True, log_device_placement=True))
+        metagraph_path = os.path.join(path, "tfmodel/model.ckpt.meta")
+        checkpoint_path = os.path.join(path, "tfmodel/model.ckpt")
+        with tf.device("/gpu:0"):
+            with self.sess.graph.as_default():
+                saver = tf.train.import_meta_graph(
+                    metagraph_path, clear_devices=True)
+                saver.restore(self.sess, checkpoint_path)
+
+    def predict_ints(self, inputs):
+        preds = self.predict_func(self.sess, inputs)
+        return [str(p) for p in preds]
+
+    def predict_floats(self, inputs):
+        preds = self.predict_func(self.sess, inputs)
+        return [str(p) for p in preds]
+
+    def predict_doubles(self, inputs):
+        preds = self.predict_func(self.sess, inputs)
+        return [str(p) for p in preds]
+
+    def predict_bytes(self, inputs):
+        preds = self.predict_func(self.sess, inputs)
+        return [str(p) for p in preds]
+
+    def predict_strings(self, inputs):
+        preds = self.predict_func(self.sess, inputs)
+        return [str(p) for p in preds]
+
+
+if __name__ == "__main__":
+    print("Starting TensorFlow container")
+    try:
+        model_name = os.environ["CLIPPER_MODEL_NAME"]
+    except KeyError:
+        print(
+            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
+            file=sys.stdout)
+        sys.exit(1)
+    try:
+        model_version = os.environ["CLIPPER_MODEL_VERSION"]
+    except KeyError:
+        print(
+            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
+            file=sys.stdout)
+        sys.exit(1)
+
+    ip = "127.0.0.1"
+    if "CLIPPER_IP" in os.environ:
+        ip = os.environ["CLIPPER_IP"]
+    else:
+        print("Connecting to Clipper on localhost")
+
+    port = 7000
+    if "CLIPPER_PORT" in os.environ:
+        port = int(os.environ["CLIPPER_PORT"])
+    else:
+        print("Connecting to Clipper with default port: 7000")
+
+    input_type = "doubles"
+    if "CLIPPER_INPUT_TYPE" in os.environ:
+        input_type = os.environ["CLIPPER_INPUT_TYPE"]
+    else:
+        print("Using default input type: doubles")
+
+    model_dir_path = os.environ["CLIPPER_MODEL_PATH"]
+    model_files = os.listdir(model_dir_path)
+    assert len(model_files) >= 2
+    fname = os.path.splitext(model_files[0])[0]
+    full_fname = os.path.join(model_dir_path, fname)
+    model = TfContainer(model_dir_path, input_type)
+    rpc_service = rpc.RPCService()
+    rpc_service.start(model, ip, port, model_name, model_version, input_type)

--- a/containers/python/tf_container_entry.sh
+++ b/containers/python/tf_container_entry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+
+IMPORT_ERROR_RETURN_CODE=3
+
+echo "Attempting to run TensorFlow container without installing any dependencies"
+echo "Contents of /model"
+ls /model/
+
+/bin/bash -c "exec python /container/tf_container.py"
+if [ $? -eq $IMPORT_ERROR_RETURN_CODE ]; then
+	echo "Running TensorFlow container without installing dependencies fails"
+	echo "Will install dependencies and try again"
+  conda install -y --file /model/conda_dependencies.txt
+  pip install -r /model/pip_dependencies.txt
+  /bin/bash -c "exec python /container/tf_container.py"
+fi

--- a/dockerfiles/ClipperTestsDockerfile
+++ b/dockerfiles/ClipperTestsDockerfile
@@ -17,12 +17,12 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
 ENV PATH "/opt/conda/bin:$PATH"
 RUN conda install -y libgcc pyzmq
  
-RUN pip install requests subprocess32 scikit-learn numpy pyyaml docker kubernetes pyspark
+RUN pip install requests subprocess32 scikit-learn numpy pyyaml docker kubernetes pyspark tensorflow
 
 # Install maven
 ARG MAVEN_VERSION=3.5.0
 ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-$MAVEN_VERSION-bin.tar.gz \

--- a/dockerfiles/SparkScalaContainerDockerfile
+++ b/dockerfiles/SparkScalaContainerDockerfile
@@ -5,7 +5,7 @@ FROM openjdk:8-jdk
 # First set up maven
 ARG MAVEN_VERSION=3.5.0
 ARG SHA=beb91419245395bd69a4a6edad5ca3ec1a8b64e41457672dc687c173a495f034
-ARG BASE_URL=https://apache.osuosl.org/maven/maven-3/${MAVEN_VERSION}/binaries
+ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
   && curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-$MAVEN_VERSION-bin.tar.gz \

--- a/dockerfiles/TensorFlowDockerfile
+++ b/dockerfiles/TensorFlowDockerfile
@@ -1,0 +1,15 @@
+ARG CODE_VERSION
+FROM clipper/py-rpc:${CODE_VERSION}
+
+COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
+RUN conda install -y --file /lib/python_container_conda_deps.txt
+
+RUN conda install tensorflow
+
+COPY containers/python/tf_container.py containers/python/tf_container_entry.sh /container/
+COPY clipper_admin/ /lib/clipper_admin
+RUN pip install /lib/clipper_admin
+
+CMD ["/container/tf_container_entry.sh"]
+
+# vim: set filetype=dockerfile:

--- a/integration-tests/deploy_tensorflow_models.py
+++ b/integration-tests/deploy_tensorflow_models.py
@@ -1,0 +1,201 @@
+from __future__ import absolute_import, print_function
+import os
+import sys
+import requests
+import json
+import numpy as np
+import time
+import logging
+
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+
+sys.path.insert(0, os.path.abspath('%s/util_direct_import/' % cur_dir))
+from util_package import mock_module_in_package as mmip
+import mock_module as mm
+
+import tensorflow as tf
+
+from test_utils import (create_docker_connection, BenchmarkException, headers,
+                        log_clipper_state)
+cur_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.abspath("%s/../clipper_admin" % cur_dir))
+from clipper_admin.deployers.tensorflow import deploy_tensorflow_model, create_endpoint
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+    datefmt='%y-%m-%d:%H:%M:%S',
+    level=logging.INFO)
+
+logger = logging.getLogger(__name__)
+
+app_name = "tensorflow-test"
+model_name = "tensorflow-model"
+
+
+def normalize(x):
+    return x.astype(np.double) / 255.0
+
+
+def objective(y, pos_label):
+    # prediction objective
+    if y == pos_label:
+        return 1
+    else:
+        return 0
+
+
+def parseData(train_path, pos_label):
+    trainData = np.genfromtxt(train_path, delimiter=',', dtype=int)
+    records = trainData[:, 1:]
+    labels = trainData[:, :1]
+    transformedlabels = [objective(ele, pos_label) for ele in labels]
+    return (records, transformedlabels)
+
+
+def reset_vars(sess):
+    sess.run(tf.global_variables_initializer())
+
+
+def reset_tf(sess):
+    if sess:
+        sess.close()
+    tf.reset_default_graph()
+    sess = tf.Session()
+    return sess
+
+
+def predict(sess, inputs):
+    preds = sess.run('predict_class:0', feed_dict={'pixels:0': inputs})
+    return [str(p) for p in preds]
+
+
+def deploy_and_test_model(clipper_conn,
+                          sess,
+                          version,
+                          input_type,
+                          link_model=False,
+                          predict_fn=predict):
+    deploy_tensorflow_model(clipper_conn, model_name, version, input_type,
+                            predict_fn, sess)
+
+    time.sleep(5)
+
+    if link_model:
+        clipper_conn.link_model_to_app(app_name, model_name)
+        time.sleep(5)
+
+    test_model(clipper_conn, app_name, version)
+
+
+def test_model(clipper_conn, app, version):
+    time.sleep(25)
+    num_preds = 25
+    num_defaults = 0
+    addr = clipper_conn.get_query_addr()
+    print(addr)
+    for i in range(num_preds):
+        response = requests.post(
+            "http://%s/%s/predict" % (addr, app),
+            headers=headers,
+            data=json.dumps({
+                'input': get_test_point()
+            }))
+        result = response.json()
+        if response.status_code == requests.codes.ok and result["default"]:
+            num_defaults += 1
+        elif response.status_code != requests.codes.ok:
+            print(result)
+            raise BenchmarkException(response.text)
+
+    if num_defaults > 0:
+        print("Error: %d/%d predictions were default" % (num_defaults,
+                                                         num_preds))
+    if num_defaults > num_preds / 2:
+        raise BenchmarkException("Error querying APP %s, MODEL %s:%d" %
+                                 (app, model_name, version))
+
+
+def train_logistic_regression(sess, X_train, y_train):
+    sess = reset_tf(sess)
+    x = tf.placeholder(tf.float32, [None, X_train.shape[1]], name="pixels")
+    y_labels = tf.placeholder(tf.int32, [None], name="labels")
+    y = tf.one_hot(y_labels, depth=2)
+
+    W = tf.Variable(tf.zeros([X_train.shape[1], 2]), name="weights")
+    b = tf.Variable(tf.zeros([2]), name="biases")
+    y_hat = tf.matmul(x, W) + b
+
+    pred = tf.argmax(tf.nn.softmax(y_hat), 1, name="predict_class")  # Softmax
+
+    loss = tf.reduce_mean(
+        tf.nn.softmax_cross_entropy_with_logits(logits=y_hat, labels=y))
+    train = tf.train.GradientDescentOptimizer(0.1).minimize(loss)
+
+    accuracy = tf.reduce_mean(
+        tf.cast(tf.equal(tf.argmax(y_hat, 1), tf.argmax(y, 1)), tf.float32))
+    reset_vars(sess)
+    for i in range(5000):
+        sess.run(train, feed_dict={x: X_train, y_labels: y_train})
+        if i % 1000 == 0:
+            print('Cost , Accuracy')
+            print(sess.run(
+                [loss, accuracy], feed_dict={x: X_train,
+                                             y_labels: y_train}))
+    return sess
+
+
+def get_test_point():
+    return [np.random.randint(255) for _ in range(784)]
+
+
+if __name__ == "__main__":
+    pos_label = 3
+    try:
+        sess = None
+        clipper_conn = create_docker_connection(
+            cleanup=True, start_clipper=True)
+
+        train_path = os.path.join(cur_dir, "data/train.data")
+        (X_train, y_train) = parseData(train_path, pos_label)
+
+        try:
+            clipper_conn.register_application(app_name, "integers",
+                                              "default_pred", 100000)
+            time.sleep(1)
+
+            addr = clipper_conn.get_query_addr()
+            response = requests.post(
+                "http://%s/%s/predict" % (addr, app_name),
+                headers=headers,
+                data=json.dumps({
+                    'input': get_test_point()
+                }))
+            result = response.json()
+            if response.status_code != requests.codes.ok:
+                print("Error: %s" % response.text)
+                raise BenchmarkException("Error creating app %s" % app_name)
+
+            version = 1
+            sess = train_logistic_regression(sess, X_train, y_train)
+            deploy_and_test_model(
+                clipper_conn, sess, version, "integers", link_model=True)
+
+            app_and_model_name = "easy-register-app-model"
+            create_endpoint(clipper_conn, app_and_model_name, "integers",
+                            predict, sess)
+            test_model(clipper_conn, app_and_model_name, 1)
+
+        except BenchmarkException as e:
+            log_clipper_state(clipper_conn)
+            logger.exception("BenchmarkException")
+            clipper_conn = create_docker_connection(
+                cleanup=True, start_clipper=False)
+            sys.exit(1)
+        else:
+            clipper_conn = create_docker_connection(
+                cleanup=True, start_clipper=False)
+    except Exception as e:
+        logger.exception("Exception")
+        clipper_conn = create_docker_connection(
+            cleanup=True, start_clipper=False)
+        sys.exit(1)


### PR DESCRIPTION
Support deploying TensorFlow models directly from the clipper_admin tool, similarly to the way we support deploying PySpark models directly by calling Clipper.deploy_pyspark_model.

Closes #240