### PR TITLE
Update RPCDockerfile to fix build error

### DIFF
--- a/dockerfiles/PyClosureContainerDockerfile
+++ b/dockerfiles/PyClosureContainerDockerfile
@@ -3,6 +3,7 @@ FROM clipper/py-rpc:${CODE_VERSION}
 
 COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
 RUN conda config --set ssl_verify no \
+  && conda install -y -n base conda=4.5.0 \
   && conda install -y -c anaconda cloudpickle=0.5.2 \
   && conda install -y --file /lib/python_container_conda_deps.txt
 

--- a/dockerfiles/RPCDockerfile
+++ b/dockerfiles/RPCDockerfile
@@ -7,7 +7,7 @@ MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>
 
 RUN mkdir -p /model \
       && apt-get update \
-      && apt-get install -y libzmq3 libzmq3-dev \
+      && apt-get install -y libzmq5 libzmq3-dev \
       && conda install -y pyzmq \
       && pip install prometheus_client pyyaml
 

--- a/dockerfiles/TensorFlowDockerfile
+++ b/dockerfiles/TensorFlowDockerfile
@@ -4,6 +4,7 @@ FROM clipper/py-rpc:${CODE_VERSION}
 COPY clipper_admin/clipper_admin/python_container_conda_deps.txt /lib/
 
 RUN conda config --set ssl_verify no \
+	&& conda install -y -n base conda=4.5.0 \
 	&& conda install -c anaconda cloudpickle=0.5.2 \
 	&& conda install -y --file /lib/python_container_conda_deps.txt \
 	&& conda install tensorflow


### PR DESCRIPTION
Current RPCDockerfile occurs below build error.
```
Building clipper/py-rpc:931561f from file RPCDockerfile
Sending build context to Docker daemon  306.2MB
Step 1/8 : ARG CODE_VERSION
Step 2/8 : FROM continuumio/anaconda:latest
 ---> 75e6069521b1
Step 3/8 : MAINTAINER Dan Crankshaw <dscrankshaw@gmail.com>
 ---> Using cache
 ---> 071997e8a017
Step 4/8 : RUN mkdir -p /model       && apt-get update       && apt-get install -y libzmq3 libzmq3-dev       && conda install -y pyzmq       && pip install prometheus_client pyyaml
 ---> Running in 7ce683cb9a79
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org stretch/updates InRelease [63.0 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Get:4 http://security.debian.org stretch/updates/main amd64 Packages [455 kB]
Hit:5 http://deb.debian.org/debian stretch Release
Fetched 609 kB in 6s (100 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package libzmq3
The command '/bin/sh -c mkdir -p /model       && apt-get update       && apt-get install -y libzmq3 libzmq3-dev       && conda install -y pyzmq       && pip install prometheus_client pyyaml' returned a non-zero code: 100
```
continuumio/anaconda image based by RPCDockerfile is built on Debian stretch.
For Debian stretch version, zeromq3 does not use libzmq3 but libzmq5. ([link](https://packages.debian.org/source/stretch/zeromq3))