### PR TITLE
Shorten input for kube integration test

### DIFF
--- a/integration-tests/clipper_metric_kube.py
+++ b/integration-tests/clipper_metric_kube.py
@@ -59,7 +59,7 @@ def deploy_model(clipper_conn, name, link=False):
                 "http://%s/%s/predict" % (addr, app_name),
                 headers=headers,
                 data=json.dumps({
-                    'input': list(np.random.random(30))
+                    'input': list([1.2, 1.3])
                 }))
             result = response.json()
             if response.status_code == requests.codes.ok and result["default"]:
@@ -88,7 +88,7 @@ def create_and_test_app(clipper_conn, name):
         "http://%s/%s/predict" % (addr, app_name),
         headers=headers,
         data=json.dumps({
-            'input': list(np.random.random(30))
+            'input': list([1.2, 1.3])
         }))
     response.json()
     if response.status_code != requests.codes.ok:

--- a/integration-tests/kubernetes_integration_test.py
+++ b/integration-tests/kubernetes_integration_test.py
@@ -55,7 +55,7 @@ def deploy_model(clipper_conn, name, version, link=False):
                     "http://%s/%s/predict" % (addr, app_name),
                     headers=headers,
                     data=json.dumps({
-                        'input': list(np.random.random(30))
+                        'input': list([1.2, 1.3])
                     }))
                 result = response.json()
                 if response.status_code == requests.codes.ok and result["default"]:
@@ -86,7 +86,7 @@ def create_and_test_app(clipper_conn, name, num_models):
         "http://%s/%s/predict" % (addr, app_name),
         headers=headers,
         data=json.dumps({
-            'input': list(np.random.random(30))
+            'input': list([1.2, 1.3])
         }))
     response.json()
     if response.status_code != requests.codes.ok:


### PR DESCRIPTION
Instead of predicting `np.random.random(30)` we just predict `[1.2, 1.3]` saves time for parsing and avoid default predictions to get returned due to slo. 