### PR TITLE
Replace 'default' of 'use_default' as a kind of the prediction response key

### DIFF
--- a/containers/R/rclipper_user/vignettes/Rclipper.Rmd
+++ b/containers/R/rclipper_user/vignettes/Rclipper.Rmd
@@ -145,6 +145,6 @@ $ curl -X POST --header "Content-Type:application/json" -d '{"input": [1,2,3,4]}
 ```
 
 ```
-$ {"query_id":2,"output":4,"default":false}
+$ {"query_id":2,"output":4,"use_default":false}
 ```
 

--- a/containers/R/rclipper_user/vignettes/Rclipper.md
+++ b/containers/R/rclipper_user/vignettes/Rclipper.md
@@ -224,4 +224,4 @@ from the command line with [cURL](https://github.com/curl/curl):
 
     $ curl -X POST --header "Content-Type:application/json" -d '{"input": [1,2,3,4]}' 127.0.0.1:1337/app1/predict
 
-    $ {"query_id":2,"output":4,"default":false}
+    $ {"query_id":2,"output":4,"use_default":false}

--- a/containers/R/rclipper_user/vignettes/Rclipper.rst
+++ b/containers/R/rclipper_user/vignettes/Rclipper.rst
@@ -636,4 +636,4 @@ from the command line with `cURL <https://github.com/curl/curl>`__:
 
     $ curl -X POST --header "Content-Type:application/json" -d '{"input": [1,2,3,4]}' 127.0.0.1:1337/app1/predict
 
-    $ {"query_id":2,"output":4,"default":false}
+    $ {"query_id":2,"output":4,"use_default":false}

--- a/examples/image_query/example.ipynb
+++ b/examples/image_query/example.ipynb
@@ -320,7 +320,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'query_id': 0, 'output': '(749, 600)', 'default': False}\n"
+      "{'query_id': 0, 'output': '(749, 600)', 'use_default': False}\n"
      ]
     }
    ],
@@ -474,7 +474,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'query_id': 1, 'output': '(749, 600)', 'default': False}\n"
+      "{'query_id': 1, 'output': '(749, 600)', 'use_use_default': False}\n"
      ]
     }
    ],
@@ -491,7 +491,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'query_id': 2, 'output': '(749, 600)', 'default': False}\n"
+      "{'query_id': 2, 'output': '(749, 600)', 'use_default': False}\n"
      ]
     }
    ],

--- a/examples/image_query/example.md
+++ b/examples/image_query/example.md
@@ -197,7 +197,7 @@ python_deployer.create_endpoint(
 query(clipper_conn.get_query_addr(), 'imgs/clipper-logo.png')
 ```
 
-    {'query_id': 0, 'output': '(749, 600)', 'default': False}
+    {'query_id': 0, 'output': '(749, 600)', 'use_default': False}
 
 
 ## Using input_type = "strings"
@@ -315,7 +315,7 @@ python_deployer.create_endpoint(
 query_json(clipper_conn.get_query_addr(), 'imgs/clipper-logo.jpg', 'jpg')
 ```
 
-    {'query_id': 1, 'output': '(749, 600)', 'default': False}
+    {'query_id': 1, 'output': '(749, 600)', 'use_default': False}
 
 
 
@@ -323,7 +323,7 @@ query_json(clipper_conn.get_query_addr(), 'imgs/clipper-logo.jpg', 'jpg')
 query_json(clipper_conn.get_query_addr(), 'imgs/clipper-logo.png', 'png')
 ```
 
-    {'query_id': 2, 'output': '(749, 600)', 'default': False}
+    {'query_id': 2, 'output': '(749, 600)', 'use_default': False}
 
 
 ## Shutdown Clipper

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -472,7 +472,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
 
         self.clipper_conn.link_model_to_app(app_name, model_name)
 
-        time.sleep(30)
+        time.sleep(60)
 
         deploy_python_closure(
             self.clipper_conn,
@@ -481,7 +481,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             input_type="doubles",
             func=predict_func2)
 
-        time.sleep(60)
+        time.sleep(120)
 
         addr = self.clipper_conn.get_query_addr()
         url = "http://{addr}/{app}/predict".format(addr=addr, app=app_name)
@@ -498,7 +498,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             }))
         try:
             pred1 = pred1_raw.json()
-            self.assertFalse(pred1["default"])
+            self.assertFalse(pred1["use_default"])
             self.assertEqual(pred1['output'], 1)
         except ValueError:
             logger.error(pred1_raw.text)
@@ -511,7 +511,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         try:
             pred2 = pred2_raw.json()
 
-            self.assertFalse(pred2["default"])
+            self.assertFalse(pred2["use_default"])
             self.assertEqual(pred2['output'], 2)
         except ValueError:
             logger.error(pred2_raw.text)
@@ -627,7 +627,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         parsed_response = response.json()
         logger.info(parsed_response)
         self.assertEqual(parsed_response["output"], self.default_output)
-        self.assertTrue(parsed_response["default"])
+        self.assertTrue(parsed_response["use_default"])
 
     def test_deployed_model_queried_successfully(self):
         model_version = 1
@@ -649,7 +649,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         parsed_response = response.json()
         logger.info(parsed_response)
         self.assertNotEqual(parsed_response["output"], self.default_output)
-        self.assertFalse(parsed_response["default"])
+        self.assertFalse(parsed_response["use_default"])
 
     def test_batch_queries_returned_successfully(self):
         model_version = 1
@@ -764,7 +764,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         self.assertEqual(len(containers), 2)
 
         self.clipper_conn.link_model_to_app(self.app_name_5, self.model_name_5)
-        time.sleep(30)
+        time.sleep(60)
 
         # We now have 2 replicas running, both the same model name and Version
         # send predictions, assert that we are getting correct response
@@ -780,7 +780,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
                 data=req_json)
             result = response.json()
             self.assertEqual(response.status_code, requests.codes.ok)
-            self.assertEqual(result["default"], False)
+            self.assertEqual(result["use_default"], False)
 
         # one of the containers should go inactive
 
@@ -803,7 +803,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
                 data=req_json)
             result = response.json()
             self.assertEqual(response.status_code, requests.codes.ok)
-            self.assertEqual(result["default"], False)
+            self.assertEqual(result["use_default"], False)
 
         #2nd container should go inactive
         self.clipper_conn.set_num_replicas(
@@ -824,7 +824,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
                 headers=headers,
                 data=req_json)
             result = response.json()
-            self.assertEqual(result["default"], True)
+            self.assertEqual(result["use_default"], True)
             self.assertEqual(result["default_explanation"],
                              "No connected models found for query")
 

--- a/integration-tests/clipper_metric_kube.py
+++ b/integration-tests/clipper_metric_kube.py
@@ -62,7 +62,7 @@ def deploy_model(clipper_conn, name, link=False):
                     'input': list([1.2, 1.3])
                 }))
             result = response.json()
-            if response.status_code == requests.codes.ok and result["default"]:
+            if response.status_code == requests.codes.ok and result["use_default"]:
                 num_defaults += 1
         if num_defaults > 0:
             logger.error("Error: %d/%d predictions were default" %

--- a/integration-tests/deploy_mxnet_models.py
+++ b/integration-tests/deploy_mxnet_models.py
@@ -75,7 +75,7 @@ def test_model(clipper_conn, app, version):
                 'input': get_test_point()
             }))
         result = response.json()
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             print(result)

--- a/integration-tests/deploy_pyspark_models.py
+++ b/integration-tests/deploy_pyspark_models.py
@@ -85,7 +85,7 @@ def test_model(clipper_conn, app, version):
                 'input': get_test_point()
             }))
         result = response.json()
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             print(result)

--- a/integration-tests/deploy_pyspark_pipeline_models.py
+++ b/integration-tests/deploy_pyspark_pipeline_models.py
@@ -134,7 +134,7 @@ def run_test():
                         json.dumps((np.random.randint(1000), "spark abcd"))
                     }))
                 result = response.json()
-                if response.status_code == requests.codes.ok and result["default"]:
+                if response.status_code == requests.codes.ok and result["use_default"]:
                     num_defaults += 1
             if num_defaults > 0:
                 print("Error: %d/%d predictions were default" % (num_defaults,
@@ -159,7 +159,7 @@ def run_test():
                         json.dumps((np.random.randint(1000), "spark abcd"))
                     }))
                 result = response.json()
-                if response.status_code == requests.codes.ok and result["default"]:
+                if response.status_code == requests.codes.ok and result["use_default"]:
                     num_defaults += 1
             if num_defaults > 0:
                 print("Error: %d/%d predictions were default" % (num_defaults,

--- a/integration-tests/deploy_pyspark_sparkml_models.py
+++ b/integration-tests/deploy_pyspark_sparkml_models.py
@@ -87,7 +87,7 @@ def test_model(clipper_conn, app, version):
             }))
         result = response.json()
         print(result)
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             print(result)

--- a/integration-tests/deploy_pytorch_models.py
+++ b/integration-tests/deploy_pytorch_models.py
@@ -91,7 +91,7 @@ def test_model(clipper_conn, app, version):
                 'input': get_test_point()
             }))
         result = response.json()
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             print(result)

--- a/integration-tests/deploy_pytorch_to_caffe2_with_onnx.py
+++ b/integration-tests/deploy_pytorch_to_caffe2_with_onnx.py
@@ -96,7 +96,7 @@ def test_model(clipper_conn, app, version):
                 'input': get_test_point()
             }))
         result = response.json()
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             logger.error(result)

--- a/integration-tests/deploy_tensorflow_models.py
+++ b/integration-tests/deploy_tensorflow_models.py
@@ -97,7 +97,7 @@ def test_model(clipper_conn, app, version):
                 'input': get_test_point()
             }))
         result = response.json()
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             print(result)

--- a/integration-tests/deploy_xgboost_models.py
+++ b/integration-tests/deploy_xgboost_models.py
@@ -61,7 +61,7 @@ def test_model(clipper_conn, app, version):
                 'input': get_test_point()
             }))
         result = response.json()
-        if response.status_code == requests.codes.ok and result["default"]:
+        if response.status_code == requests.codes.ok and result["use_default"]:
             num_defaults += 1
         elif response.status_code != requests.codes.ok:
             print(result)

--- a/integration-tests/kubernetes_integration_test.py
+++ b/integration-tests/kubernetes_integration_test.py
@@ -58,7 +58,7 @@ def deploy_model(clipper_conn, name, version, link=False):
                         'input': list([1.2, 1.3])
                     }))
                 result = response.json()
-                if response.status_code == requests.codes.ok and result["default"]:
+                if response.status_code == requests.codes.ok and result["use_default"]:
                     num_defaults += 1
             except requests.RequestException:
                 num_defaults += 1

--- a/integration-tests/kubernetes_multi_frontend.py
+++ b/integration-tests/kubernetes_multi_frontend.py
@@ -63,7 +63,7 @@ def deploy_model(clipper_conn, name, link=False):
                 }))
             result = response.json()
             print(result)
-            if response.status_code == requests.codes.ok and result["default"]:
+            if response.status_code == requests.codes.ok and result["use_default"]:
                 num_defaults += 1
         if num_defaults > 0:
             logger.error("Error: %d/%d predictions were default" %

--- a/integration-tests/kubernetes_namespace.py
+++ b/integration-tests/kubernetes_namespace.py
@@ -28,8 +28,8 @@ def test():
 
     res_1 = predict_(conn_1.get_query_addr(), [.1, .2, .3])
     res_2 = predict_(conn_2.get_query_addr(), [.1, .2, .3])
-    assert not res_1['default']
-    assert not res_2['default']
+    assert not res_1['use_default']
+    assert not res_2['use_default']
 
     conn_1.stop_all()
     conn_2.stop_all()

--- a/integration-tests/many_apps_many_models.py
+++ b/integration-tests/many_apps_many_models.py
@@ -53,7 +53,7 @@ def deploy_model(clipper_conn, name, version, link=False):
                     'input': list(np.random.random(30))
                 }))
             result = response.json()
-            if response.status_code == requests.codes.ok and result["default"]:
+            if response.status_code == requests.codes.ok and result["use_default"]:
                 num_defaults += 1
         if num_defaults > 0:
             logger.error("Error: %d/%d predictions were default" %

--- a/integration-tests/multi_tenancy_test.py
+++ b/integration-tests/multi_tenancy_test.py
@@ -23,8 +23,8 @@ def test(kubernetes):
 
     res_1 = predict_(conn_1.get_query_addr(), [.1, .2, .3])
     res_2 = predict_(conn_2.get_query_addr(), [.1, .2, .3])
-    assert not res_1['default']
-    assert not res_2['default']
+    assert not res_1['use_default']
+    assert not res_2['use_default']
 
     conn_1.stop_all()
     conn_2.stop_all()

--- a/integration-tests/r_integration_test/deploy_query_test_model.py
+++ b/integration-tests/r_integration_test/deploy_query_test_model.py
@@ -66,7 +66,7 @@ def send_requests(clipper_conn):
                     'input': list(np.random.random(30))
                 }))
             result = response.json()
-            if response.status_code == requests.codes.ok and not result["default"]:
+            if response.status_code == requests.codes.ok and not result["use_default"]:
                 num_success += 1
             else:
                 logger.warning(result)

--- a/src/frontends/src/query_frontend.hpp
+++ b/src/frontends/src/query_frontend.hpp
@@ -42,7 +42,7 @@ const std::string GET_METRICS = "^/metrics$";
 
 const char* PREDICTION_RESPONSE_KEY_QUERY_ID = "query_id";
 const char* PREDICTION_RESPONSE_KEY_OUTPUT = "output";
-const char* PREDICTION_RESPONSE_KEY_USED_DEFAULT = "default";
+const char* PREDICTION_RESPONSE_KEY_USE_DEFAULT = "use_default";
 const char* PREDICTION_RESPONSE_KEY_DEFAULT_EXPLANATION = "default_explanation";
 const char* PREDICTION_ERROR_RESPONSE_KEY_ERROR = "error";
 const char* PREDICTION_ERROR_RESPONSE_KEY_CAUSE = "cause";
@@ -471,7 +471,7 @@ class RequestHandler {
    * {
    *    "query_id" := int,
    *    "output" := float,
-   *    "default" := boolean
+   *    "use_default" := boolean
    *    "default_explanation" := string (optional)
    * }
    */
@@ -496,7 +496,7 @@ class RequestHandler {
       clipper::json::add_string(json_response, PREDICTION_RESPONSE_KEY_OUTPUT,
                                 y_hat_str);
     }
-    clipper::json::add_bool(json_response, PREDICTION_RESPONSE_KEY_USED_DEFAULT,
+    clipper::json::add_bool(json_response, PREDICTION_RESPONSE_KEY_USE_DEFAULT,
                             query_response.output_is_default_);
     if (query_response.output_is_default_ &&
         query_response.default_explanation_) {
@@ -517,7 +517,7 @@ class RequestHandler {
    *     {
    *        "query_id" := int,
    *        "output" := float,
-   *        "default" := boolean
+   *        "use_default" := boolean
    *        "default_explanation" := string (optional)
    *     }
    * }

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -350,7 +350,7 @@ TEST_F(QueryFrontendTest,
   ASSERT_TRUE(
       parsed_response.GetObject().HasMember(PREDICTION_RESPONSE_KEY_OUTPUT));
   ASSERT_TRUE(parsed_response.GetObject().HasMember(
-      PREDICTION_RESPONSE_KEY_USED_DEFAULT));
+      PREDICTION_RESPONSE_KEY_USE_DEFAULT));
   ASSERT_TRUE(parsed_response.GetObject()
                   .FindMember(PREDICTION_RESPONSE_KEY_QUERY_ID)
                   ->value.IsInt());
@@ -358,7 +358,7 @@ TEST_F(QueryFrontendTest,
                   .FindMember(PREDICTION_RESPONSE_KEY_OUTPUT)
                   ->value.IsFloat());
   ASSERT_TRUE(parsed_response.GetObject()
-                  .FindMember(PREDICTION_RESPONSE_KEY_USED_DEFAULT)
+                  .FindMember(PREDICTION_RESPONSE_KEY_USE_DEFAULT)
                   ->value.IsBool());
 }
 


### PR DESCRIPTION
So many languages use 'default' as a keyword. 
How about replace 'default' of 'use_default' as a kind of the prediction response key?
