### PR TITLE
change set_num_replicas in docker_container_manager

### DIFF
--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -359,10 +359,12 @@ class DockerContainerManager(ContainerManager):
                 model_container_names.append(container_name)
             for name in model_container_names:
                 container = self.docker_client.containers.get(name)
-                while container.attrs.get("State") is None or self.docker_client.api.inspect_container(name) is None:
-                    time.sleep(3)
-                while container.attrs.get("State").get("Status") != "running" or \
-                        self.docker_client.api.inspect_container(name).get("State").get("Health").get("Status") != "healthy":
+                while True:
+                    state = container.attrs.get("State")
+                    container = self.docker_client.api.inspect_container(name)
+                    if (state is not None and state.get("Status") == "running") or \
+                            (container is not None and container.get("State").get("Health").get("Status") == "healthy"):
+                        break
                     time.sleep(3)
 
         elif len(current_replicas) > num_replicas:

--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -359,6 +359,8 @@ class DockerContainerManager(ContainerManager):
                 model_container_names.append(container_name)
             for name in model_container_names:
                 container = self.docker_client.containers.get(name)
+                while container.attrs.get("State") is None or self.docker_client.api.inspect_container(name) is None:
+                    time.sleep(3)
                 while container.attrs.get("State").get("Status") != "running" or \
                         self.docker_client.api.inspect_container(name).get("State").get("Health").get("Status") != "healthy":
                     time.sleep(3)

--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -361,9 +361,10 @@ class DockerContainerManager(ContainerManager):
                 container = self.docker_client.containers.get(name)
                 while True:
                     state = container.attrs.get("State")
-                    container = self.docker_client.api.inspect_container(name)
+                    inspect_container = self.docker_client.api.inspect_container(name)
                     if (state is not None and state.get("Status") == "running") or \
-                            (container is not None and container.get("State").get("Health").get("Status") == "healthy"):
+                            (inspect_container is not None and
+                             inspect_container.get("State").get("Health").get("Status") == "healthy"):
                         break
                     time.sleep(3)
 


### PR DESCRIPTION
Due to 
> [docker_container_manager.py:353] [default-cluster] Found 0 replicas for sample-model:1. Adding 1
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/lineplus/anaconda3/envs/dory_py3.6/lib/python3.6/site-packages/clipper_admin/clipper_admin.py", line 620, in deploy_model
    num_replicas=num_replicas)
  File "/Users/lineplus/anaconda3/envs/dory_py3.6/lib/python3.6/site-packages/clipper_admin/docker/docker_container_manager.py", line 279, in deploy_model
    self.set_num_replicas(name, version, input_type, image, num_replicas)
  File "/Users/lineplus/anaconda3/envs/dory_py3.6/lib/python3.6/site-packages/clipper_admin/docker/docker_container_manager.py", line 363, in set_num_replicas
    self.docker_client.api.inspect_container(name).get("State").get("Health").get("Status") != "healthy":
AttributeError: 'NoneType' object has no attribute 'get'

This error occurs because container.attrs.get("State") and self.docker_client.api.inspect_container(name) can be 'None' type before enough delay time. 
Giving delay time can resolve this problem.