### PR TITLE
add urllib3 version restriction to requirements.txt

### DIFF
--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -6,3 +6,4 @@ kubernetes==6.0.0
 mock
 prometheus_client
 redis
+urllib3<1.25

--- a/clipper_admin/requirements.txt
+++ b/clipper_admin/requirements.txt
@@ -6,4 +6,6 @@ kubernetes==6.0.0
 mock
 prometheus_client
 redis
+# https://github.com/ucbrise/clipper/issues/678.
+# It should be removed once urllib3>=1.25 is compatible with requests library
 urllib3<1.25

--- a/dockerfiles/ClipperPy35DevDockerfile
+++ b/dockerfiles/ClipperPy35DevDockerfile
@@ -22,7 +22,7 @@ RUN echo '#!/bin/bash\npython3 "$@"' > /usr/bin/python && \
 
 RUN pip3 install cloudpickle==0.5.* pyzmq==17.0.* requests==2.18.* scikit-learn==0.19.* \
   numpy==1.14.* pyyaml==3.12.* docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
-  xgboost==0.7.* urllib3==1.24.*
+  xgboost==0.7.* urllib3==1.24.* # CI is broken when urllib3's version is 1.25.1. Delete urllib3==1.24.* later once version compatibility is stabilized
 
 # Install PyTorch
 RUN pip3 install torch==1.0.* torchvision==0.2.*

--- a/dockerfiles/ClipperPy35DevDockerfile
+++ b/dockerfiles/ClipperPy35DevDockerfile
@@ -22,7 +22,7 @@ RUN echo '#!/bin/bash\npython3 "$@"' > /usr/bin/python && \
 
 RUN pip3 install cloudpickle==0.5.* pyzmq==17.0.* requests==2.18.* scikit-learn==0.19.* \
   numpy==1.14.* pyyaml==3.12.* docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
-  xgboost==0.7.*
+  xgboost==0.7.* urllib3==1.24.*
 
 # Install PyTorch
 RUN pip3 install torch==1.0.* torchvision==0.2.*


### PR DESCRIPTION
Details are in https://github.com/ucbrise/clipper/issues/678. Once `requests` library starts to be compatible with `urllib3 >= 1.25`, we should remove this line. 