### PR TITLE
Queue batch prediction tasks collectively

### DIFF
--- a/integration-tests/clipper_admin_tests.py
+++ b/integration-tests/clipper_admin_tests.py
@@ -791,6 +791,45 @@ class ClipperManagerTestCaseLong(unittest.TestCase):
         self.assertGreaterEqual(num_max_batch_queries,
                                 int(total_num_queries * .7))
 
+    def test_fixed_batch_size_model_processes_all_inputs_as_single_batch(
+            self):
+        model_version = 1
+
+        def predict_func(inputs):
+            batch_size = len(inputs)
+            return [str(batch_size) for _ in inputs]
+
+        fixed_batch_size = 9
+        total_num_queries = fixed_batch_size
+        deploy_python_closure(
+            self.clipper_conn,
+            self.model_name_4,
+            model_version,
+            self.input_type,
+            predict_func,
+            batch_size=fixed_batch_size)
+        self.clipper_conn.link_model_to_app(self.app_name_4, self.model_name_4)
+        time.sleep(60)
+
+        addr = self.clipper_conn.get_query_addr()
+        url = "http://{addr}/{app}/predict".format(
+            addr=addr, app=self.app_name_4)
+        test_input = [[float(x) + (j * .001) for x in range(5)]
+                      for j in range(total_num_queries)]
+        req_json = json.dumps({'input_batch': test_input})
+        headers = {'Content-type': 'application/json'}
+        response = requests.post(url, headers=headers, data=req_json)
+        parsed_response = response.json()
+        num_max_batch_queries = 0
+        for prediction in parsed_response["batch_predictions"]:
+            batch_size = prediction["output"]
+            if batch_size != self.default_output and int(
+                    batch_size) == fixed_batch_size:
+                num_max_batch_queries += 1
+
+        self.assertEqual(num_max_batch_queries,
+                                total_num_queries)
+
     def test_remove_inactive_container(self):
         container_name = "{}/noop-container:{}".format(clipper_registry,
                                                        clipper_version)
@@ -902,7 +941,8 @@ LONG_TEST_ORDERING = [
     'test_deployed_model_queried_successfully',
     'test_batch_queries_returned_successfully',
     'test_deployed_python_closure_queried_successfully',
-    'test_fixed_batch_size_model_processes_specified_query_batch_size_when_saturated'
+    'test_fixed_batch_size_model_processes_specified_query_batch_size_when_saturated',
+    'test_fixed_batch_size_model_processes_all_inputs_as_single_batch'
 ]
 
 if __name__ == '__main__':

--- a/src/libclipper/include/clipper/query_processor.hpp
+++ b/src/libclipper/include/clipper/query_processor.hpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <tuple>
 #include <utility>
+#include <vector>
 
 #include <folly/futures/Future.h>
 
@@ -34,8 +35,8 @@ class QueryProcessor {
   QueryProcessor(QueryProcessor&& other) = default;
   QueryProcessor& operator=(QueryProcessor&& other) = default;
 
-  folly::Future<Response> predict(Query query);
-  folly::Future<FeedbackAck> update(FeedbackQuery feedback);
+  folly::Future<std::vector<Response>> predict(const Query& query);
+  folly::Future<FeedbackAck> update(const FeedbackQuery& feedback);
 
   std::shared_ptr<StateDB> get_state_table() const;
 

--- a/src/libclipper/include/clipper/task_executor.hpp
+++ b/src/libclipper/include/clipper/task_executor.hpp
@@ -486,12 +486,17 @@ class TaskExecutor {
     std::vector<folly::Future<Output>> output_futures;
     boost::shared_lock<boost::shared_mutex> lock(model_queues_mutex_);
     for (const auto &m : models) {
+      if (active_containers_->get_replicas_for_model(m).empty()) {
+        log_error_formatted(LOGGING_TAG_TASK_EXECUTOR,
+                            "No active model containers for model: {} : {}",
+                            m.get_name(), m.get_id());
+        continue;
+      }
       // add each task to the queue corresponding to its associated model
       auto model_queue_entry = model_queues_.find(m);
 
       if (model_queue_entry != model_queues_.end()) {
         std::vector<PredictTask> model_tasks;
-        size_t initial_outputs_size = output_futures.size();
         for (const auto &t : tasks) {
           auto cache_result = cache_->fetch(m, t.input_);
 
@@ -504,14 +509,6 @@ class TaskExecutor {
               auto cur_model_metric = cur_model_metric_entry->second;
               cur_model_metric.cache_hit_ratio_->increment(1, 1);
             }
-          } else if (active_containers_->get_replicas_for_model(m).empty()) {
-            log_error_formatted(LOGGING_TAG_TASK_EXECUTOR,
-                                "No active model containers for model: {} : {}",
-                                m.get_name(), m.get_id());
-            model_tasks.clear();
-            output_futures.erase(output_futures.begin() + initial_outputs_size,
-                                 output_futures.end());
-            break;
           } else {
             output_futures.push_back(std::move(cache_result));
             model_tasks.push_back(t);

--- a/src/libclipper/src/datatypes.cpp
+++ b/src/libclipper/src/datatypes.cpp
@@ -223,22 +223,21 @@ rpc::PredictionResponse::deserialize_prediction_response(
 }
 
 Query::Query(std::string label, long user_id,
-             std::shared_ptr<PredictionData> input, long latency_budget_micros,
-             std::string selection_policy,
+             std::vector<std::shared_ptr<PredictionData>> input_batch,
+             long latency_budget_micros, std::string selection_policy,
              std::vector<VersionedModelId> candidate_models)
     : label_(std::move(label)),
       user_id_(user_id),
-      input_(std::move(input)),
+      input_batch_(std::move(input_batch)),
       latency_budget_micros_(latency_budget_micros),
       selection_policy_(std::move(selection_policy)),
       candidate_models_(std::move(candidate_models)),
       create_time_(std::chrono::high_resolution_clock::now()) {}
 
-Response::Response(Query query, QueryId query_id, const long duration_micros,
+Response::Response(QueryId query_id, const long duration_micros,
                    Output output, const bool output_is_default,
                    const boost::optional<std::string> default_explanation)
-    : query_(std::move(query)),
-      query_id_(query_id),
+    : query_id_(query_id),
       duration_micros_(duration_micros),
       output_(std::move(output)),
       output_is_default_(output_is_default),
@@ -266,20 +265,16 @@ FeedbackQuery::FeedbackQuery(std::string label, long user_id, Feedback feedback,
       candidate_models_(std::move(candidate_models)) {}
 
 PredictTask::PredictTask(std::shared_ptr<PredictionData> input,
-                         VersionedModelId model, float utility,
                          QueryId query_id, long latency_slo_micros,
                          bool artificial)
     : input_(std::move(input)),
-      model_(std::move(model)),
-      utility_(utility),
       query_id_(query_id),
       latency_slo_micros_(latency_slo_micros),
       artificial_(artificial) {}
 
-FeedbackTask::FeedbackTask(Feedback feedback, VersionedModelId model,
-                           QueryId query_id, long latency_slo_micros)
+FeedbackTask::FeedbackTask(Feedback feedback, QueryId query_id,
+                           long latency_slo_micros)
     : feedback_(feedback),
-      model_(model),
       query_id_(query_id),
       latency_slo_micros_(latency_slo_micros) {}
 

--- a/src/libclipper/src/selection_policies.cpp
+++ b/src/libclipper/src/selection_policies.cpp
@@ -111,6 +111,10 @@ DefaultOutputSelectionPolicy::combine_predictions(
   }
 
   if (outputs.size() < query.input_batch_.size()) {
+    log_error_formatted(LOGGING_TAG_SELECTION_POLICY,
+                        "DefaultOutputSelectionPolicy expecting {} "
+                        "outputs but found {}. Filling with default.",
+                        query.input_batch_.size(), predictions.size());
     Output default_output =
         std::dynamic_pointer_cast<DefaultOutputSelectionState>(state)
             ->default_output_;

--- a/src/libclipper/src/task_executor.cpp
+++ b/src/libclipper/src/task_executor.cpp
@@ -22,7 +22,7 @@ PredictionCache::PredictionCache(size_t size_bytes)
 }
 
 folly::Future<Output> PredictionCache::fetch(
-    const VersionedModelId &model, std::shared_ptr<PredictionData> &input) {
+    const VersionedModelId &model, const std::shared_ptr<PredictionData> &input) {
   std::unique_lock<std::mutex> l(m_);
   auto key = hash(model, input->hash());
   auto search = entries_.find(key);
@@ -60,7 +60,7 @@ folly::Future<Output> PredictionCache::fetch(
 }
 
 void PredictionCache::put(const VersionedModelId &model,
-                          std::shared_ptr<PredictionData> &input,
+                          const std::shared_ptr<PredictionData> &input,
                           const Output &output) {
   std::unique_lock<std::mutex> l(m_);
   auto key = hash(model, input->hash());

--- a/src/libclipper/test/task_executor_test.cpp
+++ b/src/libclipper/test/task_executor_test.cpp
@@ -21,10 +21,9 @@ namespace {
 PredictTask create_predict_task(long query_id, long latency_slo_millis) {
   UniquePoolPtr<double> data = memory::allocate_unique<double>(1);
   data.get()[0] = 1.0;
-  VersionedModelId model_id = VersionedModelId("test", "1");
   std::shared_ptr<PredictionData> input =
       std::make_shared<DoubleVector>(std::move(data), 1);
-  PredictTask task(input, model_id, 1.0, query_id, latency_slo_millis);
+  PredictTask task(input, query_id, latency_slo_millis);
   return task;
 }
 


### PR DESCRIPTION
This PR allows inputs of batch queries (using `input_batch`) to be sent to the model container all together (limited to the maximum batch size), rather than individually.
It does this by adding all of the subqueries of the batch query at once to the model queue, so that the queue is locked and the waiters notified once only for the entire batch rather than locking the queue and notifying for each subquery individually.