### PR TITLE
Fix the following build error of rpc_service.cpp

### DIFF
--- a/src/libclipper/src/rpc_service.cpp
+++ b/src/libclipper/src/rpc_service.cpp
@@ -3,6 +3,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <numeric>
 
 #include <concurrentqueue.h>
 #include <clipper/config.hpp>


### PR DESCRIPTION
```
/src/libclipper/src/rpc_service.cpp:389:16: error: no member named 'accumulate' in namespace 'std'
          std::accumulate(output_header, output_header + num_outputs, 0));
          ~~~~~^
1 error generated.
```