### PR TITLE
Implement delete_versioned_model API

### DIFF
--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -1247,8 +1247,13 @@ class ClipperConnection(object):
             raise UnconnectedException()
         return self.cm.get_metric_addr()
 
-    def unregister_versioned_models(self, model_versions_dict):
+    def _unregister_versioned_models(self, model_versions_dict):
         """Unregister the specified versions of the specified models from Clipper internal.
+
+        This function does not be opened to public because it might cause critical operation.
+        Please use 'stop_models', 'stop_versioned_models', 'stop_inactive_model_versions',
+        and 'stop_all_model_containers' APIs according to your need.
+
         Parameters
         ----------
         model_versions_dict : dict(str, list(str))
@@ -1307,7 +1312,7 @@ class ClipperConnection(object):
                 else:
                     model_dict[m["model_name"]] = [m["model_version"]]
         self.cm.stop_models(model_dict)
-        self.unregister_versioned_models(model_dict)
+        self._unregister_versioned_models(model_dict)
         pp = pprint.PrettyPrinter(indent=4)
         self.logger.info(
             "Stopped all containers for these models and versions:\n{}".format(
@@ -1334,7 +1339,7 @@ class ClipperConnection(object):
         if not self.connected:
             raise UnconnectedException()
         self.cm.stop_models(model_versions_dict)
-        self.unregister_versioned_models(model_versions_dict)
+        self._unregister_versioned_models(model_versions_dict)
         pp = pprint.PrettyPrinter(indent=4)
         self.logger.info(
             "Stopped all containers for these models and versions:\n{}".format(
@@ -1371,7 +1376,7 @@ class ClipperConnection(object):
                 else:
                     model_dict[m["model_name"]] = [m["model_version"]]
         self.cm.stop_models(model_dict)
-        self.unregister_versioned_models(model_dict)
+        self._unregister_versioned_models(model_dict)
         pp = pprint.PrettyPrinter(indent=4)
         self.logger.info(
             "Stopped all containers for these models and versions:\n{}".format(
@@ -1399,7 +1404,7 @@ class ClipperConnection(object):
             else:
                 model_dict[m["model_name"]] = [m["model_version"]]
         self.cm.stop_all_model_containers()
-        self.unregister_versioned_models(model_dict)
+        self._unregister_versioned_models(model_dict)
         pp = pprint.PrettyPrinter(indent=4)
         self.logger.info("Stopped all Clipper model containers:\n{}".format(
             pp.pformat(model_dict)))

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -304,7 +304,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             "robertplant": ["i", "ii", "iii", "iv"]
         })
         self.check_registered_models(
-            pairs=[(a, b) for a in mnames[:2] for b in versions])
+            pairs=[(a, b) for a in mnames[2:] for b in versions])
 
         # After calling this method, the remaining models should be:
         # jpj:i, jpj:iii, johnbohman:ii
@@ -321,8 +321,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             "johnbohnam": ["i", "iv", "iii"],
         })
         self.check_registered_models(
-            pairs=[("jpj", "ii"), ("jpj", "iv"), ("johnbohnam", "i"),
-                   ("johnbohnam", "iv"), ("johnbohnam", "iii")])
+            pairs=[("jpj", "i"), ("jpj", "iii"), ("johnbohnam", "ii")])
 
         self.clipper_conn.stop_all_model_containers()
         containers = self.get_containers(container_name)

--- a/src/libclipper/include/clipper/redis.hpp
+++ b/src/libclipper/include/clipper/redis.hpp
@@ -131,13 +131,25 @@ bool add_model(redox::Redox& redis, const VersionedModelId& model_id,
                const std::string& model_data_path, int batch_size);
 
 /**
+ * Marks a model for deletion if it exists.
+ *
+ * \return Returns true if the model was present in the table
+ * and was successfully marked for deletion. Returns false if there was a
+ * problem
+ * or if the model was not in the table.
+ */
+bool mark_versioned_model_for_delete(redox::Redox& redis,
+                                     const VersionedModelId& model_id);
+
+/**
  * Deletes a model from the model table if it exists.
  *
  * \return Returns true if the model was present in the table
  * and was successfully deleted. Returns false if there was a problem
  * or if the model was not in the table.
  */
-bool delete_model(redox::Redox& redis, const VersionedModelId& model_id);
+bool delete_versioned_model(redox::Redox& redis,
+                            const VersionedModelId& model_id);
 
 /**
  * Looks up a model based on its model ID. This

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -425,12 +425,6 @@ class TaskExecutor {
             }
             active_containers_->register_batch_size(vm, batch_size);
 
-            EstimatorFittingThreadPool::create_queue(vm, replica_id);
-            TaskExecutionThreadPool::create_queue(vm, replica_id);
-            TaskExecutionThreadPool::submit_job(
-                vm, replica_id, [this, vm, replica_id]() {
-                  on_container_ready(vm, replica_id);
-                });
             bool created_queue = create_model_queue_if_necessary(vm);
             if (created_queue) {
               log_info_formatted(LOGGING_TAG_TASK_EXECUTOR,
@@ -438,6 +432,13 @@ class TaskExecutor {
                                  vm.get_name(), vm.get_id());
             }
             register_container_to_model_queue(vm, replica_id);
+
+            EstimatorFittingThreadPool::create_queue(vm, replica_id);
+            TaskExecutionThreadPool::create_queue(vm, replica_id);
+            TaskExecutionThreadPool::submit_job(
+                vm, replica_id, [this, vm, replica_id]() {
+                  on_container_ready(vm, replica_id);
+                });
 
           } else if (!*task_executor_valid) {
             log_info(LOGGING_TAG_TASK_EXECUTOR,

--- a/src/libclipper/include/clipper/threadpool.hpp
+++ b/src/libclipper/include/clipper/threadpool.hpp
@@ -210,27 +210,35 @@ class ThreadPool {
    * queue.
    */
   void worker(size_t worker_id, bool is_block_worker) {
-    while (!done_) {
-      std::unique_ptr<IThreadTask> pTask{nullptr};
-      bool work_to_do = false;
-      {
-        boost::shared_lock<boost::shared_mutex> l(queues_mutex_);
-        if (is_block_worker) {
-          work_to_do = queues_[worker_id].wait_pop(pTask, l);
-        } else {
-          // NOTE: The use of try_pop here means the worker will spin instead of
-          // block while waiting for work. This is intentional. We defer to the
-          // submitted tasks to block when no work is available.
-          work_to_do = queues_[worker_id].try_pop(pTask);
-        }
-      }
-      if (work_to_do) {
-        pTask->execute();
-      }
-    }
     auto thread_id = std::this_thread::get_id();
     std::stringstream ss;
     ss << thread_id;
+
+    try {
+        while (!done_ && queues_[worker_id].is_valid()) {
+          boost::this_thread::interruption_point();
+          std::unique_ptr<IThreadTask> pTask{nullptr};
+          bool work_to_do = false;
+          {
+            boost::shared_lock<boost::shared_mutex> l(queues_mutex_);
+            if (is_block_worker) {
+              work_to_do = queues_[worker_id].wait_pop(pTask, l);
+            } else {
+              // NOTE: The use of try_pop here means the worker will spin instead of
+              // block while waiting for work. This is intentional. We defer to the
+              // submitted tasks to block when no work is available.
+              work_to_do = queues_[worker_id].try_pop(pTask);
+            }
+          }
+          if (work_to_do) {
+            pTask->execute();
+          }
+        }
+    } catch (boost::thread_interrupted&) {
+      log_info_formatted(LOGGING_TAG_THREADPOOL,
+                         "Worker {}, thread {} is interrupted",
+                         std::to_string(worker_id), ss.str());
+    }
     log_info_formatted(LOGGING_TAG_THREADPOOL,
                        "Worker {}, thread {} is shutting down",
                        std::to_string(worker_id), ss.str());
@@ -256,7 +264,7 @@ class ThreadPool {
   boost::shared_mutex queues_mutex_;
   std::unordered_map<size_t, ThreadSafeQueue<std::unique_ptr<IThreadTask>>>
       queues_;
-  std::unordered_map<size_t, std::thread> threads_;
+  std::unordered_map<size_t, boost::thread> threads_;
 };
 
 class ModelQueueThreadPool : public ThreadPool {
@@ -297,6 +305,55 @@ class ModelQueueThreadPool : public ThreadPool {
       log_info_formatted(LOGGING_TAG_THREADPOOL,
                          "Work queue created for model {}, replica {}",
                          vm.serialize(), std::to_string(replica_id));
+      return true;
+    }
+  }
+
+  bool interrupt_thread(VersionedModelId vm, const int replica_id) {
+    boost::shared_lock<boost::shared_mutex> l(queues_mutex_);
+    size_t queue_id = get_queue_id(vm, replica_id);
+    auto thread = threads_.find(queue_id);
+    if (thread == threads_.end()) {
+      log_error_formatted(LOGGING_TAG_THREADPOOL,
+                          "Thread does not exist for model {}, replica {}",
+                          vm.serialize(), replica_id);
+      return false;
+    } else {
+      thread->second.interrupt();
+      log_info_formatted(LOGGING_TAG_THREADPOOL,
+                         "Thread is interrupted for model {}, replica {}",
+                         vm.serialize(), replica_id);
+      return true;
+    }
+  }
+
+  bool delete_queue(VersionedModelId vm, const int replica_id) {
+    boost::unique_lock<boost::shared_mutex> l(queues_mutex_);
+    size_t queue_id = get_queue_id(vm, replica_id);
+    auto queue = queues_.find(queue_id);
+    if (queue == queues_.end() || !queue->second.is_valid()) {
+      log_error_formatted(LOGGING_TAG_THREADPOOL,
+                          "Work queue does not exist for model {}, replica {}",
+                          vm.serialize(), replica_id);
+      return false;
+    } else {
+      queue->second.invalidate();
+      l.unlock();
+
+      auto thread = threads_.find(queue_id);
+      if (thread->second.joinable()) {
+        thread->second.join();
+      }
+
+      {
+        boost::unique_lock<boost::shared_mutex> l(queues_mutex_);
+        queues_.erase(queue);
+        threads_.erase(thread);
+      }
+
+      log_info_formatted(LOGGING_TAG_THREADPOOL,
+                         "Work queue destroyed for model {}, replica {}",
+                         vm.serialize(), replica_id);
       return true;
     }
   }
@@ -371,6 +428,14 @@ inline void create_queue(VersionedModelId vm, int replica_id) {
   get_thread_pool().create_queue(vm, replica_id, false);
 }
 
+inline void delete_queue(VersionedModelId vm, int replica_id) {
+  get_thread_pool().delete_queue(vm, replica_id);
+}
+
+inline void interrupt_thread(VersionedModelId vm, int replica_id) {
+  get_thread_pool().interrupt_thread(vm, replica_id);
+}
+
 }  // namespace TaskExecutionThreadPool
 
 namespace EstimatorFittingThreadPool {
@@ -394,6 +459,10 @@ inline auto submit_job(Func&& func, Args&&... args) {
 
 inline void create_queue(VersionedModelId vm, int replica_id) {
   get_thread_pool().create_queue(vm, replica_id, true);
+}
+
+inline void delete_queue(VersionedModelId vm, int replica_id) {
+  get_thread_pool().delete_queue(vm, replica_id);
 }
 
 }  // namespace EstimatorFittingThreadPool

--- a/src/libclipper/test/redis_test.cpp
+++ b/src/libclipper/test/redis_test.cpp
@@ -89,10 +89,10 @@ TEST_F(RedisTest, AddModel) {
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
                         model_path, DEFAULT_BATCH_SIZE));
   auto result = get_model(*redis_, model);
-  // The model table has 8 fields, so we expect
-  // to get back a map with 8 entries in it
+  // The model table has 9 fields, so we expect
+  // to get back a map with 9 entries in it
   // (see add_model() in redis.cpp for details on what the fields are).
-  EXPECT_EQ(result.size(), static_cast<size_t>(8));
+  EXPECT_EQ(result.size(), static_cast<size_t>(9));
   ASSERT_EQ(result["model_name"], model.get_name());
   ASSERT_EQ(result["model_version"], model.get_id());
   ASSERT_FLOAT_EQ(std::stof(result["load"]), 0.0);
@@ -233,8 +233,8 @@ TEST_F(RedisTest, DeleteModel) {
   ASSERT_TRUE(add_model(*redis_, model, InputType::Ints, labels, container_name,
                         model_path, DEFAULT_BATCH_SIZE));
   auto add_result = get_model(*redis_, model);
-  EXPECT_EQ(add_result.size(), static_cast<size_t>(8));
-  ASSERT_TRUE(delete_model(*redis_, model));
+  EXPECT_EQ(add_result.size(), static_cast<size_t>(9));
+  ASSERT_TRUE(delete_versioned_model(*redis_, model));
   auto delete_result = get_model(*redis_, model);
   EXPECT_EQ(delete_result.size(), static_cast<size_t>(0));
 }
@@ -421,7 +421,7 @@ TEST_F(RedisTest, SubscriptionDetectModelDelete) {
       });
   // give Redis some time to register the subscription
   std::this_thread::sleep_for(std::chrono::milliseconds(500));
-  ASSERT_TRUE(delete_model(*redis_, model));
+  ASSERT_TRUE(delete_versioned_model(*redis_, model));
   std::unique_lock<std::mutex> l(notification_mutex);
   bool result = notification_recv.wait_for(l, std::chrono::milliseconds(1000),
                                            [&recv]() { return recv == true; });

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -467,6 +467,7 @@ class RequestHandler {
         [this](std::shared_ptr<HttpServer::Response> response,
                std::shared_ptr<HttpServer::Request> request) {
             respond_http("PONG", "200 OK", response);
+        });
 
     server_.add_endpoint(
         DELETE_VERSIONED_MODEL, "POST",

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -1340,6 +1340,15 @@ class RequestHandler {
          << " does not exist";
       throw clipper::ManagementOperationError(ss.str());
     }
+    if (existing_model_data.find("valid") == existing_model_data.end()) {
+      std::stringstream ss;
+      ss << "model with name "
+         << "'" << model_name << "'"
+         << " and version "
+         << "'" << model_version << "'"
+         << " is already marked as 'invalid'";
+      throw clipper::ManagementOperationError(ss.str())
+    }
 
     if (clipper::redis::mark_versioned_model_for_delete(redis_connection_, model_id)) {
       std::stringstream ss;

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -1175,7 +1175,7 @@ class RequestHandler {
     response_doc.SetObject();
 
     if (model_metadata.size() > 0) {
-      /* We assume that redis::get_model returns an empty map iff no model
+      /* We assume that redis::get_model returns an empty map if no model
        * exists */
       redis_model_metadata_to_json(response_doc, model_metadata);
       bool is_current_version =

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -1347,7 +1347,7 @@ class RequestHandler {
          << " and version "
          << "'" << model_version << "'"
          << " is already marked as 'invalid'";
-      throw clipper::ManagementOperationError(ss.str())
+      throw clipper::ManagementOperationError(ss.str());
     }
 
     if (clipper::redis::mark_versioned_model_for_delete(redis_connection_, model_id)) {

--- a/src/management/src/management_frontend.hpp
+++ b/src/management/src/management_frontend.hpp
@@ -53,6 +53,7 @@ const std::string ADD_APPLICATION = ADMIN_PATH + "/add_app$";
 const std::string DELETE_APPLICATION = ADMIN_PATH + "/delete_app$";
 const std::string ADD_MODEL_LINKS = ADMIN_PATH + "/add_model_links$";
 const std::string ADD_MODEL = ADMIN_PATH + "/add_model$";
+const std::string DELETE_VERSIONED_MODEL = ADMIN_PATH + "/delete_versioned_model";
 const std::string SET_MODEL_VERSION = ADMIN_PATH + "/set_model_version$";
 
 // const std::string ADD_CONTAINER = ADMIN_PATH + "/add_container$";
@@ -125,6 +126,13 @@ const std::string ADD_MODEL_JSON_SCHEMA = R"(
    "input_type" := "integers" | "bytes" | "floats" | "doubles" | "strings",
    "container_name" := string,
    "model_data_path" := string
+  }
+)";
+
+const std::string DELETE_VERSIONED_MODEL_JSON_SCHEMA = R"(
+  {
+   "model_name" := string,
+   "model_version" := string,
   }
 )";
 
@@ -436,6 +444,8 @@ class RequestHandler {
         [this](std::shared_ptr<HttpServer::Response> response,
                std::shared_ptr<HttpServer::Request> request) {
           try {
+            clipper::log_info(LOGGING_TAG_MANAGEMENT_FRONTEND,
+                              "Get selection state POST request");
             std::string result = get_selection_state(request->content.string());
             respond_http(result, "200 OK", response);
           } catch (const json_parse_error& e) {
@@ -457,6 +467,27 @@ class RequestHandler {
         [this](std::shared_ptr<HttpServer::Response> response,
                std::shared_ptr<HttpServer::Request> request) {
             respond_http("PONG", "200 OK", response);
+
+    server_.add_endpoint(
+        DELETE_VERSIONED_MODEL, "POST",
+        [this](std::shared_ptr<HttpServer::Response> response,
+               std::shared_ptr<HttpServer::Request> request) {
+          try {
+            clipper::log_info(LOGGING_TAG_MANAGEMENT_FRONTEND,
+                              "Delete versioned model POST request");
+            std::string result = delete_versioned_model(request->content.string());
+            respond_http(result, "200 OK", response);
+          } catch (const json_parse_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), DELETE_VERSIONED_MODEL_JSON_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const json_semantic_error& e) {
+            std::string err_msg =
+                json_error_msg(e.what(), DELETE_VERSIONED_MODEL_JSON_SCHEMA);
+            respond_http(err_msg, "400 Bad Request", response);
+          } catch (const clipper::ManagementOperationError& e) {
+            respond_http(e.what(), "400 Bad Request", response);
+          }
         });
   }
 
@@ -1193,6 +1224,56 @@ class RequestHandler {
     auto app_metadata =
         clipper::redis::get_application(redis_connection_, app_name);
     return app_metadata["default_output"];
+  }
+
+  /**
+   * Processes a request to remove the versioned model from Clipper
+   *
+   * JSON format:
+   * {
+   *  "model_name" := string,
+   *  "model_version" := string
+   * }
+   *
+   * \return A string describing the operation's success
+   * \throws ManagementOperationError if the operation is not successful
+   */
+  std::string delete_versioned_model(const std::string& json) {
+    rapidjson::Document d;
+    parse_json(json, d);
+    std::string model_name = get_string(d, "model_name");
+    std::string model_version = get_string(d, "model_version");
+    VersionedModelId model_id = VersionedModelId(model_name, model_version);
+
+    // check if this version of the model has been existed or not
+    std::unordered_map<std::string, std::string> existing_model_data =
+        clipper::redis::get_model(redis_connection_, model_id);
+    if (existing_model_data.empty()) {
+      std::stringstream ss;
+      ss << "model with name "
+         << "'" << model_name << "'"
+         << " and version "
+         << "'" << model_version << "'"
+         << " does not exist";
+      throw clipper::ManagementOperationError(ss.str());
+    }
+
+    if (clipper::redis::mark_versioned_model_for_delete(redis_connection_, model_id)) {
+      std::stringstream ss;
+      ss << "Successfully deleted model with name "
+         << "'" << model_name << "'"
+         << " and version "
+         << "'" << model_version << "'";
+      return ss.str();
+    } else {
+      std::stringstream ss;
+      ss << "Error deleting model with name "
+         << "'" << model_name << "'"
+         << " and version "
+         << "'" << model_version << "'"
+         << " from Redis";
+      throw clipper::ManagementOperationError(ss.str());
+    }
   }
 
   /**

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -1017,7 +1017,7 @@ TEST_F(ManagementFrontendTest, TestDeleteVersionedModelCorrect) {
 
   // Make sure that the current model version has been updated
   // appropriately.
-  ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version)
+  ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version);
 
   std::string delete_versioned_model_json = R"(
   {
@@ -1058,7 +1058,7 @@ TEST_F(ManagementFrontendTest, TestDeleteVersionedModelMissingField) {
 
   // Make sure that the current model version has been updated
   // appropriately.
-  ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version)
+  ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version);
 
   // model_version is omitted.
   std::string delete_versioned_model_json = R"(
@@ -1095,7 +1095,7 @@ TEST_F(ManagementFrontendTest, TestDeleteVersionedModelForNonexistentModel) {
 
   // Make sure that the current model version has been updated
   // appropriately.
-  ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version)
+  ASSERT_EQ(*get_current_model_version(*redis_, model_name), model_version);
 
   // Try to delete wrong versioned model.
   std::string delete_versioned_model_json = R"(

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -1009,11 +1009,11 @@ TEST_F(ManagementFrontendTest, TestDeleteVersionedModelCorrect) {
   ASSERT_NO_THROW(rh_.add_model(add_model_json));
   std::string model_name = "test_delete_versioned_model_correct";
   std::string model_version = "1";
-  auto result = get_model(*redis_, VersionedModelId(model_name, model_version));
+  auto res1 = get_model(*redis_, VersionedModelId(model_name, model_version));
   // The model table has 9 fields, so we expect to get back a map with 9
   // entries in it (see add_model() in redis.cpp for details on what the
   // fields are).
-  ASSERT_EQ(result.size(), static_cast<size_t>(9));
+  ASSERT_EQ(res1.size(), static_cast<size_t>(9));
 
   // Make sure that the current model version has been updated
   // appropriately.
@@ -1029,8 +1029,8 @@ TEST_F(ManagementFrontendTest, TestDeleteVersionedModelCorrect) {
   ASSERT_NO_THROW(rh_.delete_versioned_model(delete_versioned_model_json));
 
   // Check that the model is invalid or not.
-  auto result = get_model(*redis_, VersionedModelId(model_name, model_version));
-  ASSERT_EQ(result.find("valid"), result.end());
+  auto res2 = get_model(*redis_, VersionedModelId(model_name, model_version));
+  ASSERT_EQ(res2.find("valid"), res2.end());
 }
 
 TEST_F(ManagementFrontendTest, TestDeleteVersionedModelMissingField) {

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -1028,10 +1028,9 @@ TEST_F(ManagementFrontendTest, TestDeleteVersionedModelCorrect) {
 
   ASSERT_NO_THROW(rh_.delete_versioned_model(delete_versioned_model_json));
 
-  // Check that subsequent calls to model return empty JSON
-  std::string json_response = rh_.get_model(delete_versioned_model_json);
-  std::string expected_response = "{}";
-  ASSERT_EQ(json_response, expected_response);
+  // Check that the model is invalid or not.
+  auto result = get_model(*redis_, VersionedModelId(model_name, model_version));
+  ASSERT_EQ(result.find("valid"), result.end());
 }
 
 TEST_F(ManagementFrontendTest, TestDeleteVersionedModelMissingField) {

--- a/src/management/src/management_frontend_tests.cpp
+++ b/src/management/src/management_frontend_tests.cpp
@@ -465,10 +465,10 @@ TEST_F(ManagementFrontendTest, TestAddModelCorrect) {
   std::string model_name = "mymodelname";
   std::string model_version = "4";
   auto result = get_model(*redis_, VersionedModelId(model_name, model_version));
-  // The model table has 8 fields, so we expect to get back a map with 8
+  // The model table has 9 fields, so we expect to get back a map with 9
   // entries in it (see add_model() in redis.cpp for details on what the
   // fields are).
-  ASSERT_EQ(result.size(), static_cast<size_t>(8));
+  ASSERT_EQ(result.size(), static_cast<size_t>(9));
 
   // Make sure that the current model version has been updated
   // appropriately.
@@ -500,10 +500,10 @@ TEST_F(ManagementFrontendTest, TestAddLinkedModelCompatibleInputType) {
   std::string model_name = "mymodelname";
   std::string model_version = "4";
   auto result = get_model(*redis_, VersionedModelId(model_name, model_version));
-  // The model table has 8 fields, so we expect to get back a map with 8
+  // The model table has 9 fields, so we expect to get back a map with 9
   // entries in it (see add_model() in redis.cpp for details on what the
   // fields are).
-  ASSERT_EQ(result.size(), static_cast<size_t>(8));
+  ASSERT_EQ(result.size(), static_cast<size_t>(9));
 
   // Make sure that the current model version has been updated
   // appropriately.
@@ -546,10 +546,10 @@ TEST_F(ManagementFrontendTest, TestAddDuplicateModelVersion) {
   std::string model_name = "mymodelname";
   std::string model_version = "4";
   auto result = get_model(*redis_, VersionedModelId(model_name, model_version));
-  // The model table has 8 fields, so we expect to get back a map with 8
+  // The model table has 9 fields, so we expect to get back a map with 9
   // entries in it (see add_model() in redis.cpp for details on what the
   // fields are).
-  ASSERT_EQ(result.size(), static_cast<size_t>(8));
+  ASSERT_EQ(result.size(), static_cast<size_t>(9));
 
   // Make sure that the current model version has been updated
   // appropriately.


### PR DESCRIPTION
### 1. in brief
* related issue : https://github.com/ucbrise/clipper/issues/603
* Remove the specified versions of the specified models from Clipper internal.

### 2. TODO
* [x] Implement `unregister_versioned_models` Clipper API in clipper_admin
* [x] Implement `delete_versioned_model` Management-Frontend API
* [x] Add some test cases to integration-tests/clipper_admin_tests.py
* [x] Add some test cases to src/management/src/management_frontend_tests.cpp

### 3. non-public `_unregister_versioned_models` Clipper API in clipper_admin
#### Description
Unregister the specified versions of the specified models from Clipper internal.
This function does not be opened to public because it might cause critical operation.
Please use `stop_models`, `stop_versioned_models`, `stop_inactive_model_versions`, and `stop_all_model_containers` APIs according to your need.

#### Parameters
> model_versions_dict : dict(str, list(str))
>     For each entry in the dict, the key is a model name and the value is a list of model

#### Raises
> :py:exc:`clipper.UnconnectedException`
>     versions. All replicas for each version of each model will be stopped.

### 4. `delete_versioned_model` Management-Frontend API
#### API path
> POST /admin/delete_versioned_model

#### Request schema
> const std::string DELETE_VERSIONED_MODEL_JSON_SCHEMA = R"(
>   {
>    "model_name" := string,
>    "model_version" := string,
>   }
> )";