### PR TITLE
Fix memory management bug with batched predictions

### DIFF
--- a/src/libclipper/src/json_util.cpp
+++ b/src/libclipper/src/json_util.cpp
@@ -519,7 +519,7 @@ void add_json_array(rapidjson::Document& d, const char* key_name,
   rapidjson::Value json_array(rapidjson::kArrayType);
   rapidjson::Document::AllocatorType& allocator = d.GetAllocator();
   for (std::string json_string : values_to_add) {
-    rapidjson::Document json_obj;
+    rapidjson::Document json_obj(&allocator);
     parse_json(json_string, json_obj);
     json_array.PushBack(json_obj, allocator);
   }


### PR DESCRIPTION
* Corrects JSON object construction behavior by ensuring that RapidJSON sub-documents share the allocator of the parent document

* Fixes #371 