### PR TITLE
Use CLIPPER_REGISTRY, CLIPPER_TAG environment variable if existed

### DIFF
--- a/bin/shipyard.sh
+++ b/bin/shipyard.sh
@@ -14,8 +14,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR/..
 
 # We will build all images and push them to 
-# dockerhub under clippertesting/{image_name}:sha_tag
-CLIPPER_REGISTRY='clippertesting'
+# dockerhub under $CLIPPER_REGISTRY/{image_name}:sha_tag
+CLIPPER_REGISTRY="${CLIPPER_REGISTRY:-clippertesting}"
 sha_tag=$(git rev-parse --verify --short=10 HEAD)
 push_version_flag="--no-push"
 

--- a/bin/shipyard.sh
+++ b/bin/shipyard.sh
@@ -16,7 +16,7 @@ cd $DIR/..
 # We will build all images and push them to 
 # dockerhub under $CLIPPER_REGISTRY/{image_name}:sha_tag
 CLIPPER_REGISTRY="${CLIPPER_REGISTRY:-clippertesting}"
-sha_tag=$(git rev-parse --verify --short=10 HEAD)
+sha_tag="${CLIPPER_TAG:-$(git rev-parse --verify --short=10 HEAD)}"
 push_version_flag="--no-push"
 
 # Jenkins will merge the PR, however we will use the unmerged


### PR DESCRIPTION
With this patch, you can easily build Clipper Docker images locally.
```
$ git clone --recursive https://github.com/ucbrise/clipper.git
$ cd clipper
$ export CLIPPER_REGISTRY="clipper"
$ export CLIPPER_TAG="develop"
$ ./bin/shipyard.sh
$ make -f CI_build.Makefile <YOUR_TARGET_TO_BUILD>
```