### PR TITLE
Fix a bug that QueryFrontend adds a garbage to http response

### DIFF
--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -70,7 +70,7 @@ void respond_http(std::string content, std::string message,
                   std::shared_ptr<HttpServer::Response> response) {
   *response << "HTTP/1.1 " << message << "\r\nContent-Type: application/json"
             << "\r\nContent-Length: " << content.length() << "\r\n\r\n"
-            << content << "\n";
+            << content;
 }
 
 /* Generate a user-facing error message containing the exception


### PR DESCRIPTION
Currently QueryFrontend sends **['http header' + 'content' + '\n']** as a http response to the outer side. Our team found some error cases occurred by wrong value(content.length()) of Content-Length in the 'http header'. To fix it, '\n' must be removed from the http response.