### PR TITLE
CUDA 10 Support for PyTorch (Py 36 + Py 27)

### DIFF
--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -291,7 +291,8 @@ class ClipperConnection(object):
                                container_registry=None,
                                num_replicas=1,
                                batch_size=-1,
-                               pkgs_to_install=None):
+                               pkgs_to_install=None,
+                               gpu=False):
         """Build a new model container Docker image with the provided data and deploy it as
         a model to Clipper.
 
@@ -343,6 +344,9 @@ class ClipperConnection(object):
         pkgs_to_install : list (of strings), optional
             A list of the names of packages to install, using pip, in the container.
             The names must be strings.
+        gpu : bool, optional
+            A boolean flag that indicates if the model will be run on a CUDA enabled GPU.
+        
         Raises
         ------
         :py:exc:`clipper.UnconnectedException`
@@ -354,7 +358,7 @@ class ClipperConnection(object):
         image = self.build_model(name, version, model_data_path, base_image,
                                  container_registry, pkgs_to_install)
         self.deploy_model(name, version, input_type, image, labels,
-                          num_replicas, batch_size)
+                          num_replicas, batch_size, gpu)
 
     def build_model(self,
                     name,
@@ -488,7 +492,8 @@ class ClipperConnection(object):
                      image,
                      labels=None,
                      num_replicas=1,
-                     batch_size=-1):
+                     batch_size=-1,
+                     gpu=False):
         """Deploys the model in the provided Docker image to Clipper.
 
         Deploying a model to Clipper does a few things.
@@ -540,6 +545,8 @@ class ClipperConnection(object):
             batches if `batch_size` queries are not immediately available.
             If the default value of -1 is used, Clipper will adaptively calculate the batch size for
             individual replicas of this model.
+        gpu : bool, optional
+            A boolean flag that indicates if the model will be run on a CUDA enabled GPU.
 
         Raises
         ------
@@ -562,7 +569,8 @@ class ClipperConnection(object):
             version=version,
             input_type=input_type,
             image=image,
-            num_replicas=num_replicas)
+            num_replicas=num_replicas,
+            gpu=gpu)
         self.register_model(
             name,
             version,

--- a/clipper_admin/clipper_admin/deployers/pytorch.py
+++ b/clipper_admin/clipper_admin/deployers/pytorch.py
@@ -241,7 +241,7 @@ def deploy_pytorch_model(clipper_conn,
                     logger.info("Using Python 3.6 base image")
                     base_image = "{}/pytorch36-container:{}".format(
                         __registry__, __version__)
-                 else:
+                else:
                     msg = (
                         "PyTorch deployer only supports Python 2.7, 3.5, and 3.6. "
                         "Detected {major}.{minor}").format(

--- a/dockerfiles/CUDA10Py27PyTorchContainerDockerfile
+++ b/dockerfiles/CUDA10Py27PyTorchContainerDockerfile
@@ -1,0 +1,56 @@
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04
+
+LABEL maintainer="Rehan Durrani <rdurrani@berkeley.edu>"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        cmake \
+        git \
+        curl \
+        vim \
+        ca-certificates \
+        libjpeg-dev \
+        libpng-dev &&\
+        rm -rf /var/lib/apt/lists/*
+
+RUN curl -o ~/miniconda.sh -O https://repo.anaconda.com/miniconda/Miniconda2-latest-Linux-x86_64.sh && \
+        chmod +x ~/miniconda.sh && \
+        ~/miniconda.sh -b -p /opt/conda && \
+        rm ~/miniconda.sh && \
+        /opt/conda/bin/conda install -y python=2.7 numpy pyyaml=3.12.* scipy ipython mkl mkl-include cython typing && \
+        /opt/conda/bin/conda install -y pytorch torchvision cuda100 -c pytorch && \
+        /opt/conda/bin/conda install -y -c anaconda pip && \
+        /opt/conda/bin/conda clean -ya
+
+ENV PATH /opt/conda/bin:$PATH
+
+RUN mkdir -p /model \
+      && apt-get update -qq \
+      && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
+
+RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
+    jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
+    numpy==1.14.* subprocess32==3.2.*
+
+COPY clipper_admin /clipper_admin/
+
+RUN cd /clipper_admin \
+    && pip install -q .
+
+WORKDIR /container
+
+COPY containers/python/__init__.py containers/python/rpc.py /container/
+
+COPY monitoring/metrics_config.yaml /container/
+
+ENV CLIPPER_MODEL_PATH=/model
+
+HEALTHCHECK --interval=3s --timeout=3s --retries=1 CMD test -f /model_is_ready.check || exit 1
+
+ENV PATH /opt/conda/bin:$PATH
+
+COPY containers/python/pytorch_container.py containers/python/container_entry.sh /container/
+
+CMD ["/container/container_entry.sh", "pytorch-container", "/container/pytorch_container.py"]
+
+# vim: set filetype=dockerfile:

--- a/dockerfiles/CUDA10Py36PyTorchContainerDockerfile
+++ b/dockerfiles/CUDA10Py36PyTorchContainerDockerfile
@@ -1,0 +1,38 @@
+FROM pytorch/pytorch:1.0-cuda10.0-cudnn7-devel
+
+RUN conda install pyyaml=3.12.*
+
+LABEL maintainer="Rehan Durrani <rdurrani@berkeley.edu>"
+
+RUN apt-get update -qq
+
+RUN apt-get install -y  build-essential libssl-dev libffi-dev python-dev
+
+RUN mkdir -p /model \
+      && apt-get update -qq \
+      && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18
+
+RUN pip install cloudpickle==0.5.* pyopenssl pyzmq==17.0.* prometheus_client==0.1.* \
+    jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
+    numpy==1.14.*
+
+COPY clipper_admin /clipper_admin/
+
+RUN cd /clipper_admin \
+                && pip install .
+
+WORKDIR /container
+
+COPY containers/python/__init__.py containers/python/rpc.py /container/
+
+COPY monitoring/metrics_config.yaml /container/
+
+ENV CLIPPER_MODEL_PATH=/model
+
+HEALTHCHECK --interval=3s --timeout=3s --retries=1 CMD test -f /model_is_ready.check || exit 1
+
+COPY containers/python/pytorch_container.py containers/python/container_entry.sh /container/
+
+CMD ["/container/container_entry.sh", "pytorch-container", "/container/pytorch_container.py"]
+
+# vim: set filetype=dockerfile:


### PR DESCRIPTION
This PR adds CUDA support for pytorch on docker. Support for TF to follow. To use, must have CUDA 10 + Nvidia-docker - just specify `gpu=True` in `pytorch.deploy_pytorch_model`. Sample Usage:
```python
pytorch.deploy_pytorch_model(clipper_conn, "resent18", "v1", predict_fn, torchvision.models.resnet18(), gpu=True)
```
Will need to change deployment code based off of what the new containers are named on the docker hub registry.