### PR TITLE
Issue with Number of Frontend Replicas

### DIFF
--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -228,7 +228,6 @@ class KubernetesContainerManager(ContainerManager):
                 elif p.name == "7000":
                     self.clipper_rpc_port = p.node_port
 
-            # NOTE: status of the front end deployments not considered 
             query_frontend_deployments = self._k8s_beta.list_namespaced_deployment(
                 namespace="default",
                 label_selector=CLIPPER_QUERY_FRONTEND_DEPLOYMENT_LABEL).items

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -17,6 +17,8 @@ import yaml
 import os
 import time
 
+CLIPPER_QUERY_FRONTEND_DEPLOYMENT_LABEL = "ai.clipper.name=query-frontend"
+
 logger = logging.getLogger(__name__)
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -225,6 +227,11 @@ class KubernetesContainerManager(ContainerManager):
                         self.clipper_query_port))
                 elif p.name == "7000":
                     self.clipper_rpc_port = p.node_port
+
+            query_frontend_deployments = self._k8s_beta.list_namespaced_deployment(
+                namespace="default",
+                label_selector=CLIPPER_QUERY_FRONTEND_DEPLOYMENT_LABEL).items
+            self.num_frontend_replicas = len(query_frontend_deployments)
 
             metrics_ports = self._k8s_v1.read_namespaced_service(
                 name="metrics", namespace='default').spec.ports

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -17,6 +17,8 @@ import yaml
 import os
 import time
 
+CLIPPER_QUERY_FRONTEND_DEPLOYMENT_LABEL = "ai.clipper.name=query-frontend"
+
 logger = logging.getLogger(__name__)
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -225,6 +227,10 @@ class KubernetesContainerManager(ContainerManager):
                         self.clipper_query_port))
                 elif p.name == "7000":
                     self.clipper_rpc_port = p.node_port
+
+            query_frontend_deployments = self._k8s_beta.list_namespaced_deployment(
+                namespace="default", label_selector=CLIPPER_QUERY_FRONTEND_DEPLOYMENT_LABEL).items
+            self.num_frontend_replicas = len(query_frontend_deployments)
 
             metrics_ports = self._k8s_v1.read_namespaced_service(
                 name="metrics", namespace='default').spec.ports

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -228,6 +228,7 @@ class KubernetesContainerManager(ContainerManager):
                 elif p.name == "7000":
                     self.clipper_rpc_port = p.node_port
 
+            # NOTE: status of the front end deployments not considered 
             query_frontend_deployments = self._k8s_beta.list_namespaced_deployment(
                 namespace="default",
                 label_selector=CLIPPER_QUERY_FRONTEND_DEPLOYMENT_LABEL).items


### PR DESCRIPTION
The number of frontend replicas is not known if we call the KubernetesContainerManager connect method directly. 
The attribute self.num_frontend_replicas would not be defined . Hence a subsequent call to deploy would fail.

This needs to be fetched during connect and set. Since each front end creates an underlying deployment, the only way i could think of was to read and filter the deployments with the label ai.clipper.name=query-frontend.
