### PR TITLE
Change k8s ServiceTypes to be changeable

### DIFF
--- a/clipper_admin/clipper_admin/container_manager.py
+++ b/clipper_admin/clipper_admin/container_manager.py
@@ -14,7 +14,6 @@ CLIPPER_NAME_LABEL = "ai.clipper.name"
 CLIPPER_MODEL_CONTAINER_LABEL = "ai.clipper.model_container.label"
 CLIPPER_QUERY_FRONTEND_CONTAINER_LABEL = "ai.clipper.query_frontend.label"
 CLIPPER_MGMT_FRONTEND_CONTAINER_LABEL = "ai.clipper.management_frontend.label"
-CLIPPER_QUERY_FRONTEND_ID_LABEL = "ai.clipper.query_frontend.id"
 CONTAINERLESS_MODEL_IMAGE = "NO_CONTAINER"
 
 CLIPPER_DOCKER_PORT_LABELS = {

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -153,14 +153,6 @@ class KubernetesContainerManager(ContainerManager):
         else:
             self.use_k8s_proxy = False
 
-        self.redis_ip = redis_ip
-        self.redis_port = redis_port
-        self.useInternalIP = useInternalIP
-        config.load_kube_config()
-        configuration.assert_hostname = False
-        self._k8s_v1 = client.CoreV1Api()
-        self._k8s_beta = client.ExtensionsV1beta1Api()
-
         # Create the template engine
         # Config: Any variable missing -> Error
         self.template_engine = jinja2.Environment(
@@ -168,6 +160,14 @@ class KubernetesContainerManager(ContainerManager):
             undefined=jinja2.StrictUndefined)
 
         self.service_types = self._determine_service_types(service_types)
+
+        self.redis_ip = redis_ip
+        self.redis_port = redis_port
+        self.useInternalIP = useInternalIP
+        config.load_kube_config()
+        configuration.assert_hostname = False
+        self._k8s_v1 = client.CoreV1Api()
+        self._k8s_beta = client.ExtensionsV1beta1Api()
 
         # Check if namespace exists and if create flag set ...create the namespace or throw error
         namespaces = []

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -203,12 +203,11 @@ class KubernetesContainerManager(ContainerManager):
 
     @staticmethod
     def _determine_service_types(st):
-        if not isinstance(st, dict):
-            raise ClipperException(
-                "service_types must be 'dict' type: {}".format(st))
-
         res = DEFAULT_CLIPPER_SERVICE_TYPES
         if st is not None:
+            if not isinstance(st, dict):
+                raise ClipperException(
+                    "service_types must be 'dict' type: {}".format(st))
             if set(st.keys()) != set(DEFAULT_CLIPPER_SERVICE_TYPES.keys()):
                 raise ClipperException(
                     "service_types has unknown keys: {}".format(st.keys()))

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -197,11 +197,11 @@ class KubernetesContainerManager(ContainerManager):
             inter_keys = service_types.keys() - DEFAULT_CLIPPER_SERVICE_TYPES.keys()
             if len(inter_keys) > 0:
                 raise ClipperException(
-                    f"Wrong keys in service_types: {inter_keys}")
+                    f"Wrong keys in service_types: {str(inter_keys)}")
             inter_values = set(service_types.values()).intersection(OFFICIAL_K8S_SERVICE_TYPE)
             if len(inter_values) > 0:
                 raise ClipperException(
-                    f"Wrong values in service_types: {inter_values}")
+                    f"Wrong values in service_types: {str(inter_values)}")
             self.service_types.update(service_types)
 
         self.logger = ClusterAdapter(logger, {

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -153,8 +153,6 @@ class KubernetesContainerManager(ContainerManager):
         else:
             self.use_k8s_proxy = False
 
-        self.service_types = self._determine_service_types(service_types)
-
         self.redis_ip = redis_ip
         self.redis_port = redis_port
         self.useInternalIP = useInternalIP
@@ -168,6 +166,8 @@ class KubernetesContainerManager(ContainerManager):
         self.template_engine = jinja2.Environment(
             loader=jinja2.FileSystemLoader(cur_dir, followlinks=True),
             undefined=jinja2.StrictUndefined)
+
+        self.service_types = self._determine_service_types(service_types)
 
         # Check if namespace exists and if create flag set ...create the namespace or throw error
         namespaces = []

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -156,14 +156,6 @@ class KubernetesContainerManager(ContainerManager):
         else:
             self.use_k8s_proxy = False
 
-        # Create the template engine
-        # Config: Any variable missing -> Error
-        self.template_engine = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(cur_dir, followlinks=True),
-            undefined=jinja2.StrictUndefined)
-
-        self.service_types = self._determine_service_types(service_types)
-
         self.redis_ip = redis_ip
         self.redis_port = redis_port
         self.useInternalIP = useInternalIP
@@ -171,6 +163,12 @@ class KubernetesContainerManager(ContainerManager):
         configuration.assert_hostname = False
         self._k8s_v1 = client.CoreV1Api()
         self._k8s_beta = client.ExtensionsV1beta1Api()
+
+        # Create the template engine
+        # Config: Any variable missing -> Error
+        self.template_engine = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(cur_dir, followlinks=True),
+            undefined=jinja2.StrictUndefined)
 
         # Check if namespace exists and if create flag set ...create the namespace or throw error
         namespaces = []
@@ -208,9 +206,11 @@ class KubernetesContainerManager(ContainerManager):
             'cluster_name': self.cluster_identifier
         })
 
+        self.service_types = self._determine_service_types(service_types)
+
     def _determine_service_types(self, st):
         yaml_file_name = CONFIG_FILES['k8s']['service_types'].replace(
-            DUMMY_CLUSTER_NAME, self.cluster_name)
+            DUMMY_CLUSTER_NAME, self.cluster_identifier)
         res = DEFAULT_CLIPPER_SERVICE_TYPES
 
         if st is None:
@@ -665,7 +665,7 @@ class KubernetesContainerManager(ContainerManager):
 
         try:
             yaml_file_name = CONFIG_FILES['k8s']['service_types'].replace(
-                DUMMY_CLUSTER_NAME, self.cluster_name)
+                DUMMY_CLUSTER_NAME, self.cluster_identifier)
             os.remove(os.path.join(cur_dir, yaml_file_name))
         except OSError:
             pass

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -197,11 +197,11 @@ class KubernetesContainerManager(ContainerManager):
             inter_keys = service_types.keys() - DEFAULT_CLIPPER_SERVICE_TYPES.keys()
             if len(inter_keys) > 0:
                 raise ClipperException(
-                    f"Wrong keys in service_types: {str(inter_keys)}")
+                    "Wrong keys in service_types: {}".format(str(inter_keys)))
             inter_values = set(service_types.values()).difference(OFFICIAL_K8S_SERVICE_TYPE)
             if len(inter_values) > 0:
                 raise ClipperException(
-                    f"Wrong values in service_types: {str(inter_values)}")
+                    "Wrong values in service_types: {}".format(str(inter_values)))
             self.service_types.update(service_types)
 
         self.logger = ClusterAdapter(logger, {

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -373,53 +373,78 @@ class KubernetesContainerManager(ContainerManager):
         return parsed
 
     def connect(self):
-        nodes = self._k8s_v1.list_node()
+        if any(v in [CLUSTER_IP, NODE_PORT] for v in self.service_types.values()):
+            nodes = self._k8s_v1.list_node()
 
-        external_node_hosts = []
-        for node in nodes.items:
-            for addr in node.status.addresses:
-                if addr.type == "ExternalDNS":
-                    external_node_hosts.append(addr.address)
+            external_node_hosts = []
+            for node in nodes.items:
+                for addr in node.status.addresses:
+                    if addr.type == "ExternalDNS":
+                        external_node_hosts.append(addr.address)
 
-        if len(external_node_hosts) == 0 and self.useInternalIP:
-            msg = "No external node addresses found. Using Internal IP address"
-            self.logger.warning(msg)
-            for addr in node.status.addresses:
-                if addr.type == "InternalIP":
-                    external_node_hosts.append(addr.address)
+            if len(external_node_hosts) == 0 and self.useInternalIP:
+                msg = "No external node addresses found. Using Internal IP address"
+                self.logger.warning(msg)
+                for addr in node.status.addresses:
+                    if addr.type == "InternalIP":
+                        external_node_hosts.append(addr.address)
 
-        if len(external_node_hosts) == 0:
-            msg = "Error connecting to Kubernetes cluster. No external node addresses found. You may pass in KubernetesContainerManager(useInternalIP=True) to connect to local Kubernetes cluster"
-            self.logger.error(msg)
-            raise ClipperException(msg)
+            if len(external_node_hosts) == 0:
+                msg = "Error connecting to Kubernetes cluster. No external node addresses found. You may pass in KubernetesContainerManager(useInternalIP=True) to connect to local Kubernetes cluster"
+                self.logger.error(msg)
+                raise ClipperException(msg)
 
-        self.external_node_hosts = external_node_hosts
-        self.logger.info("Found {num_nodes} nodes: {nodes}".format(
-            num_nodes=len(external_node_hosts),
-            nodes=", ".join(external_node_hosts)))
+            self.external_node_hosts = external_node_hosts
+            self.logger.info("Found {num_nodes} nodes: {nodes}".format(
+                num_nodes=len(external_node_hosts),
+                nodes=", ".join(external_node_hosts)))
 
         try:
-            mgmt_frontend_ports = self._k8s_v1.read_namespaced_service(
+            v1service = self._k8s_v1.read_namespaced_service(
                 name="mgmt-frontend-at-{cluster_name}".format(
                     cluster_name=self.cluster_name),
-                namespace=self.k8s_namespace).spec.ports
+                namespace=self.k8s_namespace)
+            mgmt_frontend_ports = v1service.spec.ports
             for p in mgmt_frontend_ports:
-                if p.name == "1338":
+                if int(p.name) == CLIPPER_INTERNAL_MANAGEMENT_PORT:
                     self.clipper_management_port = p.node_port
-                    self.logger.info("Setting Clipper mgmt port to {}".format(
-                        self.clipper_management_port))
 
-            query_frontend_ports = self._k8s_v1.read_namespaced_service(
+            if self.service_types['management'] in [CLUSTER_IP, NODE_PORT]:
+                self.logger.info("Setting Clipper mgmt port to {port}".format(
+                    port=self.clipper_management_port))
+            elif self.service_types['management'] == LOAD_BALANCER:
+                self.clipper_management_ip = v1service.status.load_balancer.ingress[0].ip
+                self.logger.info("Setting Clipper mgmt port to {ip}:{port}"
+                                 .format(ip=self.clipper_management_ip,
+                                         port=self.clipper_management_port))
+            else:
+                msg = "Unknown service_type of management: {}".format(
+                        self.service_types['management'])
+                raise ClipperException(msg)
+
+            v1service = self._k8s_v1.read_namespaced_service(
                 name="query-frontend-at-{cluster_name}".format(
                     cluster_name=self.cluster_name),
-                namespace=self.k8s_namespace).spec.ports
+                namespace=self.k8s_namespace)
+            query_frontend_ports = v1service.spec.ports
             for p in query_frontend_ports:
                 if int(p.name) == CLIPPER_INTERNAL_QUERY_PORT:
                     self.clipper_query_port = p.node_port
-                    self.logger.info("Setting Clipper query port to {}".format(
-                        self.clipper_query_port))
                 elif int(p.name) == CLIPPER_INTERNAL_RPC_PORT:
                     self.clipper_rpc_port = p.node_port
+
+            if self.service_types['query'] in [CLUSTER_IP, NODE_PORT]:
+                self.logger.info("Setting Clipper query port to {}".format(
+                    self.clipper_query_port))
+            elif self.service_types['query'] == LOAD_BALANCER:
+                self.clipper_query_ip = v1service.status.load_balancer.ingress[0].ip
+                self.logger.info("Setting Clipper query port to {ip}:{port}"
+                                 .format(ip=self.clipper_query_ip,
+                                         port=self.clipper_query_port))
+            else:
+                msg = "Unknown service_type of query: {}".format(
+                        self.service_types['query'])
+                raise ClipperException(msg)
 
             query_frontend_deployments = self._k8s_beta.list_namespaced_deployment(
                 namespace=self.k8s_namespace,
@@ -431,16 +456,27 @@ class KubernetesContainerManager(ContainerManager):
                     cluster_name=self.cluster_name)).items
             self.num_frontend_replicas = len(query_frontend_deployments)
 
-            metrics_ports = self._k8s_v1.read_namespaced_service(
+            v1service = self._k8s_v1.read_namespaced_service(
                 name="metrics-at-{cluster_name}".format(
                     cluster_name=self.cluster_name),
-                namespace=self.k8s_namespace).spec.ports
+                namespace=self.k8s_namespace)
+            metrics_ports = v1service.spec.ports
             for p in metrics_ports:
                 if p.name == "9090":
                     self.clipper_metric_port = p.node_port
-                    self.logger.info(
-                        "Setting Clipper metric port to {}".format(
-                            self.clipper_metric_port))
+
+            if self.service_types['metric'] in [CLUSTER_IP, NODE_PORT]:
+                self.logger.info("Setting Clipper metric port to {port}".format(
+                    port=self.clipper_metric_port))
+            elif self.service_types['metric'] == LOAD_BALANCER:
+                self.clipper_metric_ip = v1service.status.load_balancer.ingress[0].ip
+                self.logger.info("Setting Clipper metric port to {ip}:{port}"
+                                 .format(ip=self.clipper_metric_ip,
+                                         port=self.clipper_metric_port))
+            else:
+                msg = "Unknown service_type of metric: {}".format(
+                    self.service_types['metric'])
+                raise ClipperException(msg)
 
         except ApiException as e:
             logging.warning(
@@ -611,6 +647,10 @@ class KubernetesContainerManager(ContainerManager):
                 "Exception deleting kubernetes resources: {}".format(e))
 
     def get_admin_addr(self):
+        if self.service_types['management'] == LOAD_BALANCER:
+            return "{host}:{port}".format(host=self.clipper_management_ip,
+                                          port=self.clipper_management_port)
+
         if self.use_k8s_proxy:
             return ("{proxy_addr}/api/v1/namespaces/{ns}/"
                     "services/mgmt-frontend-at-{cluster}:{port}/proxy").format(
@@ -625,6 +665,10 @@ class KubernetesContainerManager(ContainerManager):
                 port=self.clipper_management_port)
 
     def get_query_addr(self):
+        if self.service_types['query'] == LOAD_BALANCER:
+            return "{host}:{port}".format(host=self.clipper_query_ip,
+                                          port=self.clipper_query_port)
+
         if self.use_k8s_proxy:
             return (
                 "{proxy_addr}/api/v1/namespaces/{ns}/"
@@ -638,6 +682,10 @@ class KubernetesContainerManager(ContainerManager):
                 host=self.external_node_hosts[0], port=self.clipper_query_port)
 
     def get_metric_addr(self):
+        if self.service_types['metric'] == LOAD_BALANCER:
+            return "{host}:{port}".format(host=self.clipper_metric_ip,
+                                          port=self.clipper_metric_port)
+
         if self.use_k8s_proxy:
             return ("{proxy_addr}/api/v1/namespaces/{ns}/"
                     "services/metrics-at-{cluster}:{port}/proxy").format(

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_container_manager.py
@@ -198,7 +198,7 @@ class KubernetesContainerManager(ContainerManager):
             if len(inter_keys) > 0:
                 raise ClipperException(
                     f"Wrong keys in service_types: {str(inter_keys)}")
-            inter_values = set(service_types.values()).intersection(OFFICIAL_K8S_SERVICE_TYPE)
+            inter_values = set(service_types.values()).difference(OFFICIAL_K8S_SERVICE_TYPE)
             if len(inter_values) > 0:
                 raise ClipperException(
                     f"Wrong values in service_types: {str(inter_values)}")

--- a/clipper_admin/clipper_admin/kubernetes/mgmt-frontend-service.yaml
+++ b/clipper_admin/clipper_admin/kubernetes/mgmt-frontend-service.yaml
@@ -6,7 +6,7 @@ metadata:
     ai.clipper.name: mgmt-frontend
   name: mgmt-frontend-at-{{ cluster_name }}
 spec:
-  type: NodePort
+  type: {{ service_type }}
   ports:
   - name: "1338"
     port: 1338

--- a/clipper_admin/clipper_admin/kubernetes/prom_service.yaml
+++ b/clipper_admin/clipper_admin/kubernetes/prom_service.yaml
@@ -6,7 +6,7 @@ metadata:
     ai.clipper.name: metrics
   name: metrics-at-{{ cluster_name }}
 spec:
-  type: NodePort
+  type: {{ service_type }}
   ports:
   - name: "9090"
     port: 9090

--- a/clipper_admin/clipper_admin/kubernetes/query-frontend-rpc-service.yaml
+++ b/clipper_admin/clipper_admin/kubernetes/query-frontend-rpc-service.yaml
@@ -6,7 +6,7 @@ metadata:
     ai.clipper.name: query-frontend
   name: {{ name }}-at-{{ cluster_name }}
 spec:
-  type: NodePort
+  type: {{ service_type }}
   ports:
   - name: "7000"
     port: 7000

--- a/clipper_admin/clipper_admin/kubernetes/query-frontend-service.yaml
+++ b/clipper_admin/clipper_admin/kubernetes/query-frontend-service.yaml
@@ -6,7 +6,7 @@ metadata:
     ai.clipper.name: query-frontend
   name: query-frontend-at-{{ cluster_name }}
 spec:
-  type: NodePort
+  type: {{ service_type }}
   ports:
   - name: "1337"
     port: 1337

--- a/clipper_admin/clipper_admin/kubernetes/redis-service.yaml
+++ b/clipper_admin/clipper_admin/kubernetes/redis-service.yaml
@@ -6,7 +6,7 @@ metadata:
     ai.clipper.name: redis
   name: {{ deployment_name }} # Cluster name included
 spec:
-  type: NodePort
+  type: {{ service_type }}
   ports:
   - name: "6379"
     port: {{ public_redis_port }}

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -18,7 +18,8 @@ import random
 from argparse import ArgumentParser
 import logging
 
-from test_utils import get_docker_client, create_docker_connection, fake_model_data
+from test_utils import (get_docker_client, create_docker_connection,
+                        create_kubernetes_connection, fake_model_data)
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -35,6 +36,7 @@ logging.basicConfig(
     level=logging.INFO)
 
 logger = logging.getLogger(__name__)
+
 
 class ClipperManagerTestCaseShort(unittest.TestCase):
     def setUp(self):
@@ -559,6 +561,46 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             None,
             pkgs_to_install=["sympy==1.1.*"])
 
+    def test_service_types_of_kubernetes_container_manager(self):
+        logger.info("Test that service_types is 'dict' type or not")
+        service_types = [
+            'redis',
+            'management',
+            'query',
+            'query-rpc',
+            'metric'
+        ]
+        with self.assertRaises(cl.ClipperException) as c:
+            create_kubernetes_connection(
+                cleanup=True, new_name=self.name, service_types=service_types)
+        self.assertTrue("service_types must be 'dict' type" in str(c.exception))
+
+        logger.info("Test that service_types has wrong keys or not")
+        service_types = {
+            'redis': 'NodePort',
+            # 'management': 'NodePort',  # for test
+            'query': 'NodePort',
+            'query-rpc': 'NodePort',
+            'metric': 'NodePort'
+        }
+        with self.assertRaises(cl.ClipperException) as c:
+            create_kubernetes_connection(
+                cleanup=True, new_name=self.name, service_types=service_types)
+        self.assertTrue("service_types has wrong keys" in str(c.exception))
+
+        logger.info("Test that service_type has wrong values or not")
+        service_types = {
+            'redis': 'NodePort',
+            'management': 'NodePort',
+            'query': 'NodePort',
+            'query-rpc': 'WRONG_K8S_SERVICE_TYPE',  # for test
+            'metric': 'NodePort'
+        }
+        with self.assertRaises(cl.ClipperException) as c:
+            create_kubernetes_connection(
+                cleanup=True, new_name=self.name, service_types=service_types)
+        self.assertTrue("service_type has wrong values" in str(c.exception))
+
 
 class ClipperManagerTestCaseLong(unittest.TestCase):
     cluster_name = "admin-l-{}".format(random.randint(0, 50000))
@@ -851,6 +893,7 @@ SHORT_TEST_ORDERING = [
     'test_build_model_with_custom_packages',
     'test_delete_application_correct',
     'test_query_specific_model_version',
+    'test_service_types_of_kubernetes_container_manager',
 ]
 
 LONG_TEST_ORDERING = [

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -589,7 +589,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
                 cleanup=True, new_name=self.name, service_types=service_types)
         self.assertTrue("service_types has unknown keys" in str(c.exception))
 
-        logger.info("Test that service_type has unknown values or not")
+        logger.info("Test that service_types has unknown values or not")
         service_types = {
             'redis': 'NodePort',
             'management': 'NodePort',
@@ -600,9 +600,9 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         with self.assertRaises(cl.ClipperException) as c:
             create_kubernetes_connection(
                 cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("service_type has unknown values" in str(c.exception))
+        self.assertTrue("service_types has unknown values" in str(c.exception))
 
-        logger.info("Test that service_type has 'ExternalName' value or not")
+        logger.info("Test that service_types has 'ExternalName' value or not")
         service_types = {
             'redis': 'NodePort',
             'management': 'NodePort',

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -562,59 +562,6 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             None,
             pkgs_to_install=["sympy==1.1.*"])
 
-    def test_service_types_of_kubernetes_container_manager(self):
-        logger.info("Test that service_types is 'dict' type or not")
-        service_types = [
-            'redis',
-            'management',
-            'query',
-            'query-rpc',
-            'metric'
-        ]
-        with self.assertRaises(cl.ClipperException) as c:
-            create_kubernetes_connection(
-                cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("service_types must be 'dict' type" in str(c.exception))
-
-        logger.info("Test that service_types has unknown keys or not")
-        service_types = {
-            'redis': 'NodePort',
-            'UNKNOWN_KEY': 'NodePort',  # for test
-            'query': 'NodePort',
-            'query-rpc': 'NodePort',
-            'metric': 'NodePort'
-        }
-        with self.assertRaises(cl.ClipperException) as c:
-            create_kubernetes_connection(
-                cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("service_types has unknown keys" in str(c.exception))
-
-        logger.info("Test that service_types has unknown values or not")
-        service_types = {
-            'redis': 'NodePort',
-            'management': 'NodePort',
-            'query': 'NodePort',
-            'query-rpc': 'UNKNOWN_VALUE',  # for test
-            'metric': 'NodePort'
-        }
-        with self.assertRaises(cl.ClipperException) as c:
-            create_kubernetes_connection(
-                cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("service_types has unknown values" in str(c.exception))
-
-        logger.info("Test that service_types has 'ExternalName' value or not")
-        service_types = {
-            'redis': 'NodePort',
-            'management': 'NodePort',
-            'query': 'NodePort',
-            'query-rpc': 'ExternalName',  # for test
-            'metric': 'NodePort'
-        }
-        with self.assertRaises(cl.ClipperException) as c:
-            create_kubernetes_connection(
-                cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("Clipper does not support" in str(c.exception))
-
 
 class ClipperManagerTestCaseLong(unittest.TestCase):
     cluster_name = "admin-l-{}".format(random.randint(0, 50000))
@@ -906,8 +853,7 @@ SHORT_TEST_ORDERING = [
     'test_test_predict_function',
     'test_build_model_with_custom_packages',
     'test_delete_application_correct',
-    'test_query_specific_model_version',
-    'test_service_types_of_kubernetes_container_manager',
+    'test_query_specific_model_version'
 ]
 
 LONG_TEST_ORDERING = [

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -576,10 +576,10 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
                 cleanup=True, new_name=self.name, service_types=service_types)
         self.assertTrue("service_types must be 'dict' type" in str(c.exception))
 
-        logger.info("Test that service_types has wrong keys or not")
+        logger.info("Test that service_types has unknown keys or not")
         service_types = {
             'redis': 'NodePort',
-            # 'management': 'NodePort',  # for test
+            'UNKNOWN_KEY': 'NodePort',  # for test
             'query': 'NodePort',
             'query-rpc': 'NodePort',
             'metric': 'NodePort'
@@ -587,20 +587,33 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         with self.assertRaises(cl.ClipperException) as c:
             create_kubernetes_connection(
                 cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("service_types has wrong keys" in str(c.exception))
+        self.assertTrue("service_types has unknown keys" in str(c.exception))
 
-        logger.info("Test that service_type has wrong values or not")
+        logger.info("Test that service_type has unknown values or not")
         service_types = {
             'redis': 'NodePort',
             'management': 'NodePort',
             'query': 'NodePort',
-            'query-rpc': 'WRONG_K8S_SERVICE_TYPE',  # for test
+            'query-rpc': 'UNKNOWN_VALUE',  # for test
             'metric': 'NodePort'
         }
         with self.assertRaises(cl.ClipperException) as c:
             create_kubernetes_connection(
                 cleanup=True, new_name=self.name, service_types=service_types)
-        self.assertTrue("service_type has wrong values" in str(c.exception))
+        self.assertTrue("service_type has unknown values" in str(c.exception))
+
+        logger.info("Test that service_type has 'ExternalName' value or not")
+        service_types = {
+            'redis': 'NodePort',
+            'management': 'NodePort',
+            'query': 'NodePort',
+            'query-rpc': 'ExternalName',  # for test
+            'metric': 'NodePort'
+        }
+        with self.assertRaises(cl.ClipperException) as c:
+            create_kubernetes_connection(
+                cleanup=True, new_name=self.name, service_types=service_types)
+        self.assertTrue("Clipper does not support" in str(c.exception))
 
 
 class ClipperManagerTestCaseLong(unittest.TestCase):

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -18,8 +18,7 @@ import random
 from argparse import ArgumentParser
 import logging
 
-from test_utils import (get_docker_client, create_docker_connection,
-                        create_kubernetes_connection, fake_model_data)
+from test_utils import get_docker_client, create_docker_connection, fake_model_data
 
 cur_dir = os.path.dirname(os.path.abspath(__file__))
 
@@ -36,7 +35,6 @@ logging.basicConfig(
     level=logging.INFO)
 
 logger = logging.getLogger(__name__)
-
 
 class ClipperManagerTestCaseShort(unittest.TestCase):
     def setUp(self):

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -121,6 +121,7 @@ def create_kubernetes_connection(cleanup=False,
                                  cleanup_name='default-cluster',
                                  new_name='default-cluster',
                                  connect_name='default-cluster',
+                                 service_types=None,
                                  namespace='default'):
     logger.info("Creating KubernetesContainerManager")
     cl = None
@@ -136,6 +137,7 @@ def create_kubernetes_connection(cleanup=False,
         cm = KubernetesContainerManager(
             cluster_name=cleanup_name,
             useInternalIP=USE_MINIKUBE,
+            service_types=service_types,
             kubernetes_proxy_addr=kubernetes_proxy_addr)
         cl = ClipperConnection(cm)
         cl.stop_all()
@@ -148,6 +150,7 @@ def create_kubernetes_connection(cleanup=False,
             kubernetes_proxy_addr=kubernetes_proxy_addr,
             namespace=namespace,
             useInternalIP=USE_MINIKUBE,
+            service_types=service_types,
             create_namespace_if_not_exists=True)
         cl = ClipperConnection(cm)
         cl.start_clipper(num_frontend_replicas=num_frontend_replicas)
@@ -157,6 +160,7 @@ def create_kubernetes_connection(cleanup=False,
             cm = KubernetesContainerManager(
                 cluster_name=connect_name,
                 useInternalIP=USE_MINIKUBE,
+                service_types=service_types,
                 kubernetes_proxy_addr=kubernetes_proxy_addr)
             cl = ClipperConnection(cm)
             cl.connect()


### PR DESCRIPTION
When creating a KubernetesManager object, you could define own ServiceTypes. For example,
```python
cm = KubernetesContainerManager(
         ....,
         service_types={
             'redis': 'NodePort',
             'management': 'LoadBalancer',
             'query': 'LoadBalancer',
             'query-rpc': 'ClusterIP',
             'metric': 'LoadBalancer'})
```
* related issue : https://github.com/ucbrise/clipper/issues/597