### PR TITLE
Address k8s del_svc api change

### DIFF
--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -8,7 +8,7 @@ from .kubernetes_metric_utils import start_prometheus, CLIPPER_FRONTEND_EXPORTER
 from contextlib import contextmanager
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
-from kubernetes.client import configuration
+from kubernetes.client import configuration, V1DeleteOptions
 import logging
 import json
 import yaml
@@ -357,7 +357,9 @@ class KubernetesContainerManager(ContainerManager):
                     label_selector=CLIPPER_DOCKER_LABEL).items:
                 service_name = service.metadata.name
                 self._k8s_v1.delete_namespaced_service(
-                    namespace='default', name=service_name)
+                    namespace='default',
+                    name=service_name,
+                    body=V1DeleteOptions())
 
             self._k8s_beta.delete_collection_namespaced_deployment(
                 namespace='default', label_selector=CLIPPER_DOCKER_LABEL)

--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -2,7 +2,7 @@ requests==2.18.4
 subprocess32==3.2.7
 pyyaml==3.12
 docker==2.5.1
-kubernetes==3.0.0
+kubernetes==6.0.0
 six==1.10.0
 mock
 prometheus_client

--- a/clipper_admin/setup.py
+++ b/clipper_admin/setup.py
@@ -26,7 +26,7 @@ setup(
     package_data={'clipper_admin': ['*.txt', '*/*.yaml']},
     keywords=['clipper', 'prediction', 'model', 'management'],
     install_requires=[
-        'requests', 'subprocess32', 'pyyaml', 'docker', 'kubernetes',
+        'requests', 'subprocess32', 'pyyaml', 'docker', 'kubernetes>=6.0.0',
         'prometheus_client', 'six', 'cloudpickle>=0.5.2', 'redis', 'enum34',
         'psutil', 'jsonschema'
     ],

--- a/dockerfiles/ClipperDevDockerfile
+++ b/dockerfiles/ClipperDevDockerfile
@@ -66,7 +66,7 @@ RUN set -ex; \
 RUN /var/lib/dpkg/info/ca-certificates-java.postinst configure
 
 RUN pip install cloudpickle==0.5.* pyzmq==17.0.* requests==2.18.* subprocess32==3.2.* scikit-learn==0.19.* \
-  numpy==1.14.* pyyaml==3.12.* docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
+  numpy==1.14.* pyyaml==3.12.* docker==3.1.* kubernetes==6.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
   xgboost==0.7.* jsonschema==2.6.* psutil==5.4.* prometheus_client
 
 # install PyTorch


### PR DESCRIPTION
Fix Kubernetes Container Manager:
```
CHANGELOG (Kubernetes)
delete_namespaced_service() now takes an required body (delete option) parameter. 
Refactor service storage to remove registry wrapper kubernetes/kubernetes#59510
```

Spec:
https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CoreV1Api.md#delete_namespaced_service

Error like 
```
  File "/Users/simonmo/Desktop/clipper/clipper/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py", line 393, in stop_all
    namespace='default', name=service_name)
TypeError: delete_namespaced_service() takes exactly 4 arguments (3 given)
``` 
will now go away. 
