### PR TITLE
#692: Added get_metric_addr to the ClipperConnection

### DIFF
--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -1231,6 +1231,42 @@ class ClipperConnection(object):
             raise UnconnectedException()
         return self.cm.get_query_addr()
 
+    def get_admin_addr(self):
+        """Get the IP address of Management Frontend that manages and updates Clipper’s internal configuration state.
+
+        Returns
+        -------
+        str
+            The address as an IP address or hostname.
+
+        Raises
+        ------
+        :py:exc:`clipper.UnconnectedException`
+            versions. All replicas for each version of each model will be stopped.
+        """
+
+        if not self.connected:
+            raise UnconnectedException()
+        self.cm.get_admin_addr()
+
+    def get_metric_addr(self):
+        """Get the IP address of Prometheus metric server.
+
+        Returns
+        -------
+        str
+            The address as an IP address or hostname.
+
+        Raises
+        ------
+        :py:exc:`clipper.UnconnectedException`
+            versions. All replicas for each version of each model will be stopped.
+        """
+
+        if not self.connected:
+            raise UnconnectedException()
+        self.cm.get_metric_addr()
+
     def stop_models(self, model_names):
         """Stops all versions of the specified models.
 

--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -1231,24 +1231,6 @@ class ClipperConnection(object):
             raise UnconnectedException()
         return self.cm.get_query_addr()
 
-    def get_admin_addr(self):
-        """Get the IP address of Management Frontend that manages and updates Clipper’s internal configuration state.
-
-        Returns
-        -------
-        str
-            The address as an IP address or hostname.
-
-        Raises
-        ------
-        :py:exc:`clipper.UnconnectedException`
-            versions. All replicas for each version of each model will be stopped.
-        """
-
-        if not self.connected:
-            raise UnconnectedException()
-        self.cm.get_admin_addr()
-
     def get_metric_addr(self):
         """Get the IP address of Prometheus metric server.
 


### PR DESCRIPTION
Related to https://github.com/ucbrise/clipper/issues/692

# Summary
Currently `ClipperConnection` API does not include `get_admin_addr()` and `get_metric_addr()`. I added these two functions to ClipperConnection.

@simon-mo I believe our CI should automatically update our API docs once it is merged, but let me know if there are other steps to do to update API documentation. (http://docs.clipper.ai/en/v0.3.0/)