### PR TITLE
Support deploying Saved Tensorflow Models

### DIFF
--- a/clipper_admin/clipper_admin/deployers/tensorflow.py
+++ b/clipper_admin/clipper_admin/deployers/tensorflow.py
@@ -5,10 +5,12 @@ import logging
 import re
 import os
 import json
+import glob
 
 from ..version import __version__
 from ..clipper_admin import ClipperException
 from .deployer_utils import save_python_function
+from tensorflow import Session
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +19,7 @@ def create_endpoint(clipper_conn,
                     name,
                     input_type,
                     func,
-                    tf_sess,
+                    tf_sess_or_saved_model_path,
                     default_output="None",
                     version=1,
                     slo_micros=3000000,
@@ -25,7 +27,7 @@ def create_endpoint(clipper_conn,
                     registry=None,
                     base_image="clipper/tf-container:{}".format(__version__),
                     num_replicas=1):
-    """Registers an app and deploys the provided predict function with TensorFlow  model as
+    """Registers an app and deploys the provided predict function with TensorFlow model as
     a Clipper model.
 
     Parameters
@@ -40,7 +42,7 @@ def create_endpoint(clipper_conn,
     func : function
         The prediction function. Any state associated with the function will be
         captured via closure capture and pickled with Cloudpickle.
-    tf_sess : The Tensorflow Session to save.
+    tf_sess : The Tensorflow Session to save or path to an existing saved model.
     default_output : str, optional
         The default output for the application. The default output will be returned whenever
         an application is unable to receive a response from a model within the specified
@@ -79,8 +81,8 @@ def create_endpoint(clipper_conn,
     clipper_conn.register_application(name, input_type, default_output,
                                       slo_micros)
     deploy_tensorflow_model(clipper_conn, name, version, input_type, func,
-                            tf_sess, base_image, labels, registry,
-                            num_replicas)
+                            tf_sess_or_saved_model_path, base_image, labels,
+                            registry, num_replicas)
 
     clipper_conn.link_model_to_app(name, name)
 
@@ -91,12 +93,12 @@ def deploy_tensorflow_model(
         version,
         input_type,
         func,
-        tf_sess,
+        tf_sess_or_saved_model_path,
         base_image="clipper/tf-container:{}".format(__version__),
         labels=None,
         registry=None,
         num_replicas=1):
-    """Deploy a Python prediction function with a Tensorflow model.
+    """Deploy a Python prediction function with a Tensorflow session or saved Tensorflow model.
     Parameters
     ----------
     clipper_conn : :py:meth:`clipper_admin.ClipperConnection`
@@ -113,7 +115,7 @@ def deploy_tensorflow_model(
         The prediction function. Any state associated with the function will be
         captured via closure capture and pickled with Cloudpickle.
     tf_sess : tensorflow.python.client.session.Session
-        The tensor flow session to save.
+        The tensor flow session to save or path to an existing saved model.
     base_image : str, optional
         The base Docker image to build the new model image from. This
         image should contain all code necessary to run a Clipper model
@@ -156,16 +158,83 @@ def deploy_tensorflow_model(
     """
     # save predict function
     serialization_dir = save_python_function(name, func)
-    # save Tensorflow session
-    tf_sess_save_loc = os.path.join(serialization_dir, "tfmodel/model.ckpt")
-    try:
-        saver = tf.train.Saver()
-        save_path = saver.save(tf_sess, tf_sess_save_loc)
-    except Exception as e:
-        logger.warn("Error saving Tensorflow model: %s" % e)
-        raise e
+    # save Tensorflow session or copy the saved model into the image
+    if isinstance(tf_sess_or_saved_model_path, Session):
+        tf_sess_save_loc = os.path.join(serialization_dir,
+                                        "tfmodel/model.ckpt")
+        try:
+            saver = tf.train.Saver()
+            save_path = saver.save(tf_sess_or_saved_model_path,
+                                   tf_sess_save_loc)
+        except Exception as e:
+            logger.warn("Error saving Tensorflow model: %s" % e)
+            raise e
+        logger.info("TensorFlow model saved at: %s " % save_path)
+    else:
+        # Check if its a frozen Graph or a saved tensorflow Model
 
-    logger.info("TensorFlow model saved at: %s " % save_path)
+        # A typical Tensorflow model contains 4 files:
+        #  model-ckpt.meta: This contains the complete graph. [This contains a serialized MetaGraphDef protocol buffer.
+        #  model-ckpt.data-0000-of-00001: This contains all the values of variables(weights, biases, placeholders,gradients, hyper-parameters etc).
+        #  model-ckpt.index: metadata.
+        #  checkpoint: All checkpoint information
+
+        # Frozen Graph
+        # Single encapsulated file(.pb extension) without un-necessary meta-data, gradients and un-necessary training variables
+
+        if os.path.isdir(tf_sess_or_saved_model_path):
+            # Directory - Check for Frozen Graph or a Saved Tensorflow Model
+            is_frozen_graph = glob.glob(
+                os.path.join(tf_sess_or_saved_model_path, "*.pb"))
+            if (len(is_frozen_graph) > 0):
+                try:
+                    shutil.copytree(tf_sess_or_saved_model_path,
+                                    os.path.join(serialization_dir, "tfmodel"))
+                except Exception as e:
+                    logger.error(
+                        "Error copying Frozen Tensorflow model: %s" % e)
+                    raise e
+            else:
+                # Check if all the 4 files are present
+                if glob.glob('data/*.meta') and glob.glob(
+                        'data/*.index') and glob.glob(
+                            "data/checkpoint") and glob.glob("data/*.data*"):
+                    try:
+                        shutil.copytree(tf_sess_or_saved_model_path,
+                                        os.path.join(serialization_dir,
+                                                     "tfmodel"))
+                    except Exception as e:
+                        logger.error("Error copying Tensorflow model: %s" % e)
+                        raise e
+                else:
+                    logger.error(
+                        "Tensorflow Model: %s not found or some files are missing"
+                        % tf_sess_or_saved_model_path)
+                    raise Exception(
+                        "Frozen Tensorflow Model: %s not found or some files are missing "
+                        % tf_sess_or_saved_model_path)
+        else:
+            # File provided ...check if file exists and a frozen model
+            # Check if a frozen model exists or else error out
+            if (os.path.isfile(tf_sess_or_saved_model_path)
+                ) and tf_sess_or_saved_model_path.lower().endswith(('.pb')):
+                os.makedirs(os.path.join(serialization_dir, "tfmodel"))
+                try:
+                    shutil.copyfile(
+                        tf_sess_or_saved_model_path,
+                        os.path.join(
+                            serialization_dir, "tfmodel/" +
+                            os.path.basename(tf_sess_or_saved_model_path)))
+                except Exception as e:
+                    logger.error(
+                        "Error copying Frozen Tensorflow model: %s" % e)
+                    raise e
+            else:
+                logger.error("Tensorflow Model: %s not found" %
+                             tf_sess_or_saved_model_path)
+                raise Exception("Frozen Tensorflow Model: %s not found " %
+                                tf_sess_or_saved_model_path)
+        logger.info("TensorFlow model copied to: tfmodel ")
 
     # Deploy model
     clipper_conn.build_and_deploy_model(name, version, input_type,


### PR DESCRIPTION
Current deployment of tensorflow models only supports deployment by passing the tensorflow session as a parameter.It should be possible to deploy any saved tensorflow model by passing the model directory path, like in the tfcifar example.This PR addresses the above issue.