### PR TITLE
Fix a bug that ManagementFrontend adds a garbage to http response

### DIFF
--- a/src/libclipper/test/container_test.cpp
+++ b/src/libclipper/test/container_test.cpp
@@ -29,6 +29,7 @@ TEST(ModelContainerTests,
   size_t last_batch_size = 1;
   for (long long i = 1; i < 200; ++i) {
     long long latency = static_cast<long long>(i * base_latency * decay_factor);
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     container.add_processing_datapoint(i, latency);
 
     if (i % 10 == 0) {
@@ -51,6 +52,7 @@ TEST(ModelContainerTests,
 
   for (long long i = 1; i <= 50; ++i) {
     long long latency = base_latency * i;
+    std::this_thread::sleep_for(std::chrono::seconds(1));
     container.add_processing_datapoint(i, latency);
 
     // Get the batch size corresponding to a latency budget

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -144,9 +144,9 @@ const std::string SELECTION_JSON_SCHEMA = R"(
 
 void respond_http(std::string content, std::string message,
                   std::shared_ptr<HttpServer::Response> response) {
-  *response << "HTTP/1.1 " << message
+  *response << "HTTP/1.1 " << message << "\r\nContent-Type: application/json"
             << "\r\nContent-Length: " << content.length() << "\r\n\r\n"
-            << content << "\n";
+            << content;
 }
 
 /* Generate a user-facing error message containing the exception


### PR DESCRIPTION
Currently ManagementFrontend sends `['http header' + 'content' + '\n']` as a http response to the outer side. Our team found some error cases occurred by wrong value(content.length()) of Content-Length in the 'http header'. To fix it, `\n` must be removed from the http response.

I found the same bug in QueryFrontend and pull-requested it already. (#415)