### PR TITLE
[CI] Recover CI job failures

### DIFF
--- a/bin/retry_with_timeout.py
+++ b/bin/retry_with_timeout.py
@@ -2,6 +2,7 @@ import argparse
 import subprocess
 import sys
 import time
+from random import randint
 
 
 def timeout_to_float(s):
@@ -63,7 +64,6 @@ def run_once_with_timeout(command_to_run, timeout):
                 return 1
 
 
-
 for try_num in range(args.retry + 1):
     print(
         "Starting Trial {try_num} with timeout {timeout} seconds".format(
@@ -74,6 +74,10 @@ for try_num in range(args.retry + 1):
     if return_code == 0:
         print("Success!")
         sys.exit(0)
+    else:
+        sleep_time = randint(60, 600)  # 1min ~ 10min
+        print("Sleep {}".format(sleep_time))
+        time.sleep(sleep_time)
 
 print("All retry failed.")
 sys.exit(1)

--- a/bin/retry_with_timeout.py
+++ b/bin/retry_with_timeout.py
@@ -64,6 +64,13 @@ def run_once_with_timeout(command_to_run, timeout):
                 return 1
 
 
+# If multiple tests are running at the same time, there may be a problem that
+# the ports used by each test collide. To avoid this problem, wait for a random
+# amount of time and start the test.
+sleep_time = randint(60, 600)  # 1min ~ 10min
+print("Sleep {} secs before starting a test".format(sleep_time))
+time.sleep(sleep_time)
+
 for try_num in range(args.retry + 1):
     print(
         "Starting Trial {try_num} with timeout {timeout} seconds".format(

--- a/bin/run_ci.sh
+++ b/bin/run_ci.sh
@@ -49,4 +49,6 @@ make -j -f CI_build.Makefile kubernetes_test_containers
 make -j -f CI_build.Makefile all
 
 # Run all test
-make -j10 -f CI_test.Makefile all
+make -j10 -f CI_test.Makefile unittest
+make -j10 -f CI_test.Makefile integration_py2
+make -j10 -f CI_test.Makefile integration_py3

--- a/bin/run_unittests.sh
+++ b/bin/run_unittests.sh
@@ -55,7 +55,7 @@ function randomize_redis_port {
         fi
       done
     fi
-    echo "$REDIS_PORT"
+    echo "randomized redis port: $REDIS_PORT"
 }
 
 trap clean_up SIGHUP SIGINT SIGTERM EXIT

--- a/bin/shipyard/clipper_test.cfg.py
+++ b/bin/shipyard/clipper_test.cfg.py
@@ -63,13 +63,13 @@ for name, test_to_run in DOCKER_INTEGRATION_TESTS.items():
     CIPrettyLogAction(
         name=f"integration_py2_{name}",
         command=generate_test_command(2, test_to_run),
-        tags="integration",
+        tags="integration_py2",
     )
 
     CIPrettyLogAction(
         name=f"integration_py3_{name}",
         command=generate_test_command(3, test_to_run),
-        tags="integration",
+        tags="integration_py3",
     )
 
 # Specify specific dependencies

--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -486,7 +486,9 @@ class DockerContainerManager(ContainerManager):
            (inspected is not None and inspected.get("State").get("Health").get("Status") == "healthy"):
             return
         else:
-            msg = "{} container is not running yet".format(name)
+            msg = "{} container is not running yet or broken. ".format(name) + \
+                  "We will try to run again. Please analyze logs if " + \
+                  "it keeps failing"
             raise ClipperException(msg)
 
     def _is_valid_logging_state_to_connect(self, all_labels):

--- a/clipper_admin/clipper_admin/docker/docker_container_manager.py
+++ b/clipper_admin/clipper_admin/docker/docker_container_manager.py
@@ -23,6 +23,7 @@ from .logging.docker_logging_utils import (
     get_default_log_config
 )
 from clipper_admin.docker.logging.fluentd import Fluentd
+from clipper_admin.decorators import retry
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +182,7 @@ class DockerContainerManager(ContainerManager):
         # Redis for cluster configuration
         if not self.external_redis:
             self.logger.info("Starting managed Redis instance in Docker")
+            redis_name = "redis-{}".format(random.randint(0, 100000))
             self.redis_port = find_unbound_port(self.redis_port)
             redis_labels = self.common_labels.copy()
             redis_labels[CLIPPER_DOCKER_PORT_LABELS['redis']] = str(
@@ -189,18 +191,19 @@ class DockerContainerManager(ContainerManager):
                 'redis:alpine',
                 "redis-server --port %s" % CLIPPER_INTERNAL_REDIS_PORT,
                 log_config=self.log_config,
-                name="redis-{}".format(random.randint(
-                    0, 100000)),  # generate a random name
+                name=redis_name,
                 ports={
                     '%s/tcp' % CLIPPER_INTERNAL_REDIS_PORT: self.redis_port
                 },
                 labels=redis_labels,
                 **self.extra_container_kwargs)
             self.redis_ip = redis_container.name
+            self._check_container_status(redis_name)
 
         # frontend management
         mgmt_cmd = "--redis_ip={redis_ip} --redis_port={redis_port}".format(
             redis_ip=self.redis_ip, redis_port=CLIPPER_INTERNAL_REDIS_PORT)
+        mgmt_name = "mgmt_frontend-{}".format(random.randint(0, 100000))
         self.clipper_management_port = find_unbound_port(
             self.clipper_management_port)
         mgmt_labels = self.common_labels.copy()
@@ -211,14 +214,14 @@ class DockerContainerManager(ContainerManager):
             mgmt_frontend_image,
             mgmt_cmd,
             log_config=self.log_config,
-            name="mgmt_frontend-{}".format(random.randint(
-                0, 100000)),  # generate a random name
+            name=mgmt_name,
             ports={
                 '%s/tcp' % CLIPPER_INTERNAL_MANAGEMENT_PORT:
                 self.clipper_management_port
             },
             labels=mgmt_labels,
             **self.extra_container_kwargs)
+        self._check_container_status(mgmt_name)
 
         # query frontend
         query_cmd = ("--redis_ip={redis_ip} --redis_port={redis_port} "
@@ -254,6 +257,7 @@ class DockerContainerManager(ContainerManager):
             },
             labels=query_labels,
             **self.extra_container_kwargs)
+        self._check_container_status(query_name)
 
         # Metric Section
         query_frontend_metric_name = "query_frontend_exporter-{}".format(
@@ -262,6 +266,7 @@ class DockerContainerManager(ContainerManager):
             query_frontend_metric_name, self.docker_client, query_name,
             frontend_exporter_image, self.common_labels,
             self.log_config, self.extra_container_kwargs)
+        self._check_container_status(query_frontend_metric_name)
 
         self.prom_config_path = tempfile.NamedTemporaryFile(
             'w', suffix='.yml', delete=False).name
@@ -272,14 +277,18 @@ class DockerContainerManager(ContainerManager):
         setup_metric_config(query_frontend_metric_name, self.prom_config_path,
                             CLIPPER_INTERNAL_METRIC_PORT)
 
+        metric_frontend_name = "metric_frontend-{}".format(
+            random.randint(0, 100000))
         self.prometheus_port = find_unbound_port(self.prometheus_port)
         metric_labels = self.common_labels.copy()
         metric_labels[CLIPPER_DOCKER_PORT_LABELS['metric']] = str(
             self.prometheus_port)
         metric_labels[CLIPPER_METRIC_CONFIG_LABEL] = self.prom_config_path
-        run_metric_image(self.docker_client, metric_labels,
-                         self.prometheus_port, self.prom_config_path,
-                         self.log_config, self.extra_container_kwargs)
+        run_metric_image(metric_frontend_name, self.docker_client,
+                         metric_labels, self.prometheus_port,
+                         self.prom_config_path, self.log_config,
+                         self.extra_container_kwargs)
+        self._check_container_status(metric_frontend_name)
 
         self.connect()
 
@@ -404,15 +413,7 @@ class DockerContainerManager(ContainerManager):
                                                    image)
                 model_container_names.append(container_name)
             for name in model_container_names:
-                container = self.docker_client.containers.get(name)
-                while True:
-                    state = container.attrs.get("State")
-                    inspect_container = self.docker_client.api.inspect_container(name)
-                    if (state is not None and state.get("Status") == "running") or \
-                            (inspect_container is not None and
-                             inspect_container.get("State").get("Health").get("Status") == "healthy"):
-                        break
-                    time.sleep(3)
+                self._check_container_status(name)
 
         elif len(current_replicas) > num_replicas:
             num_extra = len(current_replicas) - num_replicas
@@ -474,6 +475,19 @@ class DockerContainerManager(ContainerManager):
                 c.stop()
             else:
                 c.kill()
+
+    # Wait for maximum 5 min.
+    @retry((docker.errors.NotFound, docker.errors.APIError, ClipperException),
+           tries=300, delay=1, backoff=1, logger=logger)
+    def _check_container_status(self, name):
+        state = self.docker_client.containers.get(name).attrs.get("State")
+        inspected = self.docker_client.api.inspect_container(name)
+        if (state is not None and state.get("Status") == "running") or \
+           (inspected is not None and inspected.get("State").get("Health").get("Status") == "healthy"):
+            return
+        else:
+            msg = "{} container is not running yet".format(name)
+            raise ClipperException(msg)
 
     def _is_valid_logging_state_to_connect(self, all_labels):
         if self.centralize_log and not self.logging_system.container_is_running(all_labels):

--- a/clipper_admin/clipper_admin/docker/docker_metric_utils.py
+++ b/clipper_admin/clipper_admin/docker/docker_metric_utils.py
@@ -4,7 +4,7 @@ import random
 from ..exceptions import ClipperException
 from ..container_manager import CLIPPER_INTERNAL_QUERY_PORT
 
-PROM_VERSION = "v2.1.0"
+PROM_VERSION = "v2.9.2"
 
 
 def get_prometheus_base_config():

--- a/clipper_admin/clipper_admin/docker/docker_metric_utils.py
+++ b/clipper_admin/clipper_admin/docker/docker_metric_utils.py
@@ -72,10 +72,12 @@ def setup_metric_config(query_frontend_metric_name, prom_config_path,
         yaml.dump(prom_config, f)
 
 
-def run_metric_image(docker_client, common_labels, prometheus_port,
-                     prom_config_path, log_config, extra_container_kwargs):
+def run_metric_image(metric_frontend_name, docker_client, common_labels,
+                     prometheus_port, prom_config_path, log_config,
+                     extra_container_kwargs):
     """
     Run the prometheus image.
+    :param metric_frontend_name: container name
     :param docker_client: The docker client object
     :param common_labels: Labels to pass in
     :param prom_config_path: Where config file lives
@@ -95,7 +97,7 @@ def run_metric_image(docker_client, common_labels, prometheus_port,
     docker_client.containers.run(
         "prom/prometheus:{}".format(PROM_VERSION),
         metric_cmd,
-        name="metric_frontend-{}".format(random.randint(0, 100000)),
+        name=metric_frontend_name,
         ports={'9090/tcp': prometheus_port},
         log_config=log_config,
         volumes={

--- a/clipper_admin/clipper_admin/kubernetes/kubernetes_metric_utils.py
+++ b/clipper_admin/clipper_admin/kubernetes/kubernetes_metric_utils.py
@@ -1,1 +1,1 @@
-PROM_VERSION = "v2.1.0"
+PROM_VERSION = "v2.9.2"

--- a/containers/python/rpc.py
+++ b/containers/python/rpc.py
@@ -761,4 +761,4 @@ def start_metric_server():
     Popen(cmd)
 
     # sleep is necessary because Popen returns immediately
-    time.sleep(1)
+    time.sleep(5)

--- a/dockerfiles/ClipperDevDockerfile
+++ b/dockerfiles/ClipperDevDockerfile
@@ -15,8 +15,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y -qq 
       && apt-get install -y -qq python python-dev python-pip libsodium18 \
       && rm -rf /var/lib/apt/lists/*
 
-RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* requests==2.18.* subprocess32==3.2.* scikit-learn==0.19.* \
-  numpy==1.14.* pyyaml==3.12.* docker==3.1.* kubernetes==6.0.* tensorflow==1.6.* mxnet==1.4.* pyspark==2.3.* \
+RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* requests==2.20.0 subprocess32==3.2.* scikit-learn==0.19.* \
+  numpy==1.14.* pyyaml>=4.2b1 docker==3.1.* kubernetes==6.0.* tensorflow==1.6.* mxnet==1.4.* pyspark==2.3.* \
   xgboost==0.7.* jsonschema==2.6.* psutil==5.4.* prometheus_client
 
 # Install PyTorch

--- a/dockerfiles/ClipperDevDockerfile
+++ b/dockerfiles/ClipperDevDockerfile
@@ -15,6 +15,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y -qq 
       && apt-get install -y -qq python python-dev python-pip libsodium18 \
       && rm -rf /var/lib/apt/lists/*
 
+ENV PIP_DEFAULT_TIMEOUT=100
+RUN pip install --upgrade pip
+
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* requests==2.20.0 subprocess32==3.2.* scikit-learn==0.19.* \
   numpy==1.14.* pyyaml>=4.2b1 docker==3.1.* kubernetes==6.0.* tensorflow==1.6.* mxnet==1.4.* pyspark==2.3.* \
   xgboost==0.7.* jsonschema==2.6.* psutil==5.4.* prometheus_client

--- a/dockerfiles/ClipperPy35DevDockerfile
+++ b/dockerfiles/ClipperPy35DevDockerfile
@@ -20,8 +20,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y -qq 
 RUN echo '#!/bin/bash\npython3 "$@"' > /usr/bin/python && \
     chmod +x /usr/bin/python
 
-RUN pip3 install cloudpickle==0.5.* pyzmq==17.0.* requests==2.18.* scikit-learn==0.19.* \
-  numpy==1.14.* pyyaml==3.12.* docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
+RUN pip3 install cloudpickle==0.5.* pyzmq==17.0.* requests==2.20.0 scikit-learn==0.19.* \
+  numpy==1.14.* pyyaml>=4.2b1 docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
   xgboost==0.7.* urllib3==1.24.* # CI is broken when urllib3's version is 1.25.1. Delete urllib3==1.24.* later once version compatibility is stabilized
 
 

--- a/dockerfiles/ClipperPy35DevDockerfile
+++ b/dockerfiles/ClipperPy35DevDockerfile
@@ -21,7 +21,7 @@ RUN echo '#!/bin/bash\npython3 "$@"' > /usr/bin/python && \
     chmod +x /usr/bin/python
 
 RUN pip3 install cloudpickle==0.5.* pyzmq==17.0.* requests==2.20.0 scikit-learn==0.19.* \
-  numpy==1.14.* pyyaml>=4.2b1 docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.1.* pyspark==2.3.* \
+  numpy==1.14.* pyyaml>=4.2b1 docker==3.1.* kubernetes==5.0.* tensorflow==1.6.* mxnet==1.4.* pyspark==2.3.* \
   xgboost==0.7.* urllib3==1.24.* # CI is broken when urllib3's version is 1.25.1. Delete urllib3==1.24.* later once version compatibility is stabilized
 
 

--- a/dockerfiles/ClipperPy35DevDockerfile
+++ b/dockerfiles/ClipperPy35DevDockerfile
@@ -16,6 +16,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y -qq 
       && apt-get install -y -qq python3 python3-dev python3-pip libsodium18 \
       && rm -rf /var/lib/apt/lists/*
 
+ENV PIP_DEFAULT_TIMEOUT=100
+RUN pip3 install --upgrade pip
+
 # Alias python to python3
 RUN echo '#!/bin/bash\npython3 "$@"' > /usr/bin/python && \
     chmod +x /usr/bin/python

--- a/dockerfiles/FrontendExporterDockerfile
+++ b/dockerfiles/FrontendExporterDockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Dan Crankshaw <dscrankshaw@gmail.com>"
 
 RUN mkdir -p /usr/src/app
 
-RUN pip install -q requests==2.18.* prometheus_client==0.1.* flatten_json==0.1.*
+RUN pip install -q requests==2.18.* prometheus_client==0.1.* flatten_json==0.1.* six==1.12.*
 
 COPY monitoring/front_end_exporter.py /usr/src/app
 ENTRYPOINT ["python", "/usr/src/app/front_end_exporter.py"]

--- a/dockerfiles/FrontendExporterDockerfile
+++ b/dockerfiles/FrontendExporterDockerfile
@@ -7,7 +7,7 @@ LABEL maintainer="Dan Crankshaw <dscrankshaw@gmail.com>"
 
 RUN mkdir -p /usr/src/app
 
-RUN pip install -q requests==2.18.* prometheus_client==0.1.* flatten_json==0.1.* six==1.12.*
+RUN pip install -q requests==2.20.0 prometheus_client==0.1.* flatten_json==0.1.* six==1.12.*
 
 COPY monitoring/front_end_exporter.py /usr/src/app
 ENTRYPOINT ["python", "/usr/src/app/front_end_exporter.py"]

--- a/dockerfiles/FrontendExporterDockerfile
+++ b/dockerfiles/FrontendExporterDockerfile
@@ -7,6 +7,9 @@ LABEL maintainer="Dan Crankshaw <dscrankshaw@gmail.com>"
 
 RUN mkdir -p /usr/src/app
 
+ENV PIP_DEFAULT_TIMEOUT=100
+RUN pip install --upgrade pip
+
 RUN pip install -q requests==2.20.0 prometheus_client==0.1.* flatten_json==0.1.* six==1.12.*
 
 COPY monitoring/front_end_exporter.py /usr/src/app

--- a/dockerfiles/Py2RPCDockerfile
+++ b/dockerfiles/Py2RPCDockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /model \
       && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
 
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
-    pyyaml==3.12.* jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
+    pyyaml>=4.2b1 jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
     numpy==1.14.* subprocess32==3.2.*
 
 COPY clipper_admin /clipper_admin/

--- a/dockerfiles/Py2RPCDockerfile
+++ b/dockerfiles/Py2RPCDockerfile
@@ -9,6 +9,9 @@ RUN mkdir -p /model \
       && apt-get update -qq \
       && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
 
+ENV PIP_DEFAULT_TIMEOUT=100
+RUN pip install --upgrade pip
+
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
     pyyaml>=4.2b1 jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
     numpy==1.14.* subprocess32==3.2.*

--- a/dockerfiles/Py35RPCDockerfile
+++ b/dockerfiles/Py35RPCDockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /model \
       && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
 
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
-    pyyaml==3.12.* jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
+    pyyaml>=4.2b1 jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
     numpy==1.14.*
 
 COPY clipper_admin /clipper_admin/

--- a/dockerfiles/Py35RPCDockerfile
+++ b/dockerfiles/Py35RPCDockerfile
@@ -9,6 +9,9 @@ RUN mkdir -p /model \
       && apt-get update -qq \
       && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
 
+ENV PIP_DEFAULT_TIMEOUT=100
+RUN pip install --upgrade pip
+
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
     pyyaml>=4.2b1 jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
     numpy==1.14.*

--- a/dockerfiles/Py36RPCDockerfile
+++ b/dockerfiles/Py36RPCDockerfile
@@ -10,7 +10,7 @@ RUN mkdir -p /model \
       && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
 
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
-    pyyaml==3.12.* jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
+    pyyaml>=4.2b1 jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
     numpy==1.14.*
 
 COPY clipper_admin /clipper_admin/

--- a/dockerfiles/Py36RPCDockerfile
+++ b/dockerfiles/Py36RPCDockerfile
@@ -9,6 +9,9 @@ RUN mkdir -p /model \
       && apt-get update -qq \
       && apt-get install -y -qq libzmq5 libzmq5-dev redis-server libsodium18 build-essential
 
+ENV PIP_DEFAULT_TIMEOUT=100
+RUN pip install --upgrade pip
+
 RUN pip install -q cloudpickle==0.5.* pyzmq==17.0.* prometheus_client==0.1.* \
     pyyaml>=4.2b1 jsonschema==2.6.* redis==2.10.* psutil==5.4.* flask==0.12.2 \
     numpy==1.14.*

--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -71,7 +71,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
     def test_register_application_correct(self):
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         app_name = "testapp"
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
@@ -84,7 +84,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         app_name = "testapp"
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
         with self.assertRaises(cl.ClipperException) as context:
@@ -94,7 +94,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
     def test_unregister_application_correct(self):
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         app_name = "testapp"
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
@@ -107,7 +107,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         app_name = "testapp"
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
         result = self.clipper_conn.get_linked_models(app_name)
@@ -118,7 +118,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         app_name = "testapp"
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
 
@@ -135,7 +135,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         app_name = "testapp"
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
 
@@ -154,7 +154,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
         app_name = "testapp"
         input_type = "doubles"
         default_output = "DEFAULT"
-        slo_micros = 30000
+        slo_micros = 3000000
         self.clipper_conn.register_application(app_name, input_type,
                                                default_output, slo_micros)
         result = self.clipper_conn.get_app_info(app_name)
@@ -462,7 +462,7 @@ class ClipperManagerTestCaseShort(unittest.TestCase):
             name=app_name,
             input_type="doubles",
             default_output="DEFAULT",
-            slo_micros=100000)
+            slo_micros=3000000)
 
         deploy_python_closure(
             self.clipper_conn,
@@ -580,7 +580,7 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         self.model_name_5 = "m8"
         self.input_type = "doubles"
         self.default_output = "DEFAULT"
-        self.latency_slo_micros = 30000
+        self.latency_slo_micros = 3000000
 
         self.clipper_conn.register_application(
             self.app_name_1, self.input_type, self.default_output,

--- a/integration-tests/clipper_metric_docker.py
+++ b/integration-tests/clipper_metric_docker.py
@@ -104,7 +104,7 @@ if __name__ == '__main__':
         cleanup=False, start_clipper=True, new_name=cluster_name)
     python_deployer.create_endpoint(
         clipper_conn, "simple-example", "doubles", feature_sum, num_replicas=2)
-    time.sleep(2)
+    time.sleep(10)
     try:
         logger.info(
             "Making 100 predictions using two model container; Should takes 25 seconds."

--- a/integration-tests/clipper_metric_docker.py
+++ b/integration-tests/clipper_metric_docker.py
@@ -41,7 +41,7 @@ def get_metrics_config():
 def get_matched_query(metric_addr, metric_name):
     query = gen_match_query(metric_addr, metric_name)
     logger.info("Querying: {}".format(query))
-    print('test why docker query is broken: {}'.format(repr(query)))
+    logger.info('test why docker query is broken: {}'.format(repr(query)))
     res = requests.get(query).json()
     logger.info(res)
     return res
@@ -96,11 +96,11 @@ if __name__ == '__main__':
     time.sleep(10)
     try:
         logger.info(
-            "Making 100 predictions using two model container; Should takes 25 seconds."
+            "Making 100 predictions using two model container; Should takes 50 seconds."
         )
         for _ in range(100):
             predict(clipper_conn.get_query_addr(), np.random.random(200))
-            time.sleep(0.2)
+            time.sleep(0.5)
 
         logger.info("Test 1: Checking status of 3 node exporter")
         check_target_health("http://{}".format(clipper_conn.cm.get_metric_addr()))

--- a/integration-tests/clipper_metric_docker.py
+++ b/integration-tests/clipper_metric_docker.py
@@ -3,13 +3,13 @@ from __future__ import print_function
 import json
 import logging
 import os
-import subprocess
 import sys
 import time
 import random
 
 import numpy as np
 import requests
+from requests.exceptions import RequestException
 import yaml
 from test_utils import log_clipper_state, create_docker_connection
 
@@ -17,6 +17,16 @@ cur_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.abspath("%s/../clipper_admin" % cur_dir))
 from clipper_admin import ClipperConnection, DockerContainerManager
 from clipper_admin.deployers import python as python_deployer
+from clipper_admin.decorators import retry
+from clipper_admin.exceptions import ClipperException
+
+logging.basicConfig(
+    format=
+    '%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
+    datefmt='%y-%m-%d:%H:%M:%S',
+    level=0)
+
+logger = logging.getLogger(__name__)
 
 
 def predict(addr, x):
@@ -38,12 +48,16 @@ def get_metrics_config():
     return conf
 
 
+# Wait for maximum 5 min.
+@retry((RequestException, ClipperException),
+       tries=300, delay=1, backoff=1, logger=logger)
 def get_matched_query(metric_addr, metric_name):
     query = gen_match_query(metric_addr, metric_name)
     logger.info("Querying: {}".format(query))
-    print('test why docker query is broken: {}'.format(repr(query)))
     res = requests.get(query).json()
     logger.info(res)
+    if len(res['data']) == 0:
+        raise ClipperException("returned data is empty")
     return res
 
 
@@ -52,11 +66,16 @@ def parse_res_and_assert_node(res, node_num):
     assert len(res['data']) == node_num
 
 
+# Wait for maximum 5 min.
+@retry((RequestException, ClipperException),
+       tries=300, delay=1, backoff=1, logger=logger)
 def check_target_health(metric_addr):
     query = metric_addr + '/api/v1/targets'
     logger.info("Querying: {}".format(query))
     res = requests.get(query).json()
     logger.info(res)
+    if len(res['data']) == 0:
+        raise ClipperException("returned data is empty")
     assert res['status'] == 'success'
 
     active_targets = res['data']['activeTargets']
@@ -77,14 +96,6 @@ def log_docker_ps(clipper_conn):
 if __name__ == '__main__':
     # metric_addr = "http://localhost:9090"
     gen_match_query = lambda addr, name: "http://{addr}/api/v1/series?match[]={name}".format(addr=addr, name=name)
-
-    logging.basicConfig(
-        format=
-        '%(asctime)s %(levelname)-8s [%(filename)s:%(lineno)d] %(message)s',
-        datefmt='%y-%m-%d:%H:%M:%S',
-        level=0)
-
-    logger = logging.getLogger(__name__)
 
     logger.info("Start Metric Test (0/1): Running 2 Replicas")
 

--- a/integration-tests/test_utils.py
+++ b/integration-tests/test_utils.py
@@ -117,6 +117,7 @@ def create_docker_connection(cleanup=False,
             clipper_rpc_port=find_unbound_port(),
             fluentd_port=find_unbound_port(),
             redis_port=find_unbound_port(),
+            prometheus_port=find_unbound_port(),
         )
         cl = ClipperConnection(cm)
         cl.stop_all(graceful=False)
@@ -134,6 +135,7 @@ def create_docker_connection(cleanup=False,
                 clipper_rpc_port=find_unbound_port(),
                 fluentd_port=find_unbound_port(),
                 redis_port=find_unbound_port(),
+                prometheus_port=find_unbound_port(),
                 use_centralized_log=use_centralized_log
             )
             cl = ClipperConnection(cm)

--- a/src/frontends/src/query_frontend_tests.cpp
+++ b/src/frontends/src/query_frontend_tests.cpp
@@ -498,11 +498,11 @@ TEST_F(QueryFrontendTest, TestReadInvalidModelVersionAtStartup) {
                         container_name, model_path, DEFAULT_BATCH_SIZE));
   // Not setting the version number will cause get_current_model_version()
   // to return -1, and the RequestHandler should then throw a runtime_error.
-  ASSERT_THROW(RequestHandler<QueryProcessor>("127.0.0.1",
-                                              QUERY_FRONTEND_PORT,
-                                              DEFAULT_THREAD_POOL_SIZE,
-                                              DEFAULT_TIMEOUT_REQUEST,
-                                              DEFAULT_TIMEOUT_CONTENT),
+  ASSERT_THROW(RequestHandler<MockQueryProcessor>("127.0.0.1",
+                                                  QUERY_FRONTEND_PORT,
+                                                  DEFAULT_THREAD_POOL_SIZE,
+                                                  DEFAULT_TIMEOUT_REQUEST,
+                                                  DEFAULT_TIMEOUT_CONTENT),
                std::runtime_error);
 }
 


### PR DESCRIPTION
Clipper CI has always failed since May 17, 2019. To resolve this problem,

* integration tests
  * Fix clipper_admin_tests.py in integration-tests.
  * Fix clipper_metric_docker.py in integration-tests.
* unit tests
  * Fix query_frontend_tests' bug.
* Dockerfile
  * Add six==1.12.* to FrontendExporterDockerfile.
  * Change pyyaml and requests version
    * pyyaml : ==3.12.* -> >=4.2b1
    * requests : ==2.18.* -> ==2.20.0
  * Update mxnet's version on ClipperPy35DevDockerfile. (1.1.* -> 1.4.*)
  * Upgrade pip to latest when building some Docker images.
* build system
  * split all tests with three parts
    * unittest
    * integration_py2
    * integration_py3
* improvements
  * Check Docker container's status after running it.
  * Increase sleep time after starting the metric server in rpc.py. (1s -> 5s)
  * Upgrade Prometheus version from `v2.1.0` to `v2.9.2`.