### PR TITLE
R Support: Handle missing libraries

### DIFF
--- a/containers/R/deserialize_model.R
+++ b/containers/R/deserialize_model.R
@@ -19,7 +19,14 @@ deserialize_model = function(model_data_path) {
     if(!(lib_dep %in% installed.packages())) {
       install.packages(lib_dep)
     }
-    library(lib_dep, character.only=TRUE)
+    tryCatch({
+      library(lib_dep, character.only=TRUE)
+    }, error = function(e) {
+      print(paste(c("Failed to install library:", lib_dep), collapse=" "))
+      print(paste("Proceeding with deserialization.",
+                  "Model inference may fail if",
+                  "this library is required!", sep=" "))
+    })
   }
   
   model_function_info <- tryCatch({


### PR DESCRIPTION
Adds error handling when deserializing and loading a model's library dependencies. If a library cannot be loaded, the container no longer crashes immediately. Instead, a warning message is emitted.

This fixes the issue where loading the `Rclipper` library into an R environment and calling `Rclipper::build_model(...)` causes the built container to crash on deployment due to the fact that `Rclipper` is not available for installation on CRAN.