### PR TITLE
Enable TCP keep alive for redox

### DIFF
--- a/dockerfiles/ClipperPy35TestsDockerfile
+++ b/dockerfiles/ClipperPy35TestsDockerfile
@@ -10,7 +10,9 @@ COPY ./ /clipper
 
 # Patch Clipper
 RUN cd /clipper/src/libs/spdlog \
-    && git apply ../patches/make_spdlog_compile_linux.patch
+    && git apply ../patches/make_spdlog_compile_linux.patch \
+    && cd /clipper/src/libs/redox \
+    && git apply ../patches/redis_keepalive.patch
 
 # Set version as git hash
 RUN cd /clipper && echo ${CODE_VERSION} > VERSION

--- a/dockerfiles/ClipperTestsDockerfile
+++ b/dockerfiles/ClipperTestsDockerfile
@@ -15,6 +15,8 @@ RUN pip install -q -e /clipper/clipper_admin
 
 RUN cd /clipper/src/libs/spdlog \
     && git apply ../patches/make_spdlog_compile_linux.patch \
+    && cd /clipper/src/libs/redox \
+    && git apply ../patches/redis_keepalive.patch \
     && cd /clipper \
     && ./configure \
     && cd debug \

--- a/dockerfiles/ManagementFrontendDockerfile
+++ b/dockerfiles/ManagementFrontendDockerfile
@@ -8,6 +8,8 @@ COPY ./ /clipper
 
 RUN cd /clipper/src/libs/spdlog \
     && git apply ../patches/make_spdlog_compile_linux.patch \
+    && cd /clipper/src/libs/redox \
+    && git apply ../patches/redis_keepalive.patch \
     && cd /clipper \
     && ./configure --cleanup-quiet \
     && ./configure --release \

--- a/dockerfiles/QueryFrontendDockerfile
+++ b/dockerfiles/QueryFrontendDockerfile
@@ -8,6 +8,8 @@ COPY ./ /clipper
 
 RUN cd /clipper/src/libs/spdlog \
     && git apply ../patches/make_spdlog_compile_linux.patch \
+    && cd /clipper/src/libs/redox \
+    && git apply ../patches/redis_keepalive.patch \
     && cd /clipper \
     && ./configure --cleanup-quiet \
     && ./configure --release \

--- a/src/libs/patches/redis_keepalive.patch
+++ b/src/libs/patches/redis_keepalive.patch
@@ -1,0 +1,11 @@
+diff -urN redox.org/src/client.cpp redox/src/client.cpp
+--- redox.org/src/client.cpp	2019-05-31 18:58:11.104997558 +0900
++++ redox/src/client.cpp	2019-05-31 20:34:21.826154449 +0900
+@@ -57,6 +57,7 @@
+ 
+   // Connect over TCP
+   ctx_ = redisAsyncConnect(host.c_str(), port);
++  redisEnableKeepAlive(&(ctx_->c));
+ 
+   if (!initHiredis())
+     return false;


### PR DESCRIPTION
### Issue
* https://github.com/ucbrise/clipper/issues/715

### Note
 * helps keep connections between mgmt_frontend, query_frontend and redis for a long idle time on k8s