### PR TITLE
Revert namespace in build_docker_images.sh

### DIFF
--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -189,7 +189,12 @@ set_version_tag () {
 
 set_version_tag
 
-namespace="clipper"
+if [[ $OSTYPE == darwin* ]]
+then
+    namespace="clipper"
+else
+    namespace=$(docker info | grep Username | awk '{ print $2 }')
+fi;
 
 # Clear clipper_docker_images.txt for future write
 rm -f $CLIPPER_ROOT/bin/clipper_docker_images.txt

--- a/bin/build_docker_images.sh
+++ b/bin/build_docker_images.sh
@@ -189,7 +189,7 @@ set_version_tag () {
 
 set_version_tag
 
-namespace=$(docker info | grep Username | awk '{ print $2 }')
+namespace="clipper"
 
 # Clear clipper_docker_images.txt for future write
 rm -f $CLIPPER_ROOT/bin/clipper_docker_images.txt

--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -854,7 +854,7 @@ class ClipperConnection(object):
         -------
         list
             Returns a list of the names of models linked to the app.
-            If no models are linked to the specified app, None is returned.
+            If no models are linked to the specified app, empty list is returned.
 
         Raises
         ------


### PR DESCRIPTION
`docker info` no longer shows username information for the DockerHub Registry. So 'namespace' must be reverted to build Clipper images.