### PR TITLE
Fix installation order errors in deployer containers

### DIFF
--- a/dockerfiles/Caffe2OnnxDockerfile
+++ b/dockerfiles/Caffe2OnnxDockerfile
@@ -5,9 +5,10 @@ COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
 
 RUN echo deb http://ftp.de.debian.org/debian jessie-backports main >> /etc/apt/sources.list \
       && apt-get update --fix-missing \
-      && apt-get install -yqq -t jessie-backports openjdk-8-jdk \
-      && conda install -y --file /lib/python_container_conda_deps.txt \
+      && apt-get install -yqq -t jessie-backports openjdk-8-jdk \ 
+      && conda config --set ssl_verify no \
       && conda install -c anaconda cloudpickle=0.5.2 \
+      && conda install -y --file /lib/python_container_conda_deps.txt \
       && conda install -c conda-forge onnx \
       && conda install -c caffe2 caffe2 \
       && pip install onnx-caffe2 \

--- a/dockerfiles/Caffe2OnnxDockerfile
+++ b/dockerfiles/Caffe2OnnxDockerfile
@@ -5,7 +5,7 @@ COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
 
 RUN echo deb http://ftp.de.debian.org/debian jessie-backports main >> /etc/apt/sources.list \
       && apt-get update --fix-missing \
-      && apt-get install -yqq -t jessie-backports openjdk-8-jdk \ 
+      && apt-get install -yqq -t jessie-backports openjdk-8-jdk \
       && conda config --set ssl_verify no \
       && conda install -c anaconda cloudpickle=0.5.2 \
       && conda install -y --file /lib/python_container_conda_deps.txt \

--- a/dockerfiles/MXNetContainerDockerfile
+++ b/dockerfiles/MXNetContainerDockerfile
@@ -6,12 +6,12 @@ COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
 RUN echo deb http://ftp.de.debian.org/debian jessie-backports main >> /etc/apt/sources.list \
       && apt-get update --fix-missing \
       && apt-get install -yqq -t jessie-backports openjdk-8-jdk \
+      && conda config --set ssl_verify no \
+      && conda install -c anaconda cloudpickle=0.5.2 \
       && conda install -y --file /lib/python_container_conda_deps.txt \
       && pip install mxnet==1.0.0 \
       && apt-get install -y graphviz \
-      && pip install graphviz \
-      && conda install -c anaconda cloudpickle=0.5.2
-
+      && pip install graphviz
 
 COPY containers/python/mxnet_container.py containers/python/mxnet_container_entry.sh /container/
 

--- a/dockerfiles/PySparkContainerDockerfile
+++ b/dockerfiles/PySparkContainerDockerfile
@@ -7,9 +7,9 @@ RUN echo deb http://ftp.de.debian.org/debian jessie-backports main >> /etc/apt/s
       && apt-get update --fix-missing \
       && apt-get install -yqq -t jessie-backports openjdk-8-jdk \
       && conda config --set ssl_verify no \
+      && conda install -c anaconda cloudpickle=0.5.2 \
       && conda install -y --file /lib/python_container_conda_deps.txt \
-      && pip install pyspark \
-      && conda install -c anaconda cloudpickle=0.5.2
+      && pip install pyspark
 
 COPY containers/python/pyspark_container.py containers/python/pyspark_container_entry.sh /container/
 

--- a/dockerfiles/PyTorchContainerDockerfile
+++ b/dockerfiles/PyTorchContainerDockerfile
@@ -7,9 +7,9 @@ RUN echo deb http://ftp.de.debian.org/debian jessie-backports main >> /etc/apt/s
       && apt-get update --fix-missing \
       && apt-get install -yqq -t jessie-backports openjdk-8-jdk \
       && conda config --set ssl_verify no \
+      && conda install -c anaconda cloudpickle=0.5.2 \
       && conda install -y --file /lib/python_container_conda_deps.txt \
-      && conda install pytorch torchvision -c pytorch \
-      && conda install -c anaconda cloudpickle=0.5.2
+      && conda install pytorch torchvision -c pytorch 
 
 
 COPY containers/python/pytorch_container.py containers/python/pytorch_container_entry.sh /container/

--- a/dockerfiles/TensorFlowDockerfile
+++ b/dockerfiles/TensorFlowDockerfile
@@ -3,11 +3,10 @@ FROM clipper/py-rpc:${CODE_VERSION}
 
 COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
 
-RUN conda config --set ssl_verify no \ 
-	&& conda install -y --file /lib/python_container_conda_deps.txt
-
-RUN conda install tensorflow \
-	&& conda install -c anaconda cloudpickle=0.5.2
+RUN conda config --set ssl_verify no \
+	&& conda install -c anaconda cloudpickle=0.5.2 \
+	&& conda install -y --file /lib/python_container_conda_deps.txt \
+	&& conda install tensorflow
 
 COPY containers/python/tf_container.py containers/python/tf_container_entry.sh /container/
 


### PR DESCRIPTION
Installing Cloudpickle after installing function-specific anaconda dependencies often yields an IOError. This seems to be fixed by ensuring that Cloudpickle is installed before all other anaconda dependencies.