### PR TITLE
Support Boost 1.66.0

### DIFF
--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -702,7 +702,7 @@ class RequestHandler {
 
     check_updated_model_consistent_with_app_links(
         VersionedModelId(model_name, model_version),
-        boost::make_optional<InputType>(input_type));
+        boost::optional<InputType>(input_type));
 
     if (clipper::redis::add_model(redis_connection_, model_id, input_type,
                                   labels, container_name, model_data_path,


### PR DESCRIPTION
New [Boost 1.66.0](http://www.boost.org/users/history/version_1_66_0.html) is release on Dec 18th, 2017. To support it, we need some modifications.
* https://github.com/ucbrise/clipper/commit/45e7ae7e425e6e7d06e31e1430cb59c606493f25 : To resolve an warning message occurred on the configuration step like below, update cmake/FindBoost.cmake from [CMake site](https://github.com/Kitware/CMake/blob/master/Modules/FindBoost.cmake).
```
CMake Warning at cmake/FindBoost.cmake:771 (message):
  Imported targets not available for Boost version 106600
```
* https://github.com/ucbrise/clipper/commit/b207fcd62565dc7fa708f06d5b58ddf8dff3c41c : Fix a build bug like below.
```
[ 80%] Building CXX object src/management/CMakeFiles/management_frontend.dir/src/management_frontend_main.cpp.o
In file included from /Users/user/Workplace/github/withsmilo/clipper/src/management/src/management_frontend_main.cpp:7:
/Users/user/Workplace/github/withsmilo/clipper/src/management/src/management_frontend.hpp:705:9: error: no
      matching function for call to 'make_optional'
        boost::make_optional<InputType>(input_type));
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/include/boost/optional/optional.hpp:1367:56: note: candidate function [with T = clipper::InputType] not
      viable: no known conversion from 'clipper::InputType' to 'clipper::InputType &&' for 1st argument
optional<BOOST_DEDUCED_TYPENAME boost::decay<T>::type> make_optional ( T && v  )
                                                       ^
/usr/local/include/boost/optional/optional.hpp:1375:56: note: candidate function template not viable: requires 2
      arguments, but 1 was provided
optional<BOOST_DEDUCED_TYPENAME boost::decay<T>::type> make_optional ( bool cond, T && v )
                                                       ^
```
