### PR TITLE
Revert ClipperLibBaseDockerfile

### DIFF
--- a/dockerfiles/ClipperLibBaseDockerfile
+++ b/dockerfiles/ClipperLibBaseDockerfile
@@ -16,14 +16,14 @@ RUN git clone https://github.com/facebook/folly \
     && git checkout tags/v2017.08.14.00 \
     && autoreconf -ivf \
     && ./configure \
-    && make -j \
+    && make -j4 \
     && make install
 
 ## Install Cityhash
 RUN git clone https://github.com/google/cityhash \
     && cd cityhash \
     && ./configure \
-    && make -j all CXXFLAGS="-g -O3" \
+    && make all check CXXFLAGS="-g -O3" \
     && make install
 
 # vim: set filetype=dockerfile:


### PR DESCRIPTION
* related issue : https://github.com/ucbrise/clipper/issues/621
* When we execute 'make -j' command with no argument on Mac, the build process can occur internal compile error. So we need to revert ClipperLibBaseDockerfile.
* Refer to https://unix.stackexchange.com/questions/316644/is-make-j-with-no-argument-dangerous.