### PR TITLE
get_metric_addr(): Added a return statement

### DIFF
--- a/clipper_admin/clipper_admin/clipper_admin.py
+++ b/clipper_admin/clipper_admin/clipper_admin.py
@@ -1247,7 +1247,7 @@ class ClipperConnection(object):
 
         if not self.connected:
             raise UnconnectedException()
-        self.cm.get_metric_addr()
+        return self.cm.get_metric_addr()
 
     def stop_models(self, model_names):
         """Stops all versions of the specified models.


### PR DESCRIPTION
I don't know how we missed this, but we forgot to add a return statement for `get_metric_addr()`. It fixes the problem.  