### PR TITLE
Added functionality for single input models

### DIFF
--- a/clipper_admin/clipper_admin/container_manager.py
+++ b/clipper_admin/clipper_admin/container_manager.py
@@ -53,7 +53,7 @@ class ContainerManager(object):
         return
 
     @abc.abstractmethod
-    def deploy_model(self, name, version, input_type, image):
+    def deploy_model(self, name, version, input_type, image, batch_mode):
         return
 
     @abc.abstractmethod
@@ -61,7 +61,7 @@ class ContainerManager(object):
         return
 
     @abc.abstractmethod
-    def set_num_replicas(self, name, version, input_type, image, num_replicas):
+    def set_num_replicas(self, name, version, input_type, image, num_replicas, batch_mode):
         return
 
     @abc.abstractmethod

--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -166,7 +166,7 @@ class DockerContainerManager(ContainerManager):
         # No extra connection steps to take on connection
         return
 
-    def deploy_model(self, name, version, input_type, image, num_replicas=1):
+    def deploy_model(self, name, version, input_type, image, num_replicas=1, batch_mode=True):
         # Parameters
         # ----------
         # image : str
@@ -174,7 +174,7 @@ class DockerContainerManager(ContainerManager):
         #     registry, the registry name must be prepended to the image. For example,
         #     "localhost:5000/my_model_name:my_model_version" or
         #     "quay.io/my_namespace/my_model_name:my_model_version"
-        self.set_num_replicas(name, version, input_type, image, num_replicas)
+        self.set_num_replicas(name, version, input_type, image, num_replicas, batch_mode)
 
     def _get_replicas(self, name, version):
         containers = self.docker_client.containers.list(
@@ -189,7 +189,7 @@ class DockerContainerManager(ContainerManager):
     def get_num_replicas(self, name, version):
         return len(self._get_replicas(name, version))
 
-    def _add_replica(self, name, version, input_type, image):
+    def _add_replica(self, name, version, input_type, image, batch_mode):
 
         containers = self.docker_client.containers.list(
             filters={
@@ -207,6 +207,7 @@ class DockerContainerManager(ContainerManager):
             # in same docker network as the query frontend
             "CLIPPER_IP": query_frontend_hostname,
             "CLIPPER_INPUT_TYPE": input_type,
+            "CLIPPER_BATCH_MODE": batch_mode
         }
 
         model_container_label = create_model_container_label(name, version)
@@ -226,7 +227,7 @@ class DockerContainerManager(ContainerManager):
         update_metric_config(model_container_name,
                              CLIPPER_INTERNAL_METRIC_PORT)
 
-    def set_num_replicas(self, name, version, input_type, image, num_replicas):
+    def set_num_replicas(self, name, version, input_type, image, num_replicas, batch_mode):
         current_replicas = self._get_replicas(name, version)
         if len(current_replicas) < num_replicas:
             num_missing = num_replicas - len(current_replicas)
@@ -238,7 +239,7 @@ class DockerContainerManager(ContainerManager):
                     version=version,
                     missing=(num_missing)))
             for _ in range(num_missing):
-                self._add_replica(name, version, input_type, image)
+                self._add_replica(name, version, input_type, image, batch_mode)
         elif len(current_replicas) > num_replicas:
             num_extra = len(current_replicas) - num_replicas
             logger.info(

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -165,7 +165,7 @@ class KubernetesContainerManager(ContainerManager):
                 "Could not connect to Clipper Kubernetes cluster. "
                 "Reason: {}".format(e))
 
-    def deploy_model(self, name, version, input_type, image, num_replicas=1):
+    def deploy_model(self, name, version, input_type, image, num_replicas=1, bacth_mode=True):
         with _pass_conflicts():
             deployment_name = get_model_deployment_name(name, version)
             body = {
@@ -206,6 +206,9 @@ class KubernetesContainerManager(ContainerManager):
                                 }, {
                                     'name': 'CLIPPER_INPUT_TYPE',
                                     'value': input_type
+                                }, {
+                                    'name': 'CLIPPER_BATCH_MODE',
+                                    'value': batch_mode
                                 }]
                             }]
                         }
@@ -222,7 +225,7 @@ class KubernetesContainerManager(ContainerManager):
 
         return response.spec.replicas
 
-    def set_num_replicas(self, name, version, input_type, image, num_replicas):
+    def set_num_replicas(self, name, version, input_type, image, num_replicas, batch_mode):
         # NOTE: assumes `metadata.name` can identify the model deployment.
         deployment_name = get_model_deployment_name(name, version)
 

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -361,15 +361,15 @@ TEST_F(QueryFrontendTest, TestReadModelsAtStartup) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
-                        container_name, model_path, DEFAULT_BATCH_SIZE));
+                        container_name, model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model2 = VersionedModelId("m", "2");
   std::string model_path2 = "/tmp/models/m/2";
   ASSERT_TRUE(add_model(*redis_, model2, InputType::Ints, labels,
-                        container_name, model_path2, DEFAULT_BATCH_SIZE));
+                        container_name, model_path2, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model3 = VersionedModelId("n", "3");
   std::string model_path3 = "/tmp/models/n/3";
   ASSERT_TRUE(add_model(*redis_, model3, InputType::Ints, labels,
-                        container_name, model_path3, DEFAULT_BATCH_SIZE));
+                        container_name, model_path3, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
 
   // Set m@v2 and n@v3 as current model versions
   set_current_model_version(*redis_, "m", "2");
@@ -421,7 +421,7 @@ TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
-                        container_name, model_path, DEFAULT_BATCH_SIZE));
+                        container_name, model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   // Not setting the version number will cause get_current_model_version()
   // to return -1, and the RequestHandler should then throw a runtime_error.
   ASSERT_THROW(RequestHandler<QueryProcessor>("127.0.0.1", 1337, 8),

--- a/src/libclipper/include/clipper/containers.hpp
+++ b/src/libclipper/include/clipper/containers.hpp
@@ -3,6 +3,7 @@
 #define CLIPPER_LIB_CONTAINERS_HPP
 
 constexpr int DEFAULT_BATCH_SIZE = -1;
+constexpr bool DEFAULT_BATCH_MODE = true;
 
 #include <memory>
 #include <unordered_map>

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -120,6 +120,7 @@ boost::optional<std::string> get_current_model_version(
  * \param model_data_path should be the path on the Clipper host
  * \param batch_size should be the user-defined batch size for all replicas of
  * the model. Its default value (-1)
+ * \param batch_mode should be the mode that the model is running in. Its default value is True
  * indicates that the batch size was unspecified and that Clipper should
  * calculate it adaptively.
  * \return Returns true if the add was successful.
@@ -128,7 +129,9 @@ bool add_model(redox::Redox& redis, const VersionedModelId& model_id,
                const InputType& input_type,
                const std::vector<std::string>& labels,
                const std::string& container_name,
-               const std::string& model_data_path, int batch_size);
+               const std::string& model_data_path,
+               int batch_size,
+               bool batch_mode);
 
 /**
  * Deletes a model from the model table if it exists.

--- a/src/libclipper/src/redis.cpp
+++ b/src/libclipper/src/redis.cpp
@@ -231,7 +231,8 @@ std::vector<std::string> get_linked_models(redox::Redox& redis,
 bool add_model(Redox& redis, const VersionedModelId& model_id,
                const InputType& input_type, const std::vector<string>& labels,
                const std::string& container_name,
-               const std::string& model_data_path, int batch_size) {
+               const std::string& model_data_path,
+               int batch_size, bool batch_mode=true) {
   if (send_cmd_no_reply<string>(
           redis, {"SELECT", std::to_string(REDIS_MODEL_DB_NUM)})) {
     std::string model_id_key = gen_versioned_model_key(model_id);
@@ -245,7 +246,8 @@ bool add_model(Redox& redis, const VersionedModelId& model_id,
       "labels",           labels_to_str(labels),
       "container_name",   container_name,
       "model_data_path",  model_data_path,
-      "batch_size", std::to_string(batch_size)};
+      "batch_size", std::to_string(batch_size),
+      "batch_mode", std::to_string(batch_mode)};
     // clang-format on
     return send_cmd_no_reply<string>(redis, cmd_vec);
   } else {

--- a/src/libclipper/test/json_util_test.cpp
+++ b/src/libclipper/test/json_util_test.cpp
@@ -320,7 +320,7 @@ TEST_F(RedisToJsonTest, TestRedisModelMetadataToJson) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model, parse_input_type(input_type), labels,
-                        container_name, model_path, DEFAULT_BATCH_SIZE));
+                        container_name, model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
 
   std::unordered_map<std::string, std::string> model_metadata =
       get_model(*redis_, model);

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -87,12 +87,12 @@ TEST_F(RedisTest, AddModel) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
-                        model_path, DEFAULT_BATCH_SIZE));
+                        model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   auto result = get_model(*redis_, model);
-  // The model table has 8 fields, so we expect
-  // to get back a map with 8 entries in it
+  // The model table has 9 fields, so we expect
+  // to get back a map with 9 entries in it
   // (see add_model() in redis.cpp for details on what the fields are).
-  EXPECT_EQ(result.size(), static_cast<size_t>(8));
+  EXPECT_EQ(result.size(), static_cast<size_t>(9));
   ASSERT_EQ(result["model_name"], model.get_name());
   ASSERT_EQ(result["model_version"], model.get_id());
   ASSERT_FLOAT_EQ(std::stof(result["load"]), 0.0);
@@ -120,9 +120,9 @@ TEST_F(RedisTest, AddModelLinks) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model_1, input_type, labels, container_name,
-                        model_path, DEFAULT_BATCH_SIZE));
+                        model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   ASSERT_TRUE(add_model(*redis_, model_2, input_type, labels, container_name,
-                        model_path, DEFAULT_BATCH_SIZE));
+                        model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
 
   std::vector<std::string> model_names =
       std::vector<std::string>{model_name_1, model_name_2};
@@ -153,15 +153,15 @@ TEST_F(RedisTest, GetModelVersions) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
-                        container_name, model_path, DEFAULT_BATCH_SIZE));
+                        container_name, model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model2 = VersionedModelId("m", "2");
   std::string model_path2 = "/tmp/models/m/2";
   ASSERT_TRUE(add_model(*redis_, model2, InputType::Ints, labels,
-                        container_name, model_path2, DEFAULT_BATCH_SIZE));
+                        container_name, model_path2, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model4 = VersionedModelId("m", "4");
   std::string model_path4 = "/tmp/models/m/4";
   ASSERT_TRUE(add_model(*redis_, model4, InputType::Ints, labels,
-                        container_name, model_path4, DEFAULT_BATCH_SIZE));
+                        container_name, model_path4, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
 
   std::vector<std::string> versions = get_model_versions(*redis_, "m");
   ASSERT_EQ(versions.size(), (size_t)3);
@@ -177,15 +177,15 @@ TEST_F(RedisTest, GetAllModelNames) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
-                        container_name, model_path, DEFAULT_BATCH_SIZE));
+                        container_name, model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model2 = VersionedModelId("m", "2");
   std::string model_path2 = "/tmp/models/m/2";
   ASSERT_TRUE(add_model(*redis_, model2, InputType::Ints, labels,
-                        container_name, model_path2, DEFAULT_BATCH_SIZE));
+                        container_name, model_path2, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model3 = VersionedModelId("n", "3");
   std::string model_path3 = "/tmp/models/n/3";
   ASSERT_TRUE(add_model(*redis_, model3, InputType::Ints, labels,
-                        container_name, model_path3, DEFAULT_BATCH_SIZE));
+                        container_name, model_path3, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
 
   // get_all_model_names() should return the de-duplicated model names
   std::vector<std::string> names = get_all_model_names(*redis_);
@@ -202,15 +202,15 @@ TEST_F(RedisTest, GetAllModels) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model1, InputType::Ints, labels,
-                        container_name, model_path, DEFAULT_BATCH_SIZE));
+                        container_name, model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model2 = VersionedModelId("m", "2");
   std::string model_path2 = "/tmp/models/m/2";
   ASSERT_TRUE(add_model(*redis_, model2, InputType::Ints, labels,
-                        container_name, model_path2, DEFAULT_BATCH_SIZE));
+                        container_name, model_path2, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   VersionedModelId model3 = VersionedModelId("n", "3");
   std::string model_path3 = "/tmp/models/n/3";
   ASSERT_TRUE(add_model(*redis_, model3, InputType::Ints, labels,
-                        container_name, model_path3, DEFAULT_BATCH_SIZE));
+                        container_name, model_path3, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
 
   // get_all_model_names() should return the de-duplicated model names
   std::vector<VersionedModelId> models = get_all_models(*redis_);
@@ -231,9 +231,9 @@ TEST_F(RedisTest, DeleteModel) {
   std::string container_name = "clipper/test_container";
   std::string model_path = "/tmp/models/m/1";
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
-                        model_path, DEFAULT_BATCH_SIZE));
+                        model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   auto add_result = get_model(*redis_, model);
-  EXPECT_EQ(add_result.size(), static_cast<size_t>(8));
+  EXPECT_EQ(add_result.size(), static_cast<size_t>(9));
   ASSERT_TRUE(delete_model(*redis_, model));
   auto delete_result = get_model(*redis_, model);
   EXPECT_EQ(delete_result.size(), static_cast<size_t>(0));
@@ -390,7 +390,7 @@ TEST_F(RedisTest, SubscriptionDetectModelAdd) {
   // give Redis some time to register the subscription
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
-                        model_path, DEFAULT_BATCH_SIZE));
+                        model_path, DEFAULT_BATCH_SIZE, DEFAULT_BATCH_MODE));
   std::unique_lock<std::mutex> l(notification_mutex);
   bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),
                                            [&recv]() { return recv == true; });

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -121,7 +121,8 @@ const std::string ADD_MODEL_JSON_SCHEMA = R"(
    "labels" := [string],
    "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
    "container_name" := string,
-   "model_data_path" := string
+   "model_data_path" := string,
+   "batch_mode" := bool
   }
 )";
 
@@ -652,7 +653,8 @@ class RequestHandler {
    *  "labels" := [string]
    *  "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
    *  "container_name" := string,
-   *  "model_data_path" := string
+   *  "model_data_path" := string,
+   *  "batch_mode" := bool
    * }
    *
    * \return A string describing the operation's success
@@ -671,6 +673,12 @@ class RequestHandler {
     std::string container_name = get_string(d, "container_name");
     std::string model_data_path = get_string(d, "model_data_path");
     int batch_size = get_int(d, "batch_size");
+    try {
+      bool batch_mode = get_bool(d, "batch_mode");
+    }
+    catch(...) {
+      bool batch_mode = true;
+    }
 
     // The batch_size should be either positive or DEFAULT_BATCH_SIZE
     if (batch_size <= 0 && batch_size != DEFAULT_BATCH_SIZE) {
@@ -706,7 +714,7 @@ class RequestHandler {
 
     if (clipper::redis::add_model(redis_connection_, model_id, input_type,
                                   labels, container_name, model_data_path,
-                                  batch_size)) {
+                                  batch_size, batch_mode)) {
       attempt_model_version_update(model_id.get_name(), model_id.get_id());
       std::stringstream ss;
       ss << "Successfully added model with name "

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -75,6 +75,7 @@ class ManagementFrontendTest : public ::testing::Test {
     add_int(d, "batch_size", DEFAULT_BATCH_SIZE);
     add_string(d, "container_name", container_name);
     add_string(d, "model_data_path", model_data_path);
+    add_bool(d, "batch_mode", DEFAULT_BATCH_MODE);
   }
 
   std::string get_add_model_request_json(std::string& model_name,
@@ -441,7 +442,8 @@ TEST_F(ManagementFrontendTest, TestAddModelCorrect) {
     "input_type": "integers",
     "batch_size": -1,
     "container_name": "clipper/sklearn_cifar",
-    "model_data_path": "/tmp/model/repo/m/1"
+    "model_data_path": "/tmp/model/repo/m/1",
+    "batch_mode": true
   }
   )";
 
@@ -476,7 +478,8 @@ TEST_F(ManagementFrontendTest, TestAddLinkedModelCompatibleInputType) {
     "input_type": "integers",
     "batch_size": -1,
     "container_name": "clipper/sklearn_cifar",
-    "model_data_path": "/tmp/model/repo/m/4"
+    "model_data_path": "/tmp/model/repo/m/4",
+    "batch_mode": true
   }
   )";
 
@@ -507,7 +510,8 @@ TEST_F(ManagementFrontendTest, TestAddLinkedModelCompatibleInputType) {
     "input_type": "ints",
     "batch_size": -1,
     "container_name": "clipper/other_container",
-    "model_data_path": "/tmp/model/repo/m/4"
+    "model_data_path": "/tmp/model/repo/m/4",
+    "batch_mode": true
   }
   )";
   ASSERT_NO_THROW(rh_.add_model(add_new_model_json));
@@ -522,7 +526,8 @@ TEST_F(ManagementFrontendTest, TestAddDuplicateModelVersion) {
     "input_type": "integers",
     "batch_size": -1,
     "container_name": "clipper/sklearn_cifar",
-    "model_data_path": "/tmp/model/repo/m/4"
+    "model_data_path": "/tmp/model/repo/m/4",
+    "batch_mode": true
   }
   )";
 
@@ -547,7 +552,8 @@ TEST_F(ManagementFrontendTest, TestAddDuplicateModelVersion) {
     "input_type": "doubles",
     "batch_size": -1,
     "container_name": "clipper/other_container",
-    "model_data_path": "/tmp/model/repo/m/4"
+    "model_data_path": "/tmp/model/repo/m/4",
+    "batch_mode": true
   }
   )";
 


### PR DESCRIPTION
Model containers now have a choice of running in batch mode or single input mode. If single input mode is chosen, the RPC server wraps the input in a for loop to allow for predictions on a single input at a time.

Fixes #285 