### PR TITLE
Add Grafana image tag to avoid pulling all versions

### DIFF
--- a/examples/monitoring/init_grafana.py
+++ b/examples/monitoring/init_grafana.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
     print("(1/3) Initializing Grafana")
     client = docker.from_env()
     container = client.containers.run(
-        "grafana/grafana", ports={'3000/tcp': 3000}, detach=True)
+        "grafana/grafana:latest", ports={'3000/tcp': 3000}, detach=True)
     print("(2/3) Grafana Initialized")
 
     time.sleep(3)


### PR DESCRIPTION
init_grafana.py doesn't specify a tag which makes scripts waiting so long to pull all version from docker hub. It's a quick fix to avoid this issue to improve experience. 

```
$ python init_grafana.py 
(1/3) Initializing Grafana
```

```
$ docker images
REPOSITORY                         TAG                 IMAGE ID            CREATED             SIZE
...
grafana/grafana                    4.2.0               8c4ef64b4ad1        12 months ago       278 MB
grafana/grafana                    4.2.0-beta1         dc9fb785575d        13 months ago       277 MB
grafana/grafana                    4.1.2               b949fa39c923        13 months ago       275 MB
grafana/grafana                    4.1.1-1484211277    52e1571d4c74        14 months ago       275 MB
grafana/grafana                    4.1.1               c40d2fbacb33        15 months ago       275 MB
grafana/grafana                    4.1.0               b1dab8a767b9        15 months ago       275 MB
grafana/grafana                    4.0.2-1481203731    7154f8abbec6        15 months ago       266 MB
grafana/grafana                    4.1.0-beta1         cb069d796e10        15 months ago       275 MB
grafana/grafana                    4.0.2               757396810071        16 months ago       268 MB
grafana/grafana                    4.0.1-1480694114    45a978dbe148        16 months ago       266 MB
grafana/grafana                    4.0.1               ce9918e85941        16 months ago       266 MB
grafana/grafana                    4.0.0               01aa08d0dd3e        16 months ago       266 MB
grafana/grafana                    4.0.0-beta2         7d09aa8b4071        16 months ago       265 MB
grafana/grafana                    3.1.1-1470047149    894e8da8af2d        16 months ago       261 MB
grafana/grafana                    4.0.0-beta1         d1c4b4e05ebc        17 months ago       267 MB
grafana/grafana                    3.1.1               2e560760b2db        20 months ago       263 MB
grafana/grafana                    3.1.0               932c5bca836b        21 months ago       263 MB
grafana/grafana                    3.1.0-beta1         959add78d4ea        21 months ago       263 MB
grafana/grafana                    3.0.3-1463994644    525dcbf08635        22 months ago       262 MB
grafana/grafana                    3.0.4               436c7c8b0cc0        22 months ago       262 MB
grafana/grafana                    3.0.3               cfd84ee1e816        23 months ago       262 MB
grafana/grafana                    3.0.2               ab442e32cc8b        23 months ago       262 MB
grafana/grafana                    3.0.1               25465fb422f9        23 months ago       262 MB
grafana/grafana                    3.0.0-beta7         7c23bbc8f610        23 months ago       262 MB
grafana/grafana                    3.0.0-beta5         7b678e45b705        24 months ago       262 MB
grafana/grafana                    3.0.0-beta3         733f4ba8fe4c        2 years ago         262 MB
grafana/grafana                    2.6.0               6d7d13093476        2 years ago         214 MB
grafana/grafana                    3.0.0-beta1         bf133de01cb9        2 years ago         278 MB
grafana/grafana                    2.5.0               b61ba0ab2d43        2 years ago         249 MB
grafana/grafana                    2.1.3               c3c2ff89a0b2        2 years ago         192 MB
grafana/grafana                    2.1.1               3e3dc0a2652b        2 years ago         192 MB
grafana/grafana                    2.1.0               f9326d54af48        2 years ago         192 MB
grafana/grafana                    2.0.2               79098c8c98d7        2 years ago         189 MB
grafana/grafana                    2.0.1               ac53632cb86b        2 years ago         189 MB

```