### PR TITLE
Move reading of Clipper env variables out of user code into RPC system code

### DIFF
--- a/containers/python/caffe2_onnx_container.py
+++ b/containers/python/caffe2_onnx_container.py
@@ -68,7 +68,8 @@ if __name__ == "__main__":
     print("Starting Caffe2Container container")
     rpc_service = rpc.RPCService()
     try:
-        model = Caffe2Container(rpc_service.get_model_path(), rpc_service.get_input_type())
+        model = Caffe2Container(rpc_service.get_model_path(),
+                                rpc_service.get_input_type())
         sys.stdout.flush()
         sys.stderr.flush()
     except ImportError:

--- a/containers/python/caffe2_onnx_container.py
+++ b/containers/python/caffe2_onnx_container.py
@@ -66,50 +66,11 @@ class Caffe2Container(rpc.ModelContainerBase):
 
 if __name__ == "__main__":
     print("Starting Caffe2Container container")
+    rpc_service = rpc.RPCService()
     try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: {port}".format(
-            port=port))
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-
-    model_path = os.environ["CLIPPER_MODEL_PATH"]
-
-    print("Initializing Caffe2 ONNX container")
-    sys.stdout.flush()
-    sys.stderr.flush()
-
-    try:
-        model = Caffe2Container(model_path, input_type)
-        rpc_service = rpc.RPCService()
-        rpc_service.start(model, ip, port, model_name, model_version,
-                          input_type)
+        model = Caffe2Container(rpc_service.get_model_path(), rpc_service.get_input_type())
+        sys.stdout.flush()
+        sys.stderr.flush()
     except ImportError:
         sys.exit(IMPORT_ERROR_RETURN_CODE)
+    rpc_service.start(model)

--- a/containers/python/mxnet_container.py
+++ b/containers/python/mxnet_container.py
@@ -74,7 +74,8 @@ if __name__ == "__main__":
     print("Starting MXNetContainer container")
     rpc_service = rpc.RPCService()
     try:
-        model = MXNetContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        model = MXNetContainer(rpc_service.get_model_path(),
+                               rpc_service.get_input_type())
         sys.stdout.flush()
         sys.stderr.flush()
     except ImportError:

--- a/containers/python/mxnet_container.py
+++ b/containers/python/mxnet_container.py
@@ -72,50 +72,11 @@ class MXNetContainer(rpc.ModelContainerBase):
 
 if __name__ == "__main__":
     print("Starting MXNetContainer container")
+    rpc_service = rpc.RPCService()
     try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: {port}".format(
-            port=port))
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-
-    model_path = os.environ["CLIPPER_MODEL_PATH"]
-
-    print("Initializing MXNet function container")
-    sys.stdout.flush()
-    sys.stderr.flush()
-
-    try:
-        model = MXNetContainer(model_path, input_type)
-        rpc_service = rpc.RPCService()
-        rpc_service.start(model, ip, port, model_name, model_version,
-                          input_type)
+        model = MXNetContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        sys.stdout.flush()
+        sys.stderr.flush()
     except ImportError:
         sys.exit(IMPORT_ERROR_RETURN_CODE)
+    rpc_service.start(model)

--- a/containers/python/noop_container.py
+++ b/containers/python/noop_container.py
@@ -29,38 +29,9 @@ class NoopContainer(rpc.ModelContainerBase):
 
 
 if __name__ == "__main__":
-    try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: 7000")
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-    model = NoopContainer()
+    print("Starting No-Op container")
     rpc_service = rpc.RPCService()
-    rpc_service.start(model, ip, port, model_name, model_version, input_type)
+    model = NoopContainer()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    rpc_service.start(model)

--- a/containers/python/pyspark_container.py
+++ b/containers/python/pyspark_container.py
@@ -85,7 +85,8 @@ if __name__ == "__main__":
     print("Starting PySparkContainer container")
     rpc_service = rpc.RPCService()
     try:
-        model = PySparkContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        model = PySparkContainer(rpc_service.get_model_path(),
+                                 rpc_service.get_input_type())
         sys.stdout.flush()
         sys.stderr.flush()
     except ImportError:

--- a/containers/python/pyspark_container.py
+++ b/containers/python/pyspark_container.py
@@ -7,8 +7,6 @@ import json
 import numpy as np
 import cloudpickle
 
-# sys.path.append(os.path.abspath("/lib/"))
-
 import pyspark
 from pyspark import SparkConf, SparkContext
 from pyspark.sql import SparkSession
@@ -85,51 +83,11 @@ class PySparkContainer(rpc.ModelContainerBase):
 
 if __name__ == "__main__":
     print("Starting PySparkContainer container")
+    rpc_service = rpc.RPCService()
     try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: {port}".format(
-            port=port))
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-
-    model_path = os.environ["CLIPPER_MODEL_PATH"]
-    print(model_path)
-
-    print("Initializing PySpark function container")
-    sys.stdout.flush()
-    sys.stderr.flush()
-
-    try:
-        model = PySparkContainer(model_path, input_type)
-        rpc_service = rpc.RPCService()
-        rpc_service.start(model, ip, port, model_name, model_version,
-                          input_type)
+        model = PySparkContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        sys.stdout.flush()
+        sys.stderr.flush()
     except ImportError:
         sys.exit(IMPORT_ERROR_RETURN_CODE)
+    rpc_service.start(model)

--- a/containers/python/python_closure_container.py
+++ b/containers/python/python_closure_container.py
@@ -50,51 +50,11 @@ class PythonContainer(rpc.ModelContainerBase):
 
 if __name__ == "__main__":
     print("Starting Python Closure container")
+    rpc_service = rpc.RPCService()
     try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: {port}".format(
-            port=port))
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-
-    model_path = os.environ["CLIPPER_MODEL_PATH"]
-
-    print("Initializing Python function container")
-    sys.stdout.flush()
-    sys.stderr.flush()
-
-    try:
-        model = PythonContainer(model_path, input_type)
-        rpc_service = rpc.RPCService()
-        rpc_service.start(model, ip, port, model_name, model_version,
-                          input_type)
-    except ImportError as e:
-        print(e)
+        model = PythonContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except ImportError:
         sys.exit(IMPORT_ERROR_RETURN_CODE)
+    rpc_service.start(model)

--- a/containers/python/python_closure_container.py
+++ b/containers/python/python_closure_container.py
@@ -52,7 +52,8 @@ if __name__ == "__main__":
     print("Starting Python Closure container")
     rpc_service = rpc.RPCService()
     try:
-        model = PythonContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        model = PythonContainer(rpc_service.get_model_path(),
+                                rpc_service.get_input_type())
         sys.stdout.flush()
         sys.stderr.flush()
     except ImportError:

--- a/containers/python/pytorch_container.py
+++ b/containers/python/pytorch_container.py
@@ -70,7 +70,8 @@ if __name__ == "__main__":
     print("Starting PyTorchContainer container")
     rpc_service = rpc.RPCService()
     try:
-        model = PyTorchContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        model = PyTorchContainer(rpc_service.get_model_path(),
+                                 rpc_service.get_input_type())
         sys.stdout.flush()
         sys.stderr.flush()
     except ImportError:

--- a/containers/python/pytorch_container.py
+++ b/containers/python/pytorch_container.py
@@ -68,50 +68,11 @@ class PyTorchContainer(rpc.ModelContainerBase):
 
 if __name__ == "__main__":
     print("Starting PyTorchContainer container")
+    rpc_service = rpc.RPCService()
     try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: {port}".format(
-            port=port))
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-
-    model_path = os.environ["CLIPPER_MODEL_PATH"]
-
-    print("Initializing Pytorch function container")
-    sys.stdout.flush()
-    sys.stderr.flush()
-
-    try:
-        model = PyTorchContainer(model_path, input_type)
-        rpc_service = rpc.RPCService()
-        rpc_service.start(model, ip, port, model_name, model_version,
-                          input_type)
+        model = PyTorchContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        sys.stdout.flush()
+        sys.stderr.flush()
     except ImportError:
         sys.exit(IMPORT_ERROR_RETURN_CODE)
+    rpc_service.start(model)

--- a/containers/python/rpc.py
+++ b/containers/python/rpc.py
@@ -710,10 +710,9 @@ class RPCService:
             sys.exit(1)
         context = zmq.Context()
         self.server = Server(context, ip, self.port)
-        model_input_type = string_to_input_type(self.input_type)
         self.server.model_name = self.model_name
         self.server.model_version = self.model_version
-        self.server.model_input_type = self.input_type
+        self.server.model_input_type = string_to_input_type(self.input_type)
         self.server.model = model
 
         # Create a file named model_is_ready.check to show that model and container

--- a/containers/python/rpc.py
+++ b/containers/python/rpc.py
@@ -642,8 +642,53 @@ class ModelContainerBase(object):
 
 
 class RPCService:
-    def __init__(self, collect_metrics=True):
+    def __init__(self, collect_metrics=True, read_config=True):
         self.collect_metrics = collect_metrics
+        if read_config:
+            self._read_config_from_environment()
+
+    def _read_config_from_environment(self):
+        try:
+            self.model_name = os.environ["CLIPPER_MODEL_NAME"]
+        except KeyError:
+            print(
+                "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
+                file=sys.stdout)
+            sys.exit(1)
+        try:
+            self.model_version = os.environ["CLIPPER_MODEL_VERSION"]
+        except KeyError:
+            print(
+                "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
+                file=sys.stdout)
+            sys.exit(1)
+
+        self.host = "127.0.0.1"
+        if "CLIPPER_IP" in os.environ:
+            self.host = os.environ["CLIPPER_IP"]
+        else:
+            print("Connecting to Clipper on localhost")
+
+        self.port = 7000
+        if "CLIPPER_PORT" in os.environ:
+            self.port = int(os.environ["CLIPPER_PORT"])
+        else:
+            print("Connecting to Clipper with default port: {port}".format(
+                port=self.port))
+
+        self.input_type = "doubles"
+        if "CLIPPER_INPUT_TYPE" in os.environ:
+            self.input_type = os.environ["CLIPPER_INPUT_TYPE"]
+        else:
+            print("Using default input type: doubles")
+
+        self.model_path = os.environ["CLIPPER_MODEL_PATH"]
+
+    def get_model_path(self):
+        return self.model_path
+
+    def get_input_type(self):
+        return self.input_type
 
     def get_event_history(self):
         if self.server:
@@ -652,28 +697,23 @@ class RPCService:
             print("Cannot retrieve message history for inactive RPC service!")
             raise
 
-    def start(self, model, host, port, model_name, model_version, input_type):
+    def start(self, model):
         """
         Args:
             model (object): The loaded model object ready to make predictions.
-            host (str): The Clipper RPC hostname or IP address.
-            port (int): The Clipper RPC port.
-            model_name (str): The name of the model.
-            model_version (int): The version of the model
-            input_type (str): One of ints, doubles, floats, bytes, strings.
         """
 
         try:
-            ip = socket.gethostbyname(host)
+            ip = socket.gethostbyname(self.host)
         except socket.error as e:
-            print("Error resolving %s: %s" % (host, e))
+            print("Error resolving %s: %s" % (self.host, e))
             sys.exit(1)
         context = zmq.Context()
-        self.server = Server(context, ip, port)
-        model_input_type = string_to_input_type(input_type)
-        self.server.model_name = model_name
-        self.server.model_version = model_version
-        self.server.model_input_type = model_input_type
+        self.server = Server(context, ip, self.port)
+        model_input_type = string_to_input_type(self.input_type)
+        self.server.model_name = self.model_name
+        self.server.model_version = self.model_version
+        self.server.model_input_type = self.input_type
         self.server.model = model
 
         # Create a file named model_is_ready.check to show that model and container

--- a/containers/python/rpc_test_container.py
+++ b/containers/python/rpc_test_container.py
@@ -31,10 +31,15 @@ class RPCTestContainer(rpc.ModelContainerBase):
 if __name__ == "__main__":
     ip = "127.0.0.1"
     port = 7000
-    model_name = "rpctest_py"
     input_type = "doubles"
     model_version = 1
 
-    rpc_service = rpc.RPCService(collect_metrics=False)
+    rpc_service = rpc.RPCService(collect_metrics=False, read_config=False)
+    rpc_service.model_name = "rpctest_py"
+    rpc_service.model_version = 1
+    rpc_service.host = "127.0.0.1"
+    rpc_service.port = 7000
+    rpc_service.input_type = "doubles"
+
     model = RPCTestContainer(rpc_service)
-    rpc_service.start(model, ip, port, model_name, model_version, input_type)
+    rpc_service.start(model)

--- a/containers/python/sum_container.py
+++ b/containers/python/sum_container.py
@@ -26,38 +26,6 @@ class SumContainer(rpc.ModelContainerBase):
 
 
 if __name__ == "__main__":
-    try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: 7000")
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-    model = SumContainer()
     rpc_service = rpc.RPCService()
-    rpc_service.start(model, ip, port, model_name, model_version, input_type)
+    model = SumContainer()
+    rpc_service.start(model)

--- a/containers/python/tf_container.py
+++ b/containers/python/tf_container.py
@@ -10,6 +10,7 @@ from tensorflow.python.saved_model import loader
 
 IMPORT_ERROR_RETURN_CODE = 3
 
+
 def load_predict_func(file_path):
     with open(file_path, 'r') as serialized_func_file:
         return cloudpickle.load(serialized_func_file)
@@ -70,7 +71,8 @@ if __name__ == "__main__":
     print("Starting TensorFlow container")
     rpc_service = rpc.RPCService()
     try:
-        model = TfContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        model = TfContainer(rpc_service.get_model_path(),
+                            rpc_service.get_input_type())
         sys.stdout.flush()
         sys.stderr.flush()
     except ImportError:

--- a/containers/python/tf_container.py
+++ b/containers/python/tf_container.py
@@ -8,6 +8,7 @@ import glob
 
 from tensorflow.python.saved_model import loader
 
+IMPORT_ERROR_RETURN_CODE = 3
 
 def load_predict_func(file_path):
     with open(file_path, 'r') as serialized_func_file:
@@ -67,44 +68,11 @@ class TfContainer(rpc.ModelContainerBase):
 
 if __name__ == "__main__":
     print("Starting TensorFlow container")
-    try:
-        model_name = os.environ["CLIPPER_MODEL_NAME"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_NAME environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-    try:
-        model_version = os.environ["CLIPPER_MODEL_VERSION"]
-    except KeyError:
-        print(
-            "ERROR: CLIPPER_MODEL_VERSION environment variable must be set",
-            file=sys.stdout)
-        sys.exit(1)
-
-    ip = "127.0.0.1"
-    if "CLIPPER_IP" in os.environ:
-        ip = os.environ["CLIPPER_IP"]
-    else:
-        print("Connecting to Clipper on localhost")
-
-    port = 7000
-    if "CLIPPER_PORT" in os.environ:
-        port = int(os.environ["CLIPPER_PORT"])
-    else:
-        print("Connecting to Clipper with default port: 7000")
-
-    input_type = "doubles"
-    if "CLIPPER_INPUT_TYPE" in os.environ:
-        input_type = os.environ["CLIPPER_INPUT_TYPE"]
-    else:
-        print("Using default input type: doubles")
-
-    model_dir_path = os.environ["CLIPPER_MODEL_PATH"]
-    model_files = os.listdir(model_dir_path)
-    assert len(model_files) >= 2
-    fname = os.path.splitext(model_files[0])[0]
-    full_fname = os.path.join(model_dir_path, fname)
-    model = TfContainer(model_dir_path, input_type)
     rpc_service = rpc.RPCService()
-    rpc_service.start(model, ip, port, model_name, model_version, input_type)
+    try:
+        model = TfContainer(rpc_service.get_model_path(), rpc_service.get_input_type())
+        sys.stdout.flush()
+        sys.stderr.flush()
+    except ImportError:
+        sys.exit(IMPORT_ERROR_RETURN_CODE)
+    rpc_service.start(model)


### PR DESCRIPTION
This removes code duplication and makes it a little simpler to write your own Clipper model container.