### PR TITLE
add instructions to install fmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+This is a forked repository from the original clipper library. ucbrise/clipper <br>
+It enables clipper to output results from multiple models <br>
+You can check the details of this modification from below <br>
+https://github.com/ucbrise/clipper/issues/683#issue-439847004
+
 # Clipper
 
 [![Build Status](https://amplab.cs.berkeley.edu/jenkins/buildStatus/icon?job=Clipper)](https://amplab.cs.berkeley.edu/jenkins/job/Clipper/) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/dockerfiles/ClipperLibBaseDockerfile
+++ b/dockerfiles/ClipperLibBaseDockerfile
@@ -16,6 +16,16 @@ RUN apt-get install -y -qq \
     liblzma-dev libsnappy-dev make zlib1g-dev binutils-dev \
     libjemalloc-dev libssl-dev pkg-config
 
+## Install fmt
+RUN git clone https://github.com/fmtlib/fmt.git
+    && cd fmt \
+    && mkdir _build && cd _build \
+    && cmake .. \
+    && make -j4 \
+    && make install \
+    && cd / \
+    && rm -rf fmt
+
 ## Install Folly.
 RUN git clone https://github.com/facebook/folly \
     && cd folly \


### PR DESCRIPTION
recently I tried to bulid Clipper using 0.4 release clone, and I got the error message as below

`CMake Error at CMake/folly-deps.cmake:214 (find_package):
  Could not find a package configuration file provided by "fmt" with any of
  the following names:

    fmtConfig.cmake
    fmt-config.cmake

  Add the installation prefix of "fmt" to CMAKE_PREFIX_PATH or set "fmt_DIR"
  to a directory containing one of the above files.  If "fmt" provides a
  separate development package or SDK, be sure it has been installed.
Call Stack (most recent call first):
  CMakeLists.txt:113 (include)
`

It seems there have been some minor changes in folly
therefore it needs to install fmt from source before install folly

check below issue for the details 
https://github.com/facebook/folly/pull/1263

thanks