### PR TITLE
Upgrade SimpleWebServer to version 2.1.1

### DIFF
--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -304,8 +304,8 @@ class RequestHandler {
 
     auto predict_fn = [this, name, input_type, policy, latency_slo_micros,
                        app_metrics](
-                          std::shared_ptr<HttpServer::Response> response,
-                          std::shared_ptr<HttpServer::Request> request) {
+        std::shared_ptr<HttpServer::Response> response,
+        std::shared_ptr<HttpServer::Request> request) {
       try {
         std::vector<std::string> models = get_linked_models_for_app(name);
         std::vector<VersionedModelId> versioned_models;
@@ -389,8 +389,8 @@ class RequestHandler {
     server_.add_endpoint(predict_endpoint, "POST", predict_fn);
 
     auto update_fn = [this, name, input_type, policy](
-                         std::shared_ptr<HttpServer::Response> response,
-                         std::shared_ptr<HttpServer::Request> request) {
+        std::shared_ptr<HttpServer::Response> response,
+        std::shared_ptr<HttpServer::Request> request) {
       try {
         std::vector<std::string> models = get_linked_models_for_app(name);
         std::vector<VersionedModelId> versioned_models;

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -120,8 +120,8 @@ class AppMetrics {
 template <class QP>
 class RequestHandler {
  public:
-  RequestHandler(std::string address, int portno, int num_threads)
-      : server_(address, portno, num_threads), query_processor_() {
+  RequestHandler(std::string address, int portno)
+      : server_(address, portno), query_processor_() {
     clipper::Config& conf = clipper::get_config();
     while (!redis_connection_.connect(conf.get_redis_address(),
                                       conf.get_redis_port())) {

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -21,15 +21,15 @@
 
 #include <server_http.hpp>
 
-using clipper::Response;
+using clipper::Feedback;
 using clipper::FeedbackAck;
-using clipper::VersionedModelId;
-using clipper::InputType;
+using clipper::FeedbackQuery;
 using clipper::Input;
+using clipper::InputType;
 using clipper::Output;
 using clipper::Query;
-using clipper::Feedback;
-using clipper::FeedbackQuery;
+using clipper::Response;
+using clipper::VersionedModelId;
 using clipper::json::json_parse_error;
 using clipper::json::json_semantic_error;
 using clipper::redis::labels_to_str;
@@ -304,8 +304,8 @@ class RequestHandler {
 
     auto predict_fn = [this, name, input_type, policy, latency_slo_micros,
                        app_metrics](
-        std::shared_ptr<HttpServer::Response> response,
-        std::shared_ptr<HttpServer::Request> request) {
+                          std::shared_ptr<HttpServer::Response> response,
+                          std::shared_ptr<HttpServer::Request> request) {
       try {
         std::vector<std::string> models = get_linked_models_for_app(name);
         std::vector<VersionedModelId> versioned_models;
@@ -389,8 +389,8 @@ class RequestHandler {
     server_.add_endpoint(predict_endpoint, "POST", predict_fn);
 
     auto update_fn = [this, name, input_type, policy](
-        std::shared_ptr<HttpServer::Response> response,
-        std::shared_ptr<HttpServer::Request> request) {
+                         std::shared_ptr<HttpServer::Response> response,
+                         std::shared_ptr<HttpServer::Request> request) {
       try {
         std::vector<std::string> models = get_linked_models_for_app(name);
         std::vector<VersionedModelId> versioned_models;

--- a/src/frontends/src/query_frontend_main.cpp
+++ b/src/frontends/src/query_frontend_main.cpp
@@ -26,6 +26,6 @@ int main(int argc, char* argv[]) {
   conf.ready();
 
   query_frontend::RequestHandler<clipper::QueryProcessor> rh(
-      "0.0.0.0", clipper::QUERY_FRONTEND_PORT, 1);
+      "0.0.0.0", clipper::QUERY_FRONTEND_PORT);
   rh.start_listening();
 }

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -42,7 +42,7 @@ class QueryFrontendTest : public ::testing::Test {
   std::shared_ptr<redox::Subscriber> subscriber_;
 
   QueryFrontendTest()
-      : rh_("0.0.0.0", 1337, 8),
+      : rh_("0.0.0.0", 1337),
         redis_(std::make_shared<redox::Redox>()),
         subscriber_(std::make_shared<redox::Subscriber>()) {
     Config& conf = get_config();
@@ -348,7 +348,7 @@ TEST_F(QueryFrontendTest, TestReadApplicationsAtStartup) {
   ASSERT_TRUE(add_application(*redis_, name2, input_type2, policy2,
                               default_output2, latency_slo_micros2));
 
-  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
+  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337);
   size_t two_apps = rh2_.num_applications();
   EXPECT_EQ(two_apps, (size_t)2);
 }
@@ -377,7 +377,7 @@ TEST_F(QueryFrontendTest, TestReadModelsAtStartup) {
   std::unordered_map<std::string, std::string> expected_models = {{"m", "2"},
                                                                   {"n", "3"}};
 
-  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
+  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337);
   EXPECT_EQ(rh2_.get_current_model_versions(), expected_models);
 }
 
@@ -400,7 +400,7 @@ TEST_F(QueryFrontendTest, TestReadModelLinksAtStartup) {
 
   std::vector<std::string> expected_app1_linked_models = {"m1", "m2", "m3"};
 
-  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337, 8);
+  RequestHandler<MockQueryProcessor> rh2_("127.0.0.1", 1337);
 
   std::vector<std::string> app1_linked_models =
       rh2_.get_linked_models_for_app(app_name_1);
@@ -424,7 +424,7 @@ TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {
                         container_name, model_path, DEFAULT_BATCH_SIZE));
   // Not setting the version number will cause get_current_model_version()
   // to return -1, and the RequestHandler should then throw a runtime_error.
-  ASSERT_THROW(RequestHandler<QueryProcessor>("127.0.0.1", 1337, 8),
+  ASSERT_THROW(RequestHandler<QueryProcessor>("127.0.0.1", 1337),
                std::runtime_error);
 }
 

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -158,8 +158,8 @@ std::string json_error_msg(const std::string& exception_msg,
 
 class RequestHandler {
  public:
-  RequestHandler(int portno, int num_threads)
-      : server_(portno, num_threads), state_db_{} {
+  RequestHandler(int portno)
+      : server_(portno), state_db_{} {
     clipper::Config& conf = clipper::get_config();
     while (!redis_connection_.connect(conf.get_redis_address(),
                                       conf.get_redis_port())) {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -24,11 +24,11 @@
 #include <clipper/util.hpp>
 
 using HttpServer = SimpleWeb::Server<SimpleWeb::HTTP>;
-using clipper::VersionedModelId;
 using clipper::InputType;
+using clipper::VersionedModelId;
+using clipper::json::add_bool;
 using clipper::json::add_string;
 using clipper::json::add_string_array;
-using clipper::json::add_bool;
 using clipper::json::get_bool;
 using clipper::json::get_candidate_models;
 using clipper::json::get_int;
@@ -38,8 +38,8 @@ using clipper::json::json_parse_error;
 using clipper::json::json_semantic_error;
 using clipper::json::parse_json;
 using clipper::json::redis_app_metadata_to_json;
-using clipper::json::redis_model_metadata_to_json;
 using clipper::json::redis_container_metadata_to_json;
+using clipper::json::redis_model_metadata_to_json;
 using clipper::json::set_string_array;
 using clipper::json::to_json_string;
 using clipper::redis::prohibited_group_strings;
@@ -158,8 +158,7 @@ std::string json_error_msg(const std::string& exception_msg,
 
 class RequestHandler {
  public:
-  RequestHandler(int portno)
-      : server_(portno), state_db_{} {
+  RequestHandler(int portno) : server_(portno), state_db_{} {
     clipper::Config& conf = clipper::get_config();
     while (!redis_connection_.connect(conf.get_redis_address(),
                                       conf.get_redis_port())) {

--- a/src/management/src/management_frontend_main.cpp
+++ b/src/management/src/management_frontend_main.cpp
@@ -21,6 +21,6 @@ int main(int argc, char* argv[]) {
   conf.set_redis_address(options["redis_ip"].as<std::string>());
   conf.set_redis_port(options["redis_port"].as<int>());
   conf.ready();
-  management::RequestHandler rh(clipper::MANAGEMENT_FRONTEND_PORT, 1);
+  management::RequestHandler rh(clipper::MANAGEMENT_FRONTEND_PORT);
   rh.start_listening();
 }

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -20,7 +20,7 @@ namespace {
 class ManagementFrontendTest : public ::testing::Test {
  public:
   ManagementFrontendTest()
-      : rh_(MANAGEMENT_FRONTEND_PORT, 1),
+      : rh_(MANAGEMENT_FRONTEND_PORT),
         redis_(std::make_shared<redox::Redox>()),
         subscriber_(std::make_shared<redox::Subscriber>()) {
     Config& conf = get_config();


### PR DESCRIPTION
Currently Clipper uses SimpleWebServer([Oct 25, 2016](https://github.com/eidheim/Simple-Web-Server/tree/8e0d3142bfd3c4932d9c7a9b9fcd517b7a4ec05b)) for http serving.
We need to upgrade this module to resolve some bugs and support keep-alive connection.
So we applied all patches except of some to reach [version 2.1.1 (May 27, 2017)](https://github.com/eidheim/Simple-Web-Server/blob/v2.1.1/server_http.hpp).
Diff between SimpleWebServer v2.1.1(left). and SimpleWebServer(right) in this PR is [here](https://www.diffchecker.com/PI1eJFwo).

* applied patch list
  * Nov 7, 2016: [Fixes #82: wrong reset method called in ::start](https://github.com/eidheim/Simple-Web-Server/commit/8da3ad4ddeed81fef2df3c97f19282ef2345f0be)
  * Nov 10, 2016: [Fixed crash if server instance gets deleted after the call to io_serv](https://github.com/eidheim/Simple-Web-Server/commit/743785b563f2371d9eb6fac971b130872459e777)
  * Nov 23, 2016: [Fixes #86: can now set timeout on client requests](https://github.com/eidheim/Simple-Web-Server/commit/8a73cb381a79d21290522ce0cbf9be3dff78bd48)
  * Nov 23, 2016: [Minor timeout source cleanups](https://github.com/eidheim/Simple-Web-Server/commit/7d95360e628db54016e2703baff73a4deaababbf)
  * Nov 23: 2016: [Simplified Server::parse_request](https://github.com/eidheim/Simple-Web-Server/commit/0d8052dcb9249ffafb18c37a7f5cdc03be4626c9)
  * Dec 4, 2016: [string::substr comparisons replaced by string::compare](https://github.com/eidheim/Simple-Web-Server/commit/14d848be3e6dac558375555ed652b4dc20446413)
  * Dec 13, 2016: [compile clean with gcc 4.6.3](https://github.com/eidheim/Simple-Web-Server/commit/dc74f7739ea044431bf136eaa02069bd5a487489)
  * Dec 19, 2016: [Added client verification when a verify file is passed to Server<HTTP](https://github.com/eidheim/Simple-Web-Server/commit/7a97f8218d585d816960acf57654d79c999913a2)
  * Dec 19, 2016: [Added error reporting through on_error std::function](https://github.com/eidheim/Simple-Web-Server/commit/eef8a108499ba6f27fd578d2cde9d587937fc6b7)
  * Dec 19, 2016: [Minor cleanup](https://github.com/eidheim/Simple-Web-Server/commit/d19244e01f6a494c37a4fb075a13aa0de4d98094)
  * Dec 19, 2016: [Minor cleanup](https://github.com/eidheim/Simple-Web-Server/commit/db95a64354d980d82a1ebddfd0cf90116fe3ba0b)
  * Dec 29, 2016: [Cleanup of server-constructors. Previous constructors have been marked](https://github.com/eidheim/Simple-Web-Server/commit/6c3a59d9bab7b429502523c840de31dfefe96094)
  * Dec 29, 2016: [Bugfix for last commit: config.timeout_content now correctly set in old constructor](https://github.com/eidheim/Simple-Web-Server/commit/175d4dd869607755d890ea4363ac894252560b52#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Dec 30, 2016: [Fixed DEPRECATED macro in cases where it is already defined](https://github.com/eidheim/Simple-Web-Server/commit/8c8ef391f89d87951f5d319cb75d1e327cfcf340#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Dec 31, 2016: [Case insensitive header cleanup. Also cleanup and additions to parse_test](https://github.com/eidheim/Simple-Web-Server/commit/549bc646bb70e60341f0bda9d8be3a61ce04d3fa#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Jan 1, 2017: [Added on_upgrade for cases where one wants to handle connection upgrades](https://github.com/eidheim/Simple-Web-Server/commit/bfcb325472911dcd91a3271459e1ae635ece9e9b#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Jan 11, 2017: [Fixed Boost.Regex workaround in regex_orderable. Fixes #100](https://github.com/eidheim/Simple-Web-Server/commit/19627bbe6bdfc85c627b4f1f038f43ef0f6b704d#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Jan 24, 2017: [Possible implementation for fixing #106](https://github.com/eidheim/Simple-Web-Server/commit/600fbe39b2d3b57accf7ce42c475f1348e397db8#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Jan 24, 2017: [Renamed close_connection_after_send to close_connection_after_response](https://github.com/eidheim/Simple-Web-Server/commit/de560e8b4811369d4608c4c6170378c9bf009a77#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Feb 5, 2017: [Added query string parsing and member to request](https://github.com/eidheim/Simple-Web-Server/commit/a4dd2e64448de2a5468a5ed4ebc2102ee064cc58#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Feb 5, 2017: [Travis CI build failed](https://github.com/eidheim/Simple-Web-Server/commit/d554c13db542a357ec97d68a655cb9b71ea8bbcf#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Feb 14, 2017: [remove locale dependent stof()](https://github.com/eidheim/Simple-Web-Server/commit/50ce7510efe58ffea1e77351c0dc7a32eda5f46a#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * Feb 27, 2017: [If query string is present then cut it from the reqeust path so find](https://github.com/eidheim/Simple-Web-Server/commit/e585a7a5bc9084fd587a2dbdad652dadc14adc39#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * May 6, 2017: [Added support for request header Connection: keep-alive (see #123)](https://github.com/eidheim/Simple-Web-Server/commit/cfafbcbc7d74d91ffd24fd2fbf1a382d52133264#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * May 27, 2017: [Finished query string parsing implementation (PR #109)](https://github.com/eidheim/Simple-Web-Server/commit/550bbfe9d77ce17f22fe978794e942d033491e4d#diff-be05a8666afdaf0bcadd9499d09cf33c)
  * May 27, 2017: [Fixed g++ error in Server::Request::parse_query_string](https://github.com/eidheim/Simple-Web-Server/commit/4469de156b72008f9446dd2cf81297f5b1403cc3#diff-be05a8666afdaf0bcadd9499d09cf33c)

* excluded patch list
  * Jan 2, 2017: [Code simplification: got rid of opt_resource at minimal cost](https://github.com/eidheim/Simple-Web-Server/commit/8cdebfb6122cf9f2c25cda99ccb7adcba0c5c692)
  * Jan 2, 2017: [Added warning to Server::resource](https://github.com/eidheim/Simple-Web-Server/commit/fa8c381a4fff1eca2747b83c6e21209b93eb1f3c)
  * Jan 3, 2017: [Removed unnecessary public](https://github.com/eidheim/Simple-Web-Server/commit/f5e65bf422a414de2ca25d259887d9dbd091dff7)