### PR TITLE
Fix port already bound error in integration tests

### DIFF
--- a/bench/bench_init.py
+++ b/bench/bench_init.py
@@ -35,8 +35,8 @@ class BenchSetup():
 
     def get_cifar_data(self):
         train_x, train_y = cifar_utils.filter_data(*cifar_utils.load_cifar(
-            self.cifar_dir_path, cifar_filename="cifar_train.data",
-            norm=False))
+            self.cifar_dir_path, cifar_filename="cifar_train.data", norm=False)
+                                                   )
         test_x, test_y = cifar_utils.filter_data(*cifar_utils.load_cifar(
             self.cifar_dir_path, cifar_filename="cifar_test.data", norm=False))
 

--- a/bench/bench_init.py
+++ b/bench/bench_init.py
@@ -35,8 +35,8 @@ class BenchSetup():
 
     def get_cifar_data(self):
         train_x, train_y = cifar_utils.filter_data(*cifar_utils.load_cifar(
-            self.cifar_dir_path, cifar_filename="cifar_train.data", norm=False)
-                                                   )
+            self.cifar_dir_path, cifar_filename="cifar_train.data",
+            norm=False))
         test_x, test_y = cifar_utils.filter_data(*cifar_utils.load_cifar(
             self.cifar_dir_path, cifar_filename="cifar_test.data", norm=False))
 

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -52,7 +52,7 @@ def find_unbound_port():
         try:
             sock.bind(("127.0.0.1", port))
             # Make sure we clean up after binding
-            sock.shutdown()
+            sock.shutdown(socket.SHUT_RDWR)
             sock.close()
             return port
         except socket.error:

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -32,7 +32,7 @@ class BenchmarkException(Exception):
 
 
 # range of ports where available ports can be found
-PORT_RANGE = [34256, 40000]
+PORT_RANGE = [34256, 50000]
 
 
 def get_docker_client():
@@ -51,9 +51,12 @@ def find_unbound_port():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         try:
             sock.bind(("127.0.0.1", port))
+            # Make sure we clean up after binding
+            sock.shutdown()
+            sock.close()
             return port
         except socket.error:
-            logger.debug(
+            logger.info(
                 "randomly generated port %d is bound. Trying again." % port)
 
 

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -52,7 +52,6 @@ def find_unbound_port():
         try:
             sock.bind(("127.0.0.1", port))
             # Make sure we clean up after binding
-            sock.shutdown(socket.SHUT_RDWR)
             sock.close()
             return port
         except socket.error:

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -52,7 +52,6 @@ def find_unbound_port():
         try:
             sock.bind(("127.0.0.1", port))
             # Make sure we clean up after binding
-            # sock.close()
             del sock
             return port
         except socket.error as e:

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -83,7 +83,8 @@ def create_docker_connection(cleanup=True, start_clipper=True):
                 time.sleep(1)
                 break
             except docker.errors.APIError as e:
-                logging.info("Problem starting Clipper: {}\nTrying again.".format(e))
+                logging.info(
+                    "Problem starting Clipper: {}\nTrying again.".format(e))
                 cl.stop_all()
                 cm = DockerContainerManager(
                     clipper_query_port=find_unbound_port(),

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -52,9 +52,11 @@ def find_unbound_port():
         try:
             sock.bind(("127.0.0.1", port))
             # Make sure we clean up after binding
-            sock.close()
+            # sock.close()
+            del sock
             return port
-        except socket.error:
+        except socket.error as e:
+            logger.info("Socket error: {}".format(e))
             logger.info(
                 "randomly generated port %d is bound. Trying again." % port)
 


### PR DESCRIPTION
I'm still trying to figure out why the unit tests are flaky. I'm hoping this fixes #352. This PR attempts two fixes:
+ Expanding the port range that we randomly generate ports from to reduce the collision probability.
+ To test if a port is bound, we call `socket.bind(PORT_NUM)` in Python and if the bind successfully completes, we know that nothing else is already bound on that port. However, we rely on the socket (that we just bound to) to be closed by the Python socket object going out of scope and being garbage collected. It's possible that that GC doesn't always happen fast enough. This PR explicitly closes the socket before returning the port number.